### PR TITLE
Strip 'nginx-' prefix from image tags when using semverCompare

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
@@ -1,11 +1,19 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -10,7 +10,7 @@
- kubeVersion: '>=1.16.0-0'
- maintainers:
+@@ -1,7 +1,6 @@
+ apiVersion: v1
+ appVersion: 0.30.0
+ description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
+-engine: gotpl
+ home: https://github.com/kubernetes/ingress-nginx
+ icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
+ keywords:
+@@ -12,7 +11,7 @@
  - name: ChiefAlexander
--name: ingress-nginx
+ - email: Trevor.G.Wood@gmail.com
+   name: taharah
+-name: nginx-ingress
 +name: rke2-ingress-nginx
  sources:
  - https://github.com/kubernetes/ingress-nginx
- version: 3.3.0
+ version: 1.36.3

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,14 +1,20 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -118,7 +118,15 @@
- Check the ingress controller version tag is at most three versions behind the last release
+@@ -55,6 +55,7 @@
+ Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
+ 
  */}}
- {{- define "isControllerTagValid" -}}
--{{- if not (semverCompare ">=0.27.0-0" .Values.controller.image.tag) -}}
-+{{- if not (semverCompare ">=0.27.0-0" (trimPrefix "nginx-" .Values.controller.image.tag)) -}}
- {{- fail "Controller container image tag should be 0.27.0 or higher" -}}
++
+ {{- define "nginx-ingress.controller.publishServicePath" -}}
+ {{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
+ {{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
+@@ -122,4 +123,12 @@
+ {{- else -}}
+ {{- print "extensions/v1beta1" -}}
  {{- end -}}
- {{- end -}}
+-{{- end -}}
+\ No newline at end of file
++{{- end -}}
 +
 +{{- define "system_default_registry" -}}
 +{{- if .Values.global.systemDefaultRegistry -}}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-createSecret.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-createSecret.yaml.patch
@@ -1,11 +1,11 @@
 --- charts-original/templates/admission-webhooks/job-patch/job-createSecret.yaml
 +++ charts/templates/admission-webhooks/job-patch/job-createSecret.yaml
-@@ -33,7 +33,7 @@
+@@ -36,7 +36,7 @@
+       {{- end }}
        containers:
          - name: create
-           {{- with .Values.controller.admissionWebhooks.patch.image }}
--          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
+-          image: {{ .Values.controller.admissionWebhooks.patch.image.repository }}:{{ .Values.controller.admissionWebhooks.patch.image.tag }}
++          image: {{ template "system_default_registry" . }}{{ .Values.controller.admissionWebhooks.patch.image.repository }}:{{ .Values.controller.admissionWebhooks.patch.image.tag }}
            imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
            args:
+             - create

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-patchWebhook.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-patchWebhook.yaml.patch
@@ -1,11 +1,11 @@
 --- charts-original/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
 +++ charts/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
-@@ -33,7 +33,7 @@
+@@ -36,7 +36,7 @@
+       {{- end }}
        containers:
          - name: patch
-           {{- with .Values.controller.admissionWebhooks.patch.image }}
--          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
-           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
+-          image: {{ .Values.controller.admissionWebhooks.patch.image.repository }}:{{ .Values.controller.admissionWebhooks.patch.image.tag }}
++          image: {{ template "system_default_registry" . }}{{ .Values.controller.admissionWebhooks.patch.image.repository }}:{{ .Values.controller.admissionWebhooks.patch.image.tag }}
+           imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.pullPolicy }}
            args:
+             - patch

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
@@ -9,3 +9,40 @@
            imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
            {{- if .Values.controller.lifecycle }}
            lifecycle:
+@@ -71,22 +71,22 @@
+           {{- if .Values.defaultBackend.enabled }}
+             - --default-backend-service={{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}
+           {{- else }}
+-            {{- if (semverCompare "<0.21.0" .Values.controller.image.tag) }}
++            {{- if (semverCompare "<0.21.0" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --default-backend-service={{ required ".Values.controller.defaultBackendService is required if .Values.defaultBackend.enabled=false and .Values.controller.image.tag < 0.21.0" .Values.controller.defaultBackendService }}
+             {{- else if .Values.controller.defaultBackendService }}
+             - --default-backend-service={{ .Values.controller.defaultBackendService }}
+             {{- end }}
+           {{- end }}
+-          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
++          {{- if and (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) .Values.controller.publishService.enabled }}
+             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --election-id={{ .Values.controller.electionID }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --ingress-class={{ .Values.controller.ingressClass }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+           {{- else }}
+             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+@@ -118,7 +118,7 @@
+             - --{{ $key }}
+             {{- end }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.16.0" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+           securityContext:
+             capabilities:
+                 drop:

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
@@ -1,11 +1,11 @@
 --- charts-original/templates/controller-daemonset.yaml
 +++ charts/templates/controller-daemonset.yaml
-@@ -61,7 +61,7 @@
+@@ -60,7 +60,7 @@
+       {{- end }}
        containers:
-         - name: controller
-           {{- with .Values.controller.image }}
--          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
-           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-         {{- if .Values.controller.lifecycle }}
+         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
+-          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
++          image: {{ template "system_default_registry" . }}{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+           {{- if .Values.controller.lifecycle }}
+           lifecycle:

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
@@ -9,7 +9,14 @@
            imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
            {{- if .Values.controller.lifecycle }}
            lifecycle:
-@@ -81,16 +81,16 @@
+@@ -75,22 +75,22 @@
+           {{- if .Values.defaultBackend.enabled }}
+             - --default-backend-service={{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}
+           {{- else }}
+-            {{- if (semverCompare "<0.21.0" .Values.controller.image.tag) }}
++            {{- if (semverCompare "<0.21.0" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --default-backend-service={{ required ".Values.controller.defaultBackendService is required if .Values.defaultBackend.enabled=false and .Values.controller.image.tag < 0.21.0" .Values.controller.defaultBackendService }}
+             {{- else if .Values.controller.defaultBackendService }}
              - --default-backend-service={{ .Values.controller.defaultBackendService }}
              {{- end }}
            {{- end }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
@@ -1,11 +1,41 @@
 --- charts-original/templates/controller-deployment.yaml
 +++ charts/templates/controller-deployment.yaml
-@@ -65,7 +65,7 @@
+@@ -64,7 +64,7 @@
+       {{- end }}
        containers:
-         - name: controller
-           {{- with .Values.controller.image }}
--          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
+         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
+-          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
++          image: {{ template "system_default_registry" . }}{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
+           {{- if .Values.controller.lifecycle }}
+           lifecycle:
+@@ -81,16 +81,16 @@
+             - --default-backend-service={{ .Values.controller.defaultBackendService }}
+             {{- end }}
            {{- end }}
-           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-         {{- if .Values.controller.lifecycle }}
+-          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
++          {{- if and (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) .Values.controller.publishService.enabled }}
+             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --election-id={{ .Values.controller.electionID }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --ingress-class={{ .Values.controller.ingressClass }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.9.0-beta.1" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+             - --configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+           {{- else }}
+             - --nginx-configmap={{ default .Release.Namespace .Values.controller.configMapNamespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+@@ -125,7 +125,7 @@
+             - --{{ $key }}
+             {{- end }}
+           {{- end }}
+-          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
++          {{- if (semverCompare ">=0.16.0" (trimPrefix "nginx-" .Values.controller.image.tag)) }}
+           securityContext:
+             capabilities:
+                 drop:

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/default-backend-deployment.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/default-backend-deployment.yaml.patch
@@ -1,11 +1,11 @@
 --- charts-original/templates/default-backend-deployment.yaml
 +++ charts/templates/default-backend-deployment.yaml
-@@ -37,7 +37,7 @@
+@@ -51,7 +51,7 @@
+       {{- end }}
        containers:
-         - name: {{ template "ingress-nginx.name" . }}-default-backend
-           {{- with .Values.defaultBackend.image }}
--          image: "{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-+          image: "{{ template "system_default_registry" . }}{{.repository}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}"
-           {{- end }}
-           imagePullPolicy: {{ .Values.defaultBackend.image.pullPolicy }}
-         {{- if .Values.defaultBackend.extraArgs }}
+         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
+-          image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
++          image:  {{ template "system_default_registry" . }}{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}
+           imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
+           args:
+           {{- range $key, $value := .Values.defaultBackend.extraArgs }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -1,17 +1,26 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -3,8 +3,8 @@
- ##
+@@ -4,8 +4,8 @@
  controller:
+   name: controller
    image:
--    repository: k8s.gcr.io/ingress-nginx/controller
--    tag: "v0.35.0"
+-    repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+-    tag: "0.30.0"
 +    repository: rancher/nginx-ingress-controller
-+    tag: "nginx-0.35.0-rancher2"
-     digest: sha256:fc4979d8b8443a831c9789b5155cded454cb7de737a8b727bc2ba0106d2eae8b
++    tag: "nginx-0.30.0-rancher1"
      pullPolicy: IfNotPresent
      # www-data -> uid 101
-@@ -35,7 +35,7 @@
+     runAsUser: 101
+@@ -37,7 +37,7 @@
+   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
+   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
+   # is merged
+-  hostNetwork: false
++  hostNetwork: true
+ 
+   # Optionally customize the pod dnsConfig.
+   dnsConfig: {}
+@@ -45,7 +45,7 @@
    # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
    # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
    # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
@@ -20,16 +29,7 @@
  
    # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
    # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
-@@ -44,7 +44,7 @@
-   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
-   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
-   # is merged
--  hostNetwork: false
-+  hostNetwork: true
- 
-   ## Use host ports 80 and 443
-   ## Disabled by default
-@@ -301,7 +301,7 @@
+@@ -242,7 +242,7 @@
      configMapKey: ""
  
    service:
@@ -38,9 +38,9 @@
  
      annotations: {}
      labels: {}
-@@ -540,8 +540,8 @@
-   enabled: false
+@@ -440,8 +440,8 @@
  
+   name: default-backend
    image:
 -    repository: k8s.gcr.io/defaultbackend-amd64
 -    tag: "1.5"
@@ -49,7 +49,7 @@
      pullPolicy: IfNotPresent
      # nobody user -> uid 65534
      runAsUser: 65534
-@@ -661,3 +661,6 @@
+@@ -573,3 +573,6 @@
  ##
  udp: {}
  #  53: "kube-system/kube-dns:53"

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/kubernetes/ingress-nginx/releases/download/ingress-nginx-3.3.0/ingress-nginx-3.3.0.tgz
+url: https://charts.helm.sh/stable/packages/nginx-ingress-1.36.3.tgz
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Add trimPrefix calls to strip the `nginx-` prefix off image tags when doing semver compares. This was handled for default Deployment scenarios, but not for the Deployment with defaultBackend disabled, or when using DaemonSet.

Related to rancher/rke2#493