### PR TITLE
Update rke2 calico config for Windows support

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1,8 +1,24 @@
+@@ -1,8 +1,35 @@
  imagePullSecrets: {}
  
  installation:
@@ -17,15 +17,26 @@
 +    bgp: Disabled
 +    ipPools:
 +    - natOutgoing: Enabled
++      blockSize: 24
 +      encapsulation: VXLAN
 +      cidr: 10.42.0.0/16
 +  imagePath: "rancher"
 +  imagePrefix: "mirrored-calico-"
 +
++felixconfigurations:
++  spec:
++    allowVXLANPacketsFromWorkloads: true
++    vxlanEnabled: true
++    ipipEnabled: false
++    vxlanVNI: 4096
++
++ipamconfigs:
++  spec:
++    strictAffinity: true
  
  certs:
    node:
-@@ -17,9 +33,12 @@
+@@ -17,9 +44,12 @@
  
  # Configuration for the tigera operator
  tigeraOperator:

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.19.1/tigera-operator-v3.19.1-2.tgz
-packageVersion: 06
+packageVersion: 07
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Adding configuration into the Calico rke2 chart that's required for Windows on 2.6/rke2