### PR TITLE
Fix CoreDNS CriticalAddonsOnly toleration

### DIFF
--- a/packages/rke2-coredns/rke2-coredns.patch
+++ b/packages/rke2-coredns/rke2-coredns.patch
@@ -181,7 +181,32 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-coredns/charts-original/templates
          {{- end }}
          app.kubernetes.io/name: {{ template "coredns.name" . }}
          app.kubernetes.io/instance: {{ .Release.Name | quote }}
-@@ -70,7 +70,7 @@
+@@ -46,7 +46,6 @@
+         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+         {{- if .Values.isClusterService }}
+         scheduler.alpha.kubernetes.io/critical-pod: ''
+-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+         {{- end }}
+     spec:
+       serviceAccountName: {{ template "coredns.serviceAccountName" . }}
+@@ -60,9 +59,15 @@
+       affinity:
+ {{ toYaml .Values.affinity | indent 8 }}
+       {{- end }}
+-      {{- if .Values.tolerations }}
++      {{- if or (.Values.isClusterService) (.Values.tolerations) }}
+       tolerations:
++        {{- if .Values.isClusterService }}
++        - key: CriticalAddonsOnly
++          operator: Exists
++        {{- end }}
++        {{- if .Values.tolerations }}
+ {{ toYaml .Values.tolerations | indent 8 }}
++        {{- end }}
+       {{- end }}
+       {{- if .Values.nodeSelector }}
+       nodeSelector:
+@@ -70,7 +75,7 @@
        {{- end }}
        containers:
        - name: "coredns"


### PR DESCRIPTION
The scheduler annotation has been unsupported and ineffective since Kubernetes 1.6 so this is long overdue.

Related to rancher/rke2#585 rancher/rke2#487