### PR TITLE
kube proxy 1.19.5 no deprecated feature gates

### DIFF
--- a/packages/rke2-kube-proxy/charts/values.yaml
+++ b/packages/rke2-kube-proxy/charts/values.yaml
@@ -94,7 +94,6 @@ featureGates:
   QOSReserved: false
   RemainingItemCount: true
   RemoveSelfLink: false
-  ResourceLimitsPriorityFunction: false
   RotateKubeletClientCertificate: true
   RotateKubeletServerCertificate: true
   RunAsGroup: true


### PR DESCRIPTION
- kube-proxy: remove DynamicAuditing feature gate
- kube-proxy: remove reference to deprecated FGs
