### PR TITLE
Add ability to configure calico failsafe ports

### DIFF
--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -154,6 +154,10 @@ spec:
               value: {{ .Values.calico.felixPrometheusMetricsEnabled | quote }}
             - name: FELIX_XDPENABLED
               value: {{ .Values.calico.felixXDPEnabled | quote }}
+            - name: FELIX_FAILSAFEINBOUNDHOSTPORTS
+              value: {{ .Values.calico.felixFailsafeInboundHostPorts | quote }}
+            - name: FELIX_FAILSAFEOUTBOUNDHOSTPORTS
+              value: {{ .Values.calico.felixFailsafeOutboundHostPorts | quote }}
           securityContext:
             privileged: true
           resources:

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -71,6 +71,10 @@ calico:
   typhaServiceName: none
   # Kubelet flex-volume-plugin-dir
   flexVolumePluginDir: /var/lib/kubelet/volumeplugins
+  # calico inbound failsafe ports. Empty string means defaults. Use 'none' to disable failsafe if you have your own rules.
+  felixFailsafeInboundHostPorts: ""
+  # calico outbound failsafe ports. Empty string means defaults. Use 'none' to disable failsafe if you have your own rules.
+  felixFailsafeOutboundHostPorts: ""
 
 global:
   systemDefaultRegistry: ""

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 02
+packageVersion: 03
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Made FailsafeOutboundHostPorts and FailsafeInboundHostPorts configurable
to allow users to have custom network policy for example SSH (22)

Previously failsafe rules would always have opened 22 even if user had
custom GlobalNetworkPolicy applied on the node.

Fixes https://github.com/rancher/rke2/issues/921