### PR TITLE
Fix bug when deploying with Cilium

### DIFF
--- a/packages/cilium/package.yaml
+++ b/packages/cilium/package.yaml
@@ -1,5 +1,5 @@
 url: https://helm.cilium.io/cilium-1.9.6.tgz
-packageVersion: 03
+packageVersion: 04
 releaseCandidateVersion: 00
 # This package is meant to be consumed as a subchart of another package,
 # not directly.

--- a/packages/rke2-cilium/charts/values.schema.json
+++ b/packages/rke2-cilium/charts/values.schema.json
@@ -127,7 +127,7 @@
             "type": "object",
             "properties": {
                 "systemDefaultRegistry": {
-                    "type": "string"
+                    "type": ["string", "integer"]
                 }
             }
         }

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 04
+packageVersion: 05
 releaseCandidateVersion: 00


### PR DESCRIPTION
When deploying with v1.21.1-alpha5-rke2r1, the helm installation uses `--set global.systemDefaultRegistry=0`, that throws an error when installing cilium:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
rke2-cilium:
- global.systemDefaultRegistry: Invalid type. Expected: string, given: integer
```
This patch adds in the schema the possibility for the value to be also an integer

Signed-off-by: Manuel Buil <mbuil@suse.com>