### PR TITLE
nginx - Resolve templating & default value issues

### DIFF
--- a/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
+++ b/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
@@ -103,7 +103,11 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/tem
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/values.yaml packages/rke2-ingress-nginx/charts/values.yaml
 --- packages/rke2-ingress-nginx/charts-original/values.yaml
 +++ packages/rke2-ingress-nginx/charts/values.yaml
-@@ -3,9 +3,8 @@
+@@ -1,11 +1,12 @@
++fullnameOverride: rke2-ingress-nginx
++
+ ## nginx configuration
+ ## Ref: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md
  ##
  controller:
    image:
@@ -115,7 +119,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
      pullPolicy: IfNotPresent
      # www-data -> uid 101
      runAsUser: 101
-@@ -35,7 +34,7 @@
+@@ -35,7 +36,7 @@
    # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
    # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
    # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
@@ -124,7 +128,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
  
    # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
    # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
-@@ -44,7 +43,7 @@
+@@ -44,7 +45,7 @@
    # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
    # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
    # is merged
@@ -133,7 +137,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
  
    ## Use host ports 80 and 443
    ## Disabled by default
-@@ -83,7 +82,7 @@
+@@ -83,7 +84,7 @@
    ## by the service. If disable, the status field reports the IP address of the
    ## node or nodes where an ingress controller pod is running.
    publishService:
@@ -142,7 +146,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
      ## Allows overriding of the publish service to bind to
      ## Must be <namespace>/<service_name>
      ##
-@@ -301,7 +300,7 @@
+@@ -301,7 +302,7 @@
      configMapKey: ""
  
    service:
@@ -151,21 +155,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
  
      annotations: {}
      labels: {}
-@@ -406,7 +405,7 @@
-   #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
- 
-   admissionWebhooks:
--    enabled: true
-+    enabled: false
-     failurePolicy: Fail
-     port: 8443
- 
-@@ -537,11 +536,11 @@
- ##
- defaultBackend:
-   ##
--  enabled: false
-+  enabled: true
+@@ -540,8 +541,8 @@
+   enabled: false
  
    image:
 -    repository: k8s.gcr.io/defaultbackend-amd64
@@ -175,7 +166,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
      pullPolicy: IfNotPresent
      # nobody user -> uid 65534
      runAsUser: 65534
-@@ -661,3 +660,6 @@
+@@ -661,3 +662,6 @@
  ##
  udp: {}
  #  53: "kube-system/kube-dns:53"

--- a/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
+++ b/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
@@ -33,78 +33,89 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/tem
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/admission-webhooks/job-patch/job-createSecret.yaml packages/rke2-ingress-nginx/charts/templates/admission-webhooks/job-patch/job-createSecret.yaml
 --- packages/rke2-ingress-nginx/charts-original/templates/admission-webhooks/job-patch/job-createSecret.yaml
 +++ packages/rke2-ingress-nginx/charts/templates/admission-webhooks/job-patch/job-createSecret.yaml
-@@ -33,7 +33,7 @@
+@@ -32,9 +32,7 @@
+     {{- end }}
        containers:
          - name: create
-           {{- with .Values.controller.admissionWebhooks.patch.image }}
+-          {{- with .Values.controller.admissionWebhooks.patch.image }}
 -          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
+-          {{- end }}
++          image: "{{ template "system_default_registry" . }}{{- with .Values.controller.admissionWebhooks.patch.image -}}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}{{- end -}}"
            imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
            args:
+             - create
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/admission-webhooks/job-patch/job-patchWebhook.yaml packages/rke2-ingress-nginx/charts/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
 --- packages/rke2-ingress-nginx/charts-original/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
 +++ packages/rke2-ingress-nginx/charts/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
-@@ -33,7 +33,7 @@
+@@ -32,9 +32,7 @@
+     {{- end }}
        containers:
          - name: patch
-           {{- with .Values.controller.admissionWebhooks.patch.image }}
+-          {{- with .Values.controller.admissionWebhooks.patch.image }}
 -          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
+-          {{- end }}
++          image: "{{ template "system_default_registry" . }}{{- with .Values.controller.admissionWebhooks.patch.image -}}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}{{- end -}}"
            imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
            args:
+             - patch
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/controller-daemonset.yaml packages/rke2-ingress-nginx/charts/templates/controller-daemonset.yaml
 --- packages/rke2-ingress-nginx/charts-original/templates/controller-daemonset.yaml
 +++ packages/rke2-ingress-nginx/charts/templates/controller-daemonset.yaml
-@@ -61,7 +61,7 @@
+@@ -60,9 +60,7 @@
+     {{- end }}
        containers:
          - name: controller
-           {{- with .Values.controller.image }}
+-          {{- with .Values.controller.image }}
 -          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
+-          {{- end }}
++          image: "{{ template "system_default_registry" . }}{{- with .Values.controller.image -}}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}{{- end -}}"
            imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
          {{- if .Values.controller.lifecycle }}
