### PR TITLE
Honor .Values.global.clusterCIDR in rke2-canal

### DIFF
--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -60,7 +60,7 @@ data:
   # Flannel network configuration. Mounted into the flannel container.
   net-conf.json: |
     {
-      "Network": {{ .Values.podCidr | quote }},
+      "Network": {{ .coalesce .Values.global.clusterCIDR Values.podCidr | quote }},
       "Backend": {
         "Type": {{ .Values.flannel.backend | quote }}
       }

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 03
+packageVersion: 04
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
@ibuildthecloud pointed out that the chart does need to use this passthrough cluster setting