### PR TITLE
Update stable charts repo URL and set priorityClassName

### DIFF
--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
-url: https://kubernetes-charts.storage.googleapis.com/coredns-1.13.8.tgz
+url: https://charts.helm.sh/stable/packages/coredns-1.13.8.tgz
 packageVersion: 00

--- a/packages/rke2-coredns/rke2-coredns.patch
+++ b/packages/rke2-coredns/rke2-coredns.patch
@@ -19,6 +19,29 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/Chart.yam
  sources:
  - https://github.com/coredns/coredns
  version: 1.13.8
+diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/_helpers.tpl packages/rke2-coredns/charts/templates/_helpers.tpl
+--- packages/rke2-coredns/charts-original/templates/_helpers.tpl
++++ packages/rke2-coredns/charts/templates/_helpers.tpl
+@@ -137,6 +137,7 @@
+     {{- end -}}
+ {{- end -}}
+ 
++
+ {{/*
+ Create the name of the service account to use
+ */}}
+@@ -147,3 +148,11 @@
+     {{ default "default" .Values.serviceAccount.name }}
+ {{- end -}}
+ {{- end -}}
++
++{{- define "system_default_registry" -}}
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/clusterrole-autoscaler.yaml packages/rke2-coredns/charts/templates/clusterrole-autoscaler.yaml
 --- packages/rke2-coredns/charts-original/templates/clusterrole-autoscaler.yaml
 +++ packages/rke2-coredns/charts/templates/clusterrole-autoscaler.yaml
@@ -28,6 +51,18 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates
      {{- if .Values.isClusterService }}
 -    k8s-app: {{ .Chart.Name }}-autoscaler
 +    k8s-app: {{ .Values.k8sApp | default .Chart.Name }}-autoscaler
+     kubernetes.io/cluster-service: "true"
+     kubernetes.io/name: "CoreDNS"
+     {{- end }}
+diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/clusterrole.yaml packages/rke2-coredns/charts/templates/clusterrole.yaml
+--- packages/rke2-coredns/charts-original/templates/clusterrole.yaml
++++ packages/rke2-coredns/charts/templates/clusterrole.yaml
+@@ -8,7 +8,7 @@
+     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+     {{- if .Values.isClusterService }}
+-    k8s-app: {{ .Chart.Name | quote }}
++    k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
      kubernetes.io/cluster-service: "true"
      kubernetes.io/name: "CoreDNS"
      {{- end }}
@@ -46,18 +81,6 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/clusterrolebinding.yaml packages/rke2-coredns/charts/templates/clusterrolebinding.yaml
 --- packages/rke2-coredns/charts-original/templates/clusterrolebinding.yaml
 +++ packages/rke2-coredns/charts/templates/clusterrolebinding.yaml
-@@ -8,7 +8,7 @@
-     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-     {{- if .Values.isClusterService }}
--    k8s-app: {{ .Chart.Name | quote }}
-+    k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
-     kubernetes.io/cluster-service: "true"
-     kubernetes.io/name: "CoreDNS"
-     {{- end }}
-diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/clusterrole.yaml packages/rke2-coredns/charts/templates/clusterrole.yaml
---- packages/rke2-coredns/charts-original/templates/clusterrole.yaml
-+++ packages/rke2-coredns/charts/templates/clusterrole.yaml
 @@ -8,7 +8,7 @@
      app.kubernetes.io/instance: {{ .Release.Name | quote }}
      helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -176,29 +199,6 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          args: [ "-conf", "/etc/coredns/Corefile" ]
          volumeMounts:
-diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/_helpers.tpl packages/rke2-coredns/charts/templates/_helpers.tpl
---- packages/rke2-coredns/charts-original/templates/_helpers.tpl
-+++ packages/rke2-coredns/charts/templates/_helpers.tpl
-@@ -137,6 +137,7 @@
-     {{- end -}}
- {{- end -}}
- 
-+
- {{/*
- Create the name of the service account to use
- */}}
-@@ -147,3 +148,11 @@
-     {{ default "default" .Values.serviceAccount.name }}
- {{- end -}}
- {{- end -}}
-+
-+{{- define "system_default_registry" -}}
-+{{- if .Values.global.systemDefaultRegistry -}}
-+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
-+{{- else -}}
-+{{- "" -}}
-+{{- end -}}
-+{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/poddisruptionbudget.yaml packages/rke2-coredns/charts/templates/poddisruptionbudget.yaml
 --- packages/rke2-coredns/charts-original/templates/poddisruptionbudget.yaml
 +++ packages/rke2-coredns/charts/templates/poddisruptionbudget.yaml
@@ -232,30 +232,6 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates
      kubernetes.io/cluster-service: "true"
      kubernetes.io/name: "CoreDNS"
      {{- else }}
-diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/serviceaccount-autoscaler.yaml packages/rke2-coredns/charts/templates/serviceaccount-autoscaler.yaml
---- packages/rke2-coredns/charts-original/templates/serviceaccount-autoscaler.yaml
-+++ packages/rke2-coredns/charts/templates/serviceaccount-autoscaler.yaml
-@@ -10,7 +10,7 @@
-     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-     {{- if .Values.isClusterService }}
--    k8s-app: {{ .Chart.Name }}-autoscaler
-+    k8s-app: {{ .Values.k8sApp | default .Chart.Name }}-autoscaler
-     kubernetes.io/cluster-service: "true"
-     kubernetes.io/name: "CoreDNS"
-     {{- end }}
-diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/serviceaccount.yaml packages/rke2-coredns/charts/templates/serviceaccount.yaml
---- packages/rke2-coredns/charts-original/templates/serviceaccount.yaml
-+++ packages/rke2-coredns/charts/templates/serviceaccount.yaml
-@@ -8,7 +8,7 @@
-     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-     {{- if .Values.isClusterService }}
--    k8s-app: {{ .Chart.Name | quote }}
-+    k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
-     kubernetes.io/cluster-service: "true"
-     kubernetes.io/name: "CoreDNS"
-     {{- end }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/service-metrics.yaml packages/rke2-coredns/charts/templates/service-metrics.yaml
 --- packages/rke2-coredns/charts-original/templates/service-metrics.yaml
 +++ packages/rke2-coredns/charts/templates/service-metrics.yaml
@@ -277,27 +253,6 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates
      {{- end }}
      app.kubernetes.io/name: {{ template "coredns.name" . }}
    ports:
-diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/servicemonitor.yaml packages/rke2-coredns/charts/templates/servicemonitor.yaml
---- packages/rke2-coredns/charts-original/templates/servicemonitor.yaml
-+++ packages/rke2-coredns/charts/templates/servicemonitor.yaml
-@@ -11,7 +11,7 @@
-     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-     {{- if .Values.isClusterService }}
--    k8s-app: {{ .Chart.Name | quote }}
-+    k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
-     kubernetes.io/cluster-service: "true"
-     kubernetes.io/name: "CoreDNS"
-     {{- end }}
-@@ -24,7 +24,7 @@
-     matchLabels:
-       app.kubernetes.io/instance: {{ .Release.Name | quote }}
-       {{- if .Values.isClusterService }}
--      k8s-app: {{ .Chart.Name | quote }}
-+      k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
-       {{- end }}
-       app.kubernetes.io/name: {{ template "coredns.name" . }}
-       app.kubernetes.io/component: metrics
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/service.yaml packages/rke2-coredns/charts/templates/service.yaml
 --- packages/rke2-coredns/charts-original/templates/service.yaml
 +++ packages/rke2-coredns/charts/templates/service.yaml
@@ -325,6 +280,51 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates
    {{- end }}
    {{- if .Values.service.externalIPs }}
    externalIPs:
+diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/serviceaccount-autoscaler.yaml packages/rke2-coredns/charts/templates/serviceaccount-autoscaler.yaml
+--- packages/rke2-coredns/charts-original/templates/serviceaccount-autoscaler.yaml
++++ packages/rke2-coredns/charts/templates/serviceaccount-autoscaler.yaml
+@@ -10,7 +10,7 @@
+     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+     {{- if .Values.isClusterService }}
+-    k8s-app: {{ .Chart.Name }}-autoscaler
++    k8s-app: {{ .Values.k8sApp | default .Chart.Name }}-autoscaler
+     kubernetes.io/cluster-service: "true"
+     kubernetes.io/name: "CoreDNS"
+     {{- end }}
+diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/serviceaccount.yaml packages/rke2-coredns/charts/templates/serviceaccount.yaml
+--- packages/rke2-coredns/charts-original/templates/serviceaccount.yaml
++++ packages/rke2-coredns/charts/templates/serviceaccount.yaml
+@@ -8,7 +8,7 @@
+     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+     {{- if .Values.isClusterService }}
+-    k8s-app: {{ .Chart.Name | quote }}
++    k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
+     kubernetes.io/cluster-service: "true"
+     kubernetes.io/name: "CoreDNS"
+     {{- end }}
+diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates/servicemonitor.yaml packages/rke2-coredns/charts/templates/servicemonitor.yaml
+--- packages/rke2-coredns/charts-original/templates/servicemonitor.yaml
++++ packages/rke2-coredns/charts/templates/servicemonitor.yaml
+@@ -11,7 +11,7 @@
+     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+     {{- if .Values.isClusterService }}
+-    k8s-app: {{ .Chart.Name | quote }}
++    k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
+     kubernetes.io/cluster-service: "true"
+     kubernetes.io/name: "CoreDNS"
+     {{- end }}
+@@ -24,7 +24,7 @@
+     matchLabels:
+       app.kubernetes.io/instance: {{ .Release.Name | quote }}
+       {{- if .Values.isClusterService }}
+-      k8s-app: {{ .Chart.Name | quote }}
++      k8s-app: {{ .Values.k8sApp | default .Chart.Name | quote }}
+       {{- end }}
+       app.kubernetes.io/name: {{ template "coredns.name" . }}
+       app.kubernetes.io/component: metrics
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/values.yaml packages/rke2-coredns/charts/values.yaml
 --- packages/rke2-coredns/charts-original/values.yaml
 +++ packages/rke2-coredns/charts/values.yaml
@@ -352,6 +352,15 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/values.ya
  
  rbac:
    # If true, create & use RBAC resources
+@@ -84,7 +84,7 @@
+ isClusterService: true
+ 
+ # Optional priority class to be used for the coredns pods. Used for autoscaler if autoscaler.priorityClassName not set.
+-priorityClassName: ""
++priorityClassName: "system-cluster-critical"
+ 
+ # Default zone is what Kubernetes recommends:
+ # https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options
 @@ -253,3 +253,7 @@
      ## Annotations for the coredns-autoscaler configmap
      # i.e. strategy.spinnaker.io/versioned: "false" to ensure configmap isn't renamed
@@ -360,4 +369,3 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/values.ya
 +
 +global:
 +  systemDefaultRegistry: ""
-\ No newline at end of file

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,2 +1,2 @@
-url: https://kubernetes-charts.storage.googleapis.com/nginx-ingress-1.36.3.tgz
+url: https://charts.helm.sh/stable/packages/nginx-ingress-1.36.3.tgz
 packageVersion: 00

--- a/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
+++ b/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
@@ -10,6 +10,32 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/Cha
  sources:
  - https://github.com/kubernetes/ingress-nginx
  version: 1.36.3
+diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/_helpers.tpl packages/rke2-ingress-nginx/charts/templates/_helpers.tpl
+--- packages/rke2-ingress-nginx/charts-original/templates/_helpers.tpl
++++ packages/rke2-ingress-nginx/charts/templates/_helpers.tpl
+@@ -55,6 +55,7 @@
+ Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
+ 
+ */}}
++
+ {{- define "nginx-ingress.controller.publishServicePath" -}}
+ {{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
+ {{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
+@@ -122,4 +123,12 @@
+ {{- else -}}
+ {{- print "extensions/v1beta1" -}}
+ {{- end -}}
+-{{- end -}}
+\ No newline at end of file
++{{- end -}}
++
++{{- define "system_default_registry" -}}
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/admission-webhooks/job-patch/job-createSecret.yaml packages/rke2-ingress-nginx/charts/templates/admission-webhooks/job-patch/job-createSecret.yaml
 --- packages/rke2-ingress-nginx/charts-original/templates/admission-webhooks/job-patch/job-createSecret.yaml
 +++ packages/rke2-ingress-nginx/charts/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -100,32 +126,6 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/tem
            imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
            args:
            {{- range $key, $value := .Values.defaultBackend.extraArgs }}
-diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/_helpers.tpl packages/rke2-ingress-nginx/charts/templates/_helpers.tpl
---- packages/rke2-ingress-nginx/charts-original/templates/_helpers.tpl
-+++ packages/rke2-ingress-nginx/charts/templates/_helpers.tpl
-@@ -55,6 +55,7 @@
- Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
- 
- */}}
-+
- {{- define "nginx-ingress.controller.publishServicePath" -}}
- {{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
- {{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
-@@ -122,4 +123,12 @@
- {{- else -}}
- {{- print "extensions/v1beta1" -}}
- {{- end -}}
--{{- end -}}
-\ No newline at end of file
-+{{- end -}}
-+
-+{{- define "system_default_registry" -}}
-+{{- if .Values.global.systemDefaultRegistry -}}
-+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
-+{{- else -}}
-+{{- "" -}}
-+{{- end -}}
-+{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/values.yaml packages/rke2-ingress-nginx/charts/values.yaml
 --- packages/rke2-ingress-nginx/charts-original/values.yaml
 +++ packages/rke2-ingress-nginx/charts/values.yaml

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
-url: https://kubernetes-charts.storage.googleapis.com/metrics-server-2.11.1.tgz
+url: https://charts.helm.sh/stable/packages/metrics-server-2.11.1.tgz
 packageVersion: 00

--- a/packages/rke2-metrics-server/rke2-metrics-server.patch
+++ b/packages/rke2-metrics-server/rke2-metrics-server.patch
@@ -60,6 +60,15 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-metrics-server/charts-original/va
  
  resources: {}
  
+@@ -58,7 +59,7 @@
+ #  scheduler.alpha.kubernetes.io/critical-pod: ''
+ 
+ ## Set a pod priorityClassName
+-# priorityClassName: system-node-critical
++priorityClassName: system-node-critical
+ 
+ extraVolumeMounts: []
+ #  - name: secrets
 @@ -107,3 +108,6 @@
    enabled: false
    minAvailable:


### PR DESCRIPTION
* Update stable helm chart repo URL
* Set priorityClassName for coredns and metrics-server

Related to rancher/rke2#585

Note that some of the patch sections are reordered due to different versions of `patch` on linux and OS X hosts. There doesn't seem to be a good fix for this, other than having everyone who touches these files agree on what version to use.