### PR TITLE
Change the default ipam mode of cilium

### DIFF
--- a/packages/rke2-cilium/charts/values.yaml
+++ b/packages/rke2-cilium/charts/values.yaml
@@ -43,7 +43,7 @@ cilium:
   eni: false
   ipam:
     # Set mode to "eni" for ENI AWS intetgration.
-    mode: "cluster-pool"
+    mode: "kubernetes"
   # Set tunnel to "disable" if ENI AWS or Azure integrations are enabled.
   tunnel: "vxlan"
   # Set to "eth0" for ENI AWS intetgration.

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 02
+packageVersion: 03
 releaseCandidateVersion: 00


### PR DESCRIPTION
Cilium's default ipam mode does not honor the pod CIDR set in kube-controller-manager.
The benefits of that mode are not relevant when deploying with rke2

Fixes issue rke2/891

Signed-off-by: Manuel Buil <mbuil@suse.com>