### PR TITLE
Update Calico with the newer version

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
@@ -2,10 +2,11 @@
 +++ charts/Chart.yaml
 @@ -1,5 +1,7 @@
  apiVersion: v2
- appVersion: v3.19.1
+-appVersion: v3.19.1-e9e1e40ca
++appVersion: v3.19.1-2
  description: Installs the Tigera operator for Calico
 -name: tigera-operator
 +name: rke2-calico
- version: v3.19.1-1
+ version: v3.19
 +annotations:
 +  catalog.cattle.io/namespace: tigera-operator

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1,8 +1,21 @@
+@@ -1,8 +1,24 @@
  imagePullSecrets: {}
  
  installation:
@@ -19,16 +19,19 @@
 +    - natOutgoing: Enabled
 +      encapsulation: VXLAN
 +      cidr: 10.42.0.0/16
++  imagePath: "rancher"
++  imagePrefix: "mirrored-calico-"
++
  
  certs:
    node:
-@@ -17,9 +30,12 @@
+@@ -17,9 +33,12 @@
  
  # Configuration for the tigera operator
  tigeraOperator:
 -  image: tigera/operator
 +  image: rancher/mirrored-calico-operator
-   version: v1.17.2
+   version: v1.17.4
 -  registry: quay.io
 +  registry: docker.io
  calicoctl:

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
-url: https://github.com/projectcalico/calico/releases/download/v3.19.1/tigera-operator-v3.19.1-1.tgz
-packageVersion: 05
+url: https://github.com/projectcalico/calico/releases/download/v3.19.1/tigera-operator-v3.19.1-2.tgz
+packageVersion: 06
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
This version fixes the problems we had:
1 - Image prefix no possible
2 - Images on 3.19.0 instead of 3.19.1

Signed-off-by: Manuel Buil <mbuil@suse.com>