### PR TITLE
rke2-kube-proxy: correct package name

### DIFF
--- a/packages/rke2-kube-proxy-1.18/package.yaml
+++ b/packages/rke2-kube-proxy-1.18/package.yaml
@@ -2,3 +2,4 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
+name: rke2-kube-proxy

--- a/packages/rke2-kube-proxy-1.19/package.yaml
+++ b/packages/rke2-kube-proxy-1.19/package.yaml
@@ -2,3 +2,4 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
+name: rke2-kube-proxy

--- a/packages/rke2-kube-proxy-1.20/package.yaml
+++ b/packages/rke2-kube-proxy-1.20/package.yaml
@@ -2,3 +2,4 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
+name: rke2-kube-proxy

--- a/packages/rke2-kube-proxy-1.21/package.yaml
+++ b/packages/rke2-kube-proxy-1.21/package.yaml
@@ -2,3 +2,4 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
+name: rke2-kube-proxy


### PR DESCRIPTION
Prevent package name inference on the rke2-kube-proxy-* sub packages
from being the directory name, but instead roll up to rke2-kube-proxy.
This should address assets showing up as
- `assets/rke2-kube-proxy-1.21/rke2-kube-proxy-v1.21.2-build2021061701.tgz`
instead of
- `assets/rke2-kube-proxy/rke2-kube-proxy-v1.21.2-build2021061701.tgz`
in the index.yaml.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
