### PR TITLE
update kube-proxy version to v1.20.5-build20210405

### DIFF
--- a/packages/rke2-kube-proxy/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.18.17-build20210318
-appVersion: v1.18.17
+version: v1.20.5-build20210405
+appVersion: v1.20.5
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy/charts/values.yaml
+++ b/packages/rke2-kube-proxy/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kube-proxy
-  tag: v1.18.17-build20210318
+  tag: v1.20.5-build20210405
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)


### PR DESCRIPTION
update kube-proxy version to v1.20.5-build20210405 for /bin/ipset addition

Validation:
 * See linked issue

Related to rancher/rke2#645