### PR TITLE
Add pod_cidr option and systemDefaultRegistry

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,0 +1,16 @@
+--- charts-original/templates/_helpers.tpl
++++ charts/templates/_helpers.tpl
+@@ -1,7 +1,10 @@
+ {{/* generate the image name for a component*/}}
+ {{- define "tigera-operator.image" -}}
+-{{- if .registry -}}
+-    {{- .registry | trimSuffix "/" -}}/
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- $_ := set .Values.tigeraOperator "registry" .Values.global.systemDefaultRegistry -}}
+ {{- end -}}
+-{{- .image -}}:{{- .version -}}
++{{- if .Values.tigeraOperator.registry -}}
++    {{- .Values.tigeraOperator.registry | trimSuffix "/" -}}/
++{{- end -}}
++{{- .Values.tigeraOperator.image -}}:{{- .Values.tigeraOperator.version -}}
+ {{- end -}}

--- a/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
@@ -1,0 +1,13 @@
+--- charts-original/templates/crs/custom-resources.yaml
++++ charts/templates/crs/custom-resources.yaml
+@@ -6,6 +6,10 @@
+ {{ $secrets = append $secrets $item }}
+ {{ end }}
+ {{ $_ := set $installSpec "imagePullSecrets" $secrets }}
++{{ $defaultipPools := get .Values.installation.calicoNetwork "ipPools" | first }}
++{{ $defaultCIDR := get $defaultipPools "cidr" }}
++{{ $finalCIDR := coalesce .Values.global.clusterCIDR $defaultCIDR }}
++{{ $_ := set $defaultipPools "cidr" $finalCIDR }}
+ 
+ apiVersion: operator.tigera.io/v1
+ kind: Installation

--- a/packages/rke2-calico/generated-changes/patch/templates/tigera-operator/02-tigera-operator.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/tigera-operator/02-tigera-operator.yaml.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/tigera-operator/02-tigera-operator.yaml
++++ charts/templates/tigera-operator/02-tigera-operator.yaml
+@@ -29,7 +29,7 @@
+       dnsPolicy: ClusterFirstWithHostNet
+       containers:
+         - name: tigera-operator
+-          image: {{ template "tigera-operator.image" .Values.tigeraOperator}}
++          image: {{ template "tigera-operator.image" . }}
+           imagePullPolicy: IfNotPresent
+           command:
+             - operator

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -13,7 +13,7 @@
  
  certs:
    node:
-@@ -17,9 +23,10 @@
+@@ -17,9 +23,13 @@
  
  # Configuration for the tigera operator
  tigeraOperator:
@@ -27,3 +27,6 @@
 -  image: quay.io/docker.io/calico/ctl
 +  image: rancher/mirrored-calico-ctl
    tag: v3.18.1
++
++global:
++  systemDefaultRegistry: ""

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.18.1/tigera-operator-v3.18.1-1.tgz
-packageVersion: 02
+packageVersion: 03
 releaseCandidateVersion: 00
 additionalCharts:
   - workingDir: charts-crd


### PR DESCRIPTION
Currently, if user sets the CLI `cluster-cidr` value, the value was not propagating into Calico's values. This patch fixes that.
Moreover, this patch adds `systemDefaultRegistry` to the already existing template, so that it uses this value if it exists for the registry

Signed-off-by: Manuel Buil <mbuil@suse.com>