### PR TITLE
revert fix-rke2-kube-proxy-assets

### DIFF
--- a/packages/rke2-kube-proxy-1.18/package.yaml
+++ b/packages/rke2-kube-proxy-1.18/package.yaml
@@ -2,4 +2,3 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
-name: rke2-kube-proxy

--- a/packages/rke2-kube-proxy-1.19/package.yaml
+++ b/packages/rke2-kube-proxy-1.19/package.yaml
@@ -2,4 +2,3 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
-name: rke2-kube-proxy

--- a/packages/rke2-kube-proxy-1.20/package.yaml
+++ b/packages/rke2-kube-proxy-1.20/package.yaml
@@ -2,4 +2,3 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
-name: rke2-kube-proxy

--- a/packages/rke2-kube-proxy-1.21/package.yaml
+++ b/packages/rke2-kube-proxy-1.21/package.yaml
@@ -2,4 +2,3 @@ url: local
 packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
-name: rke2-kube-proxy


### PR DESCRIPTION
Revert "rke2-kube-proxy: correct package name"
    
This reverts commit 073d132f790acd2b46f86844dc9bd074f2c193a7.