### PR TITLE
Update coredns and kube-proxy charts to use passthrough values

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
@@ -14,7 +14,7 @@
      {
        {{- range .plugins }}
 -        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
-+        {{ .name }} {{ if .parameters }} {{if eq .name "kubernetes" }} {{ (lookup "v1" "ConfigMap" "kube-system" "cluster-dns").data.clusterDomain }} {{ end }} {{.parameters}}{{ end }}{{ if .configBlock }} {
++        {{ .name }} {{ if .parameters }} {{if eq .name "kubernetes" }} {{ coalesce $.Values.global.clusterDomain "cluster.local" }} {{ end }} {{.parameters}}{{ end }}{{ if .configBlock }} {
  {{ .configBlock | indent 12 }}
          }{{ end }}
        {{- end }}

--- a/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
@@ -20,7 +20,7 @@
    {{- if .Values.service.clusterIP }}
    clusterIP: {{ .Values.service.clusterIP }}
 +  {{ else }}
-+  clusterIP: {{ (lookup "v1" "ConfigMap" "kube-system" "cluster-dns").data.clusterDNS }}
++  clusterIP: {{ coalesce .Values.global.clusterDNS "10.43.0.10" }}
    {{- end }}
    {{- if .Values.service.externalTrafficPolicy }}
    externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://charts.helm.sh/stable/packages/coredns-1.10.1.tgz
-packageVersion: 02
+packageVersion: 03
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00

--- a/packages/rke2-kube-proxy/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.20.6-build20210419
-appVersion: v1.20.6
+version: v1.21.0-build20210413
+appVersion: v1.21.0
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy/charts/templates/config.yaml
+++ b/packages/rke2-kube-proxy/charts/templates/config.yaml
@@ -10,7 +10,7 @@ data:
       contentType: {{ .Values.clientConnection.contentType | quote }}
       kubeconfig: {{ include "kubeproxy_kubeconfig" . | quote }}
       qps: {{ .Values.clientConnection.qps }} 
-    clusterCIDR: {{ .Values.clusterCIDR | quote }} 
+    clusterCIDR: {{ coalesce .Values.global.clusterCIDR .Values.clusterCIDR | quote }}
     configSyncPeriod: {{ .Values.configSyncPeriod }}
     conntrack:
       maxPerCore: {{ .Values.conntrack.maxPerCore }}

--- a/packages/rke2-kube-proxy/charts/values.yaml
+++ b/packages/rke2-kube-proxy/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kube-proxy
-  tag: v1.20.6-build20210419
+  tag: v1.21.0-build20210413
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)

--- a/packages/rke2-kube-proxy/package.yaml
+++ b/packages/rke2-kube-proxy/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Required for rancher/rke2#917