### PR TITLE
Add the calicoctl and operator images

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -13,3 +13,17 @@
  
  certs:
    node:
+@@ -17,9 +23,10 @@
+ 
+ # Configuration for the tigera operator
+ tigeraOperator:
+-  image: tigera/operator
++  registry: docker.io
++  image: rancher/mirrored-calico-operator
+   version: v1.15.1
+-  registry: quay.io
++
+ calicoctl:
+-  image: quay.io/docker.io/calico/ctl
++  image: rancher/mirrored-calico-ctl
+   tag: v3.18.1

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.18.1/tigera-operator-v3.18.1-1.tgz
-packageVersion: 01
+packageVersion: 02
 releaseCandidateVersion: 00
 additionalCharts:
   - workingDir: charts-crd


### PR DESCRIPTION
Consume the operator and calicoctl images from our rancher/mirrored-xxx images

Unfortunately, we can't consume the rest of the images since this feature is unavailable in calico's helm

Signed-off-by: Manuel Buil <mbuil@suse.com>