### PR TITLE
cilium: Update to 1.9.8

### DIFF
--- a/packages/cilium/generated-changes/patch/values.yaml.patch
+++ b/packages/cilium/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1320,6 +1320,8 @@
+@@ -1325,6 +1325,8 @@
    - effect: NoSchedule
      key: node-role.kubernetes.io/master
    - effect: NoSchedule

--- a/packages/cilium/package.yaml
+++ b/packages/cilium/package.yaml
@@ -1,5 +1,5 @@
-url: https://helm.cilium.io/cilium-1.9.6.tgz
-packageVersion: 06
+url: https://helm.cilium.io/cilium-1.9.8.tgz
+packageVersion: 07
 releaseCandidateVersion: 00
 # This package is meant to be consumed as a subchart of another package,
 # not directly.

--- a/packages/rke2-cilium/charts/Chart.yaml
+++ b/packages/rke2-cilium/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rke2-cilium
 description: eBPF-based Networking, Security, and Observability
-version: 1.9.6
+version: 1.9.8
 kubeVersion: '>= 1.12.0-0'
 home: https://cilium.io/
 keywords:

--- a/packages/rke2-cilium/charts/values.yaml
+++ b/packages/rke2-cilium/charts/values.yaml
@@ -6,11 +6,11 @@ cilium:
   imagePullSecrets: []
   image:
     repository: rancher/mirrored-cilium-cilium
-    tag: v1.9.6
+    tag: v1.9.8
   operator:
     image:
       repository: rancher/mirrored-cilium-operator
-      tag: v1.9.6
+      tag: v1.9.8
   nodeinit:
     image:
       repository: rancher/mirrored-cilium-startup-script
@@ -20,7 +20,7 @@ cilium:
     enabled: false
     image:
       repository: rancher/mirrored-cilium-cilium
-      tag: v1.9.6
+      tag: v1.9.8
 
   #
   # Enable Azure integration.

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 07
+packageVersion: 08
 releaseCandidateVersion: 00


### PR DESCRIPTION
Update Cilium from 1.9.6 to 1.9.8. Changelogs of the last two releases:

* https://github.com/cilium/cilium/releases/tag/v1.9.8
* https://github.com/cilium/cilium/releases/tag/v1.9.7

Ref: rancher/rke2#1099
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>