### PR TITLE
Honor data-dir when templating kubeconfig volumeMount and path

### DIFF
--- a/packages/rke2-kube-proxy/charts/templates/_helpers.tpl
+++ b/packages/rke2-kube-proxy/charts/templates/_helpers.tpl
@@ -12,3 +12,10 @@
 {{- "/var/lib/rancher/rke2" -}}
 {{- end -}}
 {{- end -}}
+{{- define "kubeproxy_kubeconfig" -}}
+{{- if .Values.global.rke2DataDir -}}
+{{- printf "%s/agent/kubeproxy.kubeconfig" .Values.global.rke2DataDir -}}
+{{- else -}}
+{{- printf "%s" .Values.clientConnection.kubeconfig -}}
+{{- end -}}
+{{- end -}}

--- a/packages/rke2-kube-proxy/charts/templates/config.yaml
+++ b/packages/rke2-kube-proxy/charts/templates/config.yaml
@@ -8,7 +8,7 @@ data:
       acceptContentTypes: {{ .Values.clientConnection.acceptContentTypes | quote }}
       burst: {{ .Values.clientConnection.burst }}
       contentType: {{ .Values.clientConnection.contentType | quote }}
-      kubeconfig: {{ .Values.clientConnection.kubeconfig | quote }}
+      kubeconfig: {{ include "kubeproxy_kubeconfig" . | quote }}
       qps: {{ .Values.clientConnection.qps }} 
     clusterCIDR: {{ .Values.clusterCIDR | quote }} 
     configSyncPeriod: {{ .Values.configSyncPeriod }}

--- a/packages/rke2-kube-proxy/charts/templates/daemonset.yaml
+++ b/packages/rke2-kube-proxy/charts/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy
-        - mountPath: /var/lib/rancher/rke2/agent
+        - mountPath: {{ template "rke2_data_dir" . }}/agent
           name: rke2config
           readOnly: true
         - mountPath: /run/xtables.lock


### PR DESCRIPTION
Turns out the kubeconfig has a bunch of absolute paths in it, so we need to template both the path to the file AND the volumeMount path when changed by data-dir.