### PR TITLE
Allow customizing rke2 data-dir path for kube-proxy

### DIFF
--- a/packages/rke2-kube-proxy/charts/templates/_helpers.tpl
+++ b/packages/rke2-kube-proxy/charts/templates/_helpers.tpl
@@ -5,3 +5,10 @@
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+{{- define "rke2_data_dir" -}}
+{{- if .Values.global.rke2DataDir -}}
+{{- printf "%s" .Values.global.rke2DataDir -}}
+{{- else -}}
+{{- "/var/lib/rancher/rke2" -}}
+{{- end -}}
+{{- end -}}

--- a/packages/rke2-kube-proxy/charts/templates/daemonset.yaml
+++ b/packages/rke2-kube-proxy/charts/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
       - operator: Exists
       volumes:
       - hostPath:
-          path: /var/lib/rancher/rke2/agent
+          path: {{ template "rke2_data_dir" . }}/agent
           type: ""
         name: rke2config
       - configMap:


### PR DESCRIPTION
Allow customizing rke2 data-dir host path for kube-proxy

Related to rancher/rke2#474