### PR TITLE
[release-1.19] Do not quote kube-proxy config values of type bool

### DIFF
--- a/packages/rke2-kube-proxy/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.21.1-build20210520
-appVersion: v1.21.1
+version: v1.19.11-build20210520
+appVersion: v1.19.11
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy/charts/templates/config.yaml
+++ b/packages/rke2-kube-proxy/charts/templates/config.yaml
@@ -18,11 +18,11 @@ data:
       tcpCloseWaitTimeout: {{ .Values.conntrack.tcpCloseWaitTimeout | quote }}
       tcpEstablishedTimeout: {{ .Values.conntrack.tcpEstablishedTimeout | quote }}
     detectLocalMode: {{ .Values.detectLocalMode | quote }}
-    enableProfiling: {{ .Values.enableProfiling | quote }}
+    enableProfiling: {{ .Values.enableProfiling }}
     healthzBindAddress: {{ .Values.healthzBindAddress | quote }}
     hostnameOverride: {{ .Values.hostnameOverride | quote }}
     iptables:
-      masqueradeAll: {{ .Values.iptables.masqueradeAll | quote }}
+      masqueradeAll: {{ .Values.iptables.masqueradeAll }}
       masqueradeBit: {{ .Values.iptables.masqueradeBit }}
       {{ if .Values.iptables.minSyncPeriod }}
       minSyncPeriod: {{ .Values.iptables.minSyncPeriod }}
@@ -34,7 +34,7 @@ data:
       minSyncPeriod: {{ .Values.ipvs.minSyncPeriod }}
       {{ end }}
       scheduler: {{ .Values.ipvs.scheduler | quote }}
-      strictARP: {{ .Values.ipvs.strictARP | quote }}
+      strictARP: {{ .Values.ipvs.strictARP }}
       syncPeriod: {{ .Values.ipvs.syncPeriod }}
       {{ if .Values.ipvs.tcpFinTimeout }}
       tcpFinTimeout: {{ .Values.ipvs.tcpFinTimeout }}

--- a/packages/rke2-kube-proxy/charts/values.yaml
+++ b/packages/rke2-kube-proxy/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kube-proxy
-  tag: v1.21.1-build20210520
+  tag: v1.19.11-build20210520
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)

--- a/packages/rke2-kube-proxy/package.yaml
+++ b/packages/rke2-kube-proxy/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 04
+packageVersion: 05
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
For https://github.com/rancher/rke2/issues/1010#issuecomment-845625976

Validated against schema from
https://github.com/kubernetes/kube-proxy/blob/release-1.19/config/v1alpha1/types.go