### PR TITLE
kube-proxy v1.18.9

### DIFF
--- a/packages/rke2-kube-proxy/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.18.8
-appVersion: v1.18.8
+version: v1.18.9
+appVersion: v1.18.9
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy/charts/values.yaml
+++ b/packages/rke2-kube-proxy/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kube-proxy
-  tag: v1.18.8
+  tag: v1.18.9
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)


### PR DESCRIPTION
Bump kube-proxy to v1.18.9 as part of rancher/rke2#343
