### PR TITLE
Add cilium v1.8.4 chart

### DIFF
--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,0 +1,1 @@
+url: https://raw.githubusercontent.com/cilium/charts/master/cilium-1.8.4.tgz

--- a/packages/rke2-cilium/rke2-cilium.patch
+++ b/packages/rke2-cilium/rke2-cilium.patch
@@ -1,0 +1,12 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-cilium/charts/Chart.yaml.original packages/rke2-cilium/charts/Chart.yaml
+--- packages/rke2-cilium/charts/Chart.yaml.original	2020-10-22 11:18:24.684786184 +0200
++++ packages/rke2-cilium/charts/Chart.yaml	2020-10-22 11:18:24.684786184 +0200
+@@ -2,7 +2,7 @@
+ appVersion: 1.8.4
+ description: Helm chart for Cilium
+ home: https://cilium.io/
+-name: cilium
++name: rke2-cilium
+ sources:
+ - https://github.com/cilium/cilium
+ version: 1.8.4


### PR DESCRIPTION
As explained in the issue: https://github.com/rancher/rke2/issues/490, it would be great to have Cilium available as CNI.

This patch includes (or hopes to include) the required files to generate the cilium helm chart to be consumed by rke2.

Signed-off-by: Manuel Buil <mbuil@suse.com>