### PR TITLE
multus: Make the daemonset init container privileged

### DIFF
--- a/packages/rke2-multus/charts/templates/daemonset.yaml
+++ b/packages/rke2-multus/charts/templates/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
       initContainers:
       - name: cni-plugins
         image: {{ template "system_default_registry" . }}{{ .Values.cniplugins.image.repository }}:{{ .Values.cniplugins.image.tag }}
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: cnibin
           mountPath: /host/opt/cni/bin

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 02
+packageVersion: 03
 releaseCandidateVersion: 00


### PR DESCRIPTION
Before this change, the multus daemonset init container had troubles
with running with SELinux in enforced mode, due to lack of the
container_file_t label on the host /opt/cni/bin directory. Fix that by
making the container privileged.

Ref: rancher/rke2#746
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>