### PR TITLE
Update flexvol path

### DIFF
--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -259,4 +259,4 @@ spec:
         - name: flexvol-driver-host
           hostPath:
             type: DirectoryOrCreate
-            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
+            path: {{ .Values.calico.flexVolumePluginDir }}/nodeagent~uds

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -69,6 +69,8 @@ calico:
   vethuMTU: 1450
   # Typha is disabled.
   typhaServiceName: none
+  # Kubelet flex-volume-plugin-dir
+  flexVolumePluginDir: /var/lib/kubelet/volumeplugins
 
 global:
   systemDefaultRegistry: ""

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Update flex volume plugin dir to match new RKE2 default; make it a Value
so that it can be changed by users to match the kubelet setting if
necessary.

Related to rancher/rke2#682