### PR TITLE
kube-proxy: remove DynamicAuditing feature gate

### DIFF
--- a/packages/rke2-kube-proxy/charts/values.yaml
+++ b/packages/rke2-kube-proxy/charts/values.yaml
@@ -68,7 +68,6 @@ featureGates:
   DefaultIngressClass: true
   DevicePlugins: true
   DryRun: true
-  DynamicAuditing: false
   DynamicKubeletConfig: true
   EndpointSlice: true
   EndpointSliceProxying: false


### PR DESCRIPTION
This was removed in 1.19

Part of rancher/rke2#485 (updates #32)
