### PR TITLE
cilium: Update to 1.9.6

### DIFF
--- a/packages/cilium/generated-changes/patch/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl.patch
+++ b/packages/cilium/generated-changes/patch/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl.patch
@@ -1,6 +1,14 @@
---- charts-original/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl	2021-02-08 14:38:47.439463526 +0100
-@@ -10,7 +10,7 @@
+--- charts-original/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
++++ charts/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl
+@@ -5,15 +5,12 @@
+     metadata:
+       labels:
+         k8s-app: clustermesh-apiserver-generate-certs
+-        {{- with .Values.clustermesh.apiserver.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-        {{- end }}
+     spec:
+       serviceAccount: clustermesh-apiserver-generate-certs
        serviceAccountName: clustermesh-apiserver-generate-certs
        containers:
          - name: certgen
@@ -9,4 +17,3 @@
            imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
            command:
              - "/usr/bin/cilium-certgen"
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/_helpers.tpl charts/templates/_helpers.tpl

--- a/packages/cilium/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/cilium/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,5 +1,5 @@
---- charts-original/templates/_helpers.tpl	2021-02-08 14:24:33.605473204 +0100
-+++ charts/templates/_helpers.tpl	2021-02-08 14:38:47.443463553 +0100
+--- charts-original/templates/_helpers.tpl
++++ charts/templates/_helpers.tpl
 @@ -122,3 +122,11 @@
  tls.crt: {{ $cert.Cert | b64enc }}
  tls.key: {{ $cert.Key | b64enc }}
@@ -12,4 +12,3 @@
 +{{- "" -}}
 +{{- end }}
 +{{- end }}
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/_hubble-generate-certs-job-spec.tpl charts/templates/_hubble-generate-certs-job-spec.tpl

--- a/packages/cilium/generated-changes/patch/templates/_hubble-generate-certs-job-spec.tpl.patch
+++ b/packages/cilium/generated-changes/patch/templates/_hubble-generate-certs-job-spec.tpl.patch
@@ -1,6 +1,14 @@
---- charts-original/templates/_hubble-generate-certs-job-spec.tpl	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/_hubble-generate-certs-job-spec.tpl	2021-02-08 14:38:47.451463609 +0100
-@@ -10,7 +10,7 @@
+--- charts-original/templates/_hubble-generate-certs-job-spec.tpl
++++ charts/templates/_hubble-generate-certs-job-spec.tpl
+@@ -5,15 +5,12 @@
+     metadata:
+       labels:
+         k8s-app: hubble-generate-certs
+-        {{- with .Values.certgen.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-        {{- end }}
+     spec:
+       serviceAccount: hubble-generate-certs
        serviceAccountName: hubble-generate-certs
        containers:
          - name: certgen
@@ -9,4 +17,3 @@
            imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
            command:
              - "/usr/bin/cilium-certgen"
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/hubble-relay-deployment.yaml charts/templates/hubble-relay-deployment.yaml

--- a/packages/cilium/generated-changes/patch/templates/cilium-agent-daemonset.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-agent-daemonset.yaml.patch
@@ -1,39 +1,48 @@
---- charts-original/templates/cilium-agent-daemonset.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/cilium-agent-daemonset.yaml	2021-02-08 14:38:47.471463747 +0100
-@@ -193,7 +193,7 @@
+--- charts-original/templates/cilium-agent-daemonset.yaml
++++ charts/templates/cilium-agent-daemonset.yaml
+@@ -56,9 +56,6 @@
+ {{- if .Values.keepDeprecatedLabels }}
+         kubernetes.io/cluster-service: "true"
+ {{- end }}
+-{{- with .Values.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+ {{- if .Values.affinity }}
+       affinity:
+@@ -196,7 +193,7 @@
  {{- with .Values.extraEnv }}
  {{ toYaml . | trim | indent 8 }}
  {{- end }}
--        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
          imagePullPolicy: {{ .Values.image.pullPolicy }}
  {{- if .Values.cni.install }}
          lifecycle:
-@@ -311,7 +311,7 @@
+@@ -314,7 +311,7 @@
  {{- range $type := .Values.monitor.eventTypes }}
          - --type={{ $type }}
  {{- end }}
--        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          volumeMounts:
          - mountPath: /var/run/cilium
-@@ -331,7 +331,7 @@
+@@ -334,7 +331,7 @@
  {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
        - name: wait-for-node-init
          command: ['sh', '-c', 'until stat {{ .Values.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
--        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          volumeMounts:
          - mountPath: {{ .Values.nodeinit.bootstrapFile }}
-@@ -369,7 +369,7 @@
+@@ -372,7 +369,7 @@
  {{- if .Values.extraEnv }}
  {{ toYaml .Values.extraEnv | indent 8 }}
  {{- end }}
--        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          name: clean-cilium-state
          securityContext:
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/cilium-etcd-operator-deployment.yaml charts/templates/cilium-etcd-operator-deployment.yaml

--- a/packages/cilium/generated-changes/patch/templates/cilium-etcd-operator-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-etcd-operator-deployment.yaml.patch
@@ -1,6 +1,16 @@
---- charts-original/templates/cilium-etcd-operator-deployment.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/cilium-etcd-operator-deployment.yaml	2021-02-08 14:38:47.511464021 +0100
-@@ -64,7 +64,7 @@
+--- charts-original/templates/cilium-etcd-operator-deployment.yaml
++++ charts/templates/cilium-etcd-operator-deployment.yaml
+@@ -26,9 +26,6 @@
+       labels:
+         io.cilium/app: etcd-operator
+         name: cilium-etcd-operator
+-{{- with .Values.etcd.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+ {{- if .Values.etcd.affinity }}
+       affinity:
+@@ -67,7 +64,7 @@
            value: "revision"
          - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
            value: "25000"
@@ -9,4 +19,3 @@
          imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
          name: cilium-etcd-operator
        dnsPolicy: ClusterFirst
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/cilium-nodeinit-daemonset.yaml charts/templates/cilium-nodeinit-daemonset.yaml

--- a/packages/cilium/generated-changes/patch/templates/cilium-nodeinit-daemonset.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-nodeinit-daemonset.yaml.patch
@@ -1,6 +1,16 @@
---- charts-original/templates/cilium-nodeinit-daemonset.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/cilium-nodeinit-daemonset.yaml	2021-02-08 14:38:47.519464077 +0100
-@@ -34,7 +34,7 @@
+--- charts-original/templates/cilium-nodeinit-daemonset.yaml
++++ charts/templates/cilium-nodeinit-daemonset.yaml
+@@ -18,9 +18,6 @@
+ {{- end }}
+       labels:
+         app: cilium-node-init
+-{{- with .Values.nodeinit.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+ {{- with .Values.tolerations }}
+       tolerations:
+@@ -37,7 +34,7 @@
  {{- end }}
        containers:
          - name: node-init
@@ -9,4 +19,3 @@
            imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
            securityContext:
              privileged: true
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/cilium-operator-deployment.yaml charts/templates/cilium-operator-deployment.yaml

--- a/packages/cilium/generated-changes/patch/templates/cilium-operator-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-operator-deployment.yaml.patch
@@ -1,18 +1,27 @@
---- charts-original/templates/cilium-operator-deployment.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/cilium-operator-deployment.yaml	2021-02-08 14:38:47.531464160 +0100
-@@ -136,11 +136,11 @@
+--- charts-original/templates/cilium-operator-deployment.yaml
++++ charts/templates/cilium-operator-deployment.yaml
+@@ -41,9 +41,6 @@
+       labels:
+         io.cilium/app: operator
+         name: cilium-operator
+-{{- with .Values.operator.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+ {{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
+       # In HA mode, cilium-operator pods must not be scheduled on the same
+@@ -139,11 +136,11 @@
            value: {{ $value }}
  {{- end }}
  {{- if .Values.eni }}
--        image: {{ .Values.operator.image.repository }}-aws:{{ .Values.operator.image.tag }}
+-        image: "{{ .Values.operator.image.repository }}-aws{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.awsDigest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.operator.image.repository }}-aws:{{ .Values.operator.image.tag }}
  {{- else if .Values.azure.enabled }}
--        image: {{ .Values.operator.image.repository }}-azure:{{ .Values.operator.image.tag }}
+-        image: "{{ .Values.operator.image.repository }}-azure{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.azureDigest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.operator.image.repository }}-azure:{{ .Values.operator.image.tag }}
  {{- else }}
--        image: {{ .Values.operator.image.repository }}-generic:{{ .Values.operator.image.tag }}
+-        image: "{{ .Values.operator.image.repository }}-generic{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.genericDigest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.operator.image.repository }}-generic:{{ .Values.operator.image.tag }}
  {{- end }}
          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
          name: cilium-operator
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/cilium-preflight-daemonset.yaml charts/templates/cilium-preflight-daemonset.yaml

--- a/packages/cilium/generated-changes/patch/templates/cilium-preflight-daemonset.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-preflight-daemonset.yaml.patch
@@ -1,10 +1,20 @@
---- charts-original/templates/cilium-preflight-daemonset.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/cilium-preflight-daemonset.yaml	2021-02-08 14:38:47.555464324 +0100
-@@ -25,14 +25,14 @@
+--- charts-original/templates/cilium-preflight-daemonset.yaml
++++ charts/templates/cilium-preflight-daemonset.yaml
+@@ -18,9 +18,6 @@
+       labels:
+         k8s-app: cilium-pre-flight-check
+         kubernetes.io/cluster-service: "true"
+-{{- with .Values.preflight.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+ {{- if .Values.imagePullSecrets }}
+       imagePullSecrets:
+@@ -28,14 +25,14 @@
  {{- end }}
        initContainers:
          - name: clean-cilium-state
--          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
 +          image: {{ template "system_default_registry" . }}{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            command: ["/bin/echo"]
@@ -12,18 +22,17 @@
            - "hello"
        containers:
          - name: cilium-pre-flight-check
--          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
 +          image: {{ template "system_default_registry" . }}{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            command: ["/bin/sh"]
            args:
-@@ -68,7 +68,7 @@
+@@ -71,7 +68,7 @@
  
  {{- if ne .Values.preflight.tofqdnsPreCache "" }}
          - name: cilium-pre-flight-fqdn-precache
--          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
 +          image: {{ template "system_default_registry" . }}{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            name: cilium-pre-flight-fqdn-precache
            command: ["/bin/sh"]
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/cilium-preflight-deployment.yaml charts/templates/cilium-preflight-deployment.yaml

--- a/packages/cilium/generated-changes/patch/templates/cilium-preflight-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-preflight-deployment.yaml.patch
@@ -1,12 +1,21 @@
---- charts-original/templates/cilium-preflight-deployment.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/cilium-preflight-deployment.yaml	2021-02-08 14:38:47.559464353 +0100
-@@ -37,7 +37,7 @@
+--- charts-original/templates/cilium-preflight-deployment.yaml
++++ charts/templates/cilium-preflight-deployment.yaml
+@@ -19,9 +19,6 @@
+       labels:
+         k8s-app: cilium-pre-flight-check-deployment
+         kubernetes.io/cluster-service: "true"
+-{{- with .Values.preflight.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+       affinity:
+         podAffinity:
+@@ -40,7 +37,7 @@
        containers:
  {{- if .Values.preflight.validateCNPs }}
          - name: cnp-validator
--          image: {{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
+-          image: "{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}{{ if .Values.preflight.image.useDigest }}@{{ .Values.preflight.image.digest }}{{ end }}"
 +          image: {{ template "system_default_registry" . }}{{ .Values.preflight.image.repository }}:{{ .Values.preflight.image.tag }}
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            command: ["/bin/sh"]
            args:
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/clustermesh-apiserver-deployment.yaml charts/templates/clustermesh-apiserver-deployment.yaml

--- a/packages/cilium/generated-changes/patch/templates/clustermesh-apiserver-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/clustermesh-apiserver-deployment.yaml.patch
@@ -1,6 +1,16 @@
---- charts-original/templates/clustermesh-apiserver-deployment.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/clustermesh-apiserver-deployment.yaml	2021-02-08 14:38:47.591464573 +0100
-@@ -30,7 +30,7 @@
+--- charts-original/templates/clustermesh-apiserver-deployment.yaml
++++ charts/templates/clustermesh-apiserver-deployment.yaml
+@@ -22,9 +22,6 @@
+ {{- end }}
+       labels:
+         k8s-app: clustermesh-apiserver
+-{{- with .Values.clustermesh.apiserver.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+ {{- with .Values.imagePullSecrets }}
+       imagePullSecrets: {{- toYaml . | nindent 8 }}
+@@ -33,7 +30,7 @@
        serviceAccount: clustermesh-apiserver
        initContainers:
        - name: etcd-init
@@ -9,7 +19,7 @@
          imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
          env:
          - name: ETCDCTL_API
-@@ -67,7 +67,7 @@
+@@ -70,7 +67,7 @@
            name: etcd-data-dir
        containers:
        - name: etcd
@@ -18,13 +28,12 @@
          imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
          env:
          - name: ETCDCTL_API
-@@ -96,7 +96,7 @@
+@@ -99,7 +96,7 @@
          - mountPath: /var/run/etcd
            name: etcd-data-dir
        - name: "apiserver"
--        image: {{ .Values.clustermesh.apiserver.image.repository }}:{{ .Values.clustermesh.apiserver.image.tag }}
+-        image: "{{ .Values.clustermesh.apiserver.image.repository }}:{{ .Values.clustermesh.apiserver.image.tag }}{{ if .Values.clustermesh.apiserver.image.useDigest }}@{{ .Values.clustermesh.apiserver.image.digest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.clustermesh.apiserver.image.repository }}:{{ .Values.clustermesh.apiserver.image.tag }}
          imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
          command:
            - /usr/bin/clustermesh-apiserver
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl charts/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl

--- a/packages/cilium/generated-changes/patch/templates/hubble-relay-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/hubble-relay-deployment.yaml.patch
@@ -1,12 +1,21 @@
---- charts-original/templates/hubble-relay-deployment.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/hubble-relay-deployment.yaml	2021-02-08 14:38:47.683465207 +0100
-@@ -45,7 +45,7 @@
+--- charts-original/templates/hubble-relay-deployment.yaml
++++ charts/templates/hubble-relay-deployment.yaml
+@@ -28,9 +28,6 @@
+ {{- end }}
+       labels:
+         k8s-app: hubble-relay
+-{{- with .Values.hubble.relay.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+       affinity:
+         podAffinity:
+@@ -48,7 +45,7 @@
  {{- end }}
        containers:
          - name: hubble-relay
--          image: {{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}
+-          image: "{{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}{{ if .Values.hubble.relay.image.useDigest }}@{{ .Values.hubble.relay.image.digest }}{{ end }}"
 +          image: {{ template "system_default_registry" . }}{{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}
            imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
            command:
              - hubble-relay
-diff -x '*.tgz' -x '*.lock' -uNr charts-original/templates/hubble-ui-deployment.yaml charts/templates/hubble-ui-deployment.yaml

--- a/packages/cilium/generated-changes/patch/templates/hubble-ui-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/hubble-ui-deployment.yaml.patch
@@ -1,6 +1,16 @@
---- charts-original/templates/hubble-ui-deployment.yaml	2021-02-04 01:17:41.000000000 +0100
-+++ charts/templates/hubble-ui-deployment.yaml	2021-02-08 14:38:47.715465428 +0100
-@@ -40,7 +40,7 @@
+--- charts-original/templates/hubble-ui-deployment.yaml
++++ charts/templates/hubble-ui-deployment.yaml
+@@ -23,9 +23,6 @@
+ {{- end }}
+       labels:
+         k8s-app: hubble-ui
+-{{- with .Values.hubble.ui.podLabels }}
+-        {{- toYaml . | nindent 8 }}
+-{{- end }}
+     spec:
+       {{- if .Values.hubble.ui.securityContext.enabled }}
+       securityContext:
+@@ -43,7 +40,7 @@
  {{- end }}
        containers:
          - name: frontend
@@ -9,7 +19,7 @@
            imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
            ports:
              - containerPort: 8080
-@@ -48,7 +48,7 @@
+@@ -51,7 +48,7 @@
            resources:
              {{- toYaml .Values.hubble.ui.frontend.resources | trim | nindent 12 }}
          - name: backend
@@ -18,7 +28,7 @@
            imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
            env:
              - name: EVENTS_SERVER_PORT
-@@ -61,7 +61,7 @@
+@@ -64,7 +61,7 @@
            resources:
              {{- toYaml .Values.hubble.ui.backend.resources  | trim | nindent 12 }}
          - name: proxy

--- a/packages/cilium/package.yaml
+++ b/packages/cilium/package.yaml
@@ -1,5 +1,5 @@
-url: https://helm.cilium.io/cilium-1.9.4.tgz
-packageVersion: 01
+url: https://helm.cilium.io/cilium-1.9.6.tgz
+packageVersion: 02
 releaseCandidateVersion: 00
 # This package is meant to be consumed as a subchart of another package,
 # not directly.

--- a/packages/rke2-cilium/charts/Chart.yaml
+++ b/packages/rke2-cilium/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rke2-cilium
 description: eBPF-based Networking, Security, and Observability
-version: 1.9.4
+version: 1.9.6
 kubeVersion: '>= 1.12.0-0'
 home: https://cilium.io/
 keywords:

--- a/packages/rke2-cilium/charts/values.yaml
+++ b/packages/rke2-cilium/charts/values.yaml
@@ -6,11 +6,11 @@ cilium:
   imagePullSecrets: []
   image:
     repository: rancher/mirrored-cilium-cilium
-    tag: v1.9.4
+    tag: v1.9.6
   operator:
     image:
       repository: rancher/mirrored-cilium-operator
-      tag: v1.9.4
+      tag: v1.9.6
   nodeinit:
     image:
       repository: rancher/mirrored-cilium-startup-script
@@ -20,7 +20,7 @@ cilium:
     enabled: false
     image:
       repository: rancher/mirrored-cilium-cilium
-      tag: v1.9.4
+      tag: v1.9.6
 
   #
   # Enable Azure integration.


### PR DESCRIPTION
This change updates the Cilium version from 1.9.4 to 1.9.6. This release updates Envoy to 1.17.2 to address CVE-2021-28682, CVE-2021-28683 and CVE-2021-29258.

The second commit contains only autoregenerated patches after the update. Those patches had to be regenerated due to upstream changes in Cilium Helm charts.