### PR TITLE
cilium: Make the wait-for-note-init container privileged

### DIFF
--- a/packages/cilium/generated-changes/patch/templates/cilium-agent-daemonset.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-agent-daemonset.yaml.patch
@@ -28,16 +28,19 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          volumeMounts:
          - mountPath: /var/run/cilium
-@@ -334,7 +331,7 @@
+@@ -334,8 +331,10 @@
  {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
        - name: wait-for-node-init
          command: ['sh', '-c', 'until stat {{ .Values.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
 -        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}{{ if .Values.image.useDigest }}@{{ .Values.image.digest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
          imagePullPolicy: {{ .Values.image.pullPolicy }}
++        securityContext:
++          privileged: true
          volumeMounts:
          - mountPath: {{ .Values.nodeinit.bootstrapFile }}
-@@ -372,7 +369,7 @@
+           name: cilium-bootstrap-file
+@@ -372,7 +371,7 @@
  {{- if .Values.extraEnv }}
  {{ toYaml .Values.extraEnv | indent 8 }}
  {{- end }}

--- a/packages/cilium/package.yaml
+++ b/packages/cilium/package.yaml
@@ -1,5 +1,5 @@
 url: https://helm.cilium.io/cilium-1.9.6.tgz
-packageVersion: 02
+packageVersion: 03
 releaseCandidateVersion: 00
 # This package is meant to be consumed as a subchart of another package,
 # not directly.

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 03
+packageVersion: 04
 releaseCandidateVersion: 00


### PR DESCRIPTION
Before this change, wait-for-node-init container was not able to execute
properly with SELinux enabled, due to lack of ability to access the bind
mounted file. Due to lack of ability to set the container_file_t label
through Kubernetes, the other possible solution, done in this commit, is
making the container privileged. All the other containers accessing the
bootstrap file are already privileged as well, so it should not be that
harmful.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>