+           lifecycle: {{ toYaml .Values.controller.lifecycle | nindent 12 }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/controller-deployment.yaml packages/rke2-ingress-nginx/charts/templates/controller-deployment.yaml
 --- packages/rke2-ingress-nginx/charts-original/templates/controller-deployment.yaml
 +++ packages/rke2-ingress-nginx/charts/templates/controller-deployment.yaml
-@@ -65,7 +65,7 @@
+@@ -64,9 +64,7 @@
+     {{- end }}
        containers:
          - name: controller
-           {{- with .Values.controller.image }}
+-          {{- with .Values.controller.image }}
 -          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
+-          {{- end }}
++          image: "{{ template "system_default_registry" . }}{{- with .Values.controller.image -}}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}{{- end -}}"
            imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
          {{- if .Values.controller.lifecycle }}
+           lifecycle: {{ toYaml .Values.controller.lifecycle | nindent 12 }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/templates/default-backend-deployment.yaml packages/rke2-ingress-nginx/charts/templates/default-backend-deployment.yaml
 --- packages/rke2-ingress-nginx/charts-original/templates/default-backend-deployment.yaml
 +++ packages/rke2-ingress-nginx/charts/templates/default-backend-deployment.yaml
-@@ -37,7 +37,7 @@
+@@ -36,9 +36,7 @@
+     {{- end }}
        containers:
          - name: {{ template "ingress-nginx.name" . }}-default-backend
-           {{- with .Values.defaultBackend.image }}
+-          {{- with .Values.defaultBackend.image }}
 -          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
+-          {{- end }}
++          image: "{{ template "system_default_registry" . }}{{- with .Values.defaultBackend.image -}}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}{{- end -}}"
            imagePullPolicy: {{ .Values.defaultBackend.image.pullPolicy }}
          {{- if .Values.defaultBackend.extraArgs }}
+           args:
 diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/values.yaml packages/rke2-ingress-nginx/charts/values.yaml
 --- packages/rke2-ingress-nginx/charts-original/values.yaml
 +++ packages/rke2-ingress-nginx/charts/values.yaml
-@@ -3,8 +3,8 @@
+@@ -3,9 +3,8 @@
  ##
  controller:
    image:
 -    repository: k8s.gcr.io/ingress-nginx/controller
 -    tag: "v0.35.0"
+-    digest: sha256:fc4979d8b8443a831c9789b5155cded454cb7de737a8b727bc2ba0106d2eae8b
 +    repository: rancher/nginx-ingress-controller
 +    tag: "nginx-0.35.0-rancher2"
-     digest: sha256:fc4979d8b8443a831c9789b5155cded454cb7de737a8b727bc2ba0106d2eae8b
      pullPolicy: IfNotPresent
      # www-data -> uid 101
-@@ -35,7 +35,7 @@
+     runAsUser: 101
+@@ -35,7 +34,7 @@
    # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
    # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
    # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
@@ -113,7 +124,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
  
    # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
    # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
-@@ -44,7 +44,7 @@
+@@ -44,7 +43,7 @@
    # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
    # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
    # is merged
@@ -122,7 +133,16 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
  
    ## Use host ports 80 and 443
    ## Disabled by default
-@@ -301,7 +301,7 @@
+@@ -83,7 +82,7 @@
+   ## by the service. If disable, the status field reports the IP address of the
+   ## node or nodes where an ingress controller pod is running.
+   publishService:
+-    enabled: true
++    enabled: false
+     ## Allows overriding of the publish service to bind to
+     ## Must be <namespace>/<service_name>
+     ##
+@@ -301,7 +300,7 @@
      configMapKey: ""
  
    service:
@@ -131,8 +151,21 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
  
      annotations: {}
      labels: {}
-@@ -540,8 +540,8 @@
-   enabled: false
+@@ -406,7 +405,7 @@
+   #   command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done;']
+ 
+   admissionWebhooks:
+-    enabled: true
++    enabled: false
+     failurePolicy: Fail
+     port: 8443
+ 
+@@ -537,11 +536,11 @@
+ ##
+ defaultBackend:
+   ##
+-  enabled: false
++  enabled: true
  
    image:
 -    repository: k8s.gcr.io/defaultbackend-amd64
@@ -142,7 +175,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
      pullPolicy: IfNotPresent
      # nobody user -> uid 65534
      runAsUser: 65534
-@@ -661,3 +661,6 @@
+@@ -661,3 +660,6 @@
  ##
  udp: {}
  #  53: "kube-system/kube-dns:53"

--- a/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
+++ b/packages/rke2-ingress-nginx/rke2-ingress-nginx.patch
@@ -104,7 +104,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rke2-ingress-nginx/charts-original/val
 --- packages/rke2-ingress-nginx/charts-original/values.yaml
 +++ packages/rke2-ingress-nginx/charts/values.yaml
 @@ -1,11 +1,12 @@
-+fullnameOverride: rke2-ingress-nginx
++nameOverride: v3
 +
  ## nginx configuration
  ## Ref: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md

--- a/scripts/generate-charts
+++ b/scripts/generate-charts
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-for f in packages/*; do
+rm -rf tmp/packages
+mkdir -p tmp/packages
+
+for p in packages/*; do
+	f=tmp/$p
+	cp -rp $p $f
 	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
 		mkdir -p assets/$(basename -- ${f})
 		if [[ -d ${f}/overlay ]]; then


### PR DESCRIPTION
Resolve issues with template scope and bad default values. 
Match things enabled features from previous release.
Needs investigation for upgrade:
```
# helm upgrade --force ingess ../rke2-charts/assets/rke2-ingress-nginx/rke2-ingress-nginx-3.3.000.tgz 
Error: UPGRADE FAILED: failed to replace object: Service "ingess-rke2-ingress-nginx-defaultbackend" is invalid: spec.clusterIPs[0]: Invalid value: []string(nil): primary clusterIP can not be unset && failed to replace object: Deployment.apps "ingess-rke2-ingress-nginx-controller" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"controller", "app.kubernetes.io/instance":"ingess", "app.kubernetes.io/name":"rke2-ingress-nginx"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```