### PR TITLE
Bug: Propagate global.systemDefaultRegistry to calico images

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
@@ -1,9 +1,12 @@
 --- charts-original/templates/crs/custom-resources.yaml
 +++ charts/templates/crs/custom-resources.yaml
-@@ -6,6 +6,10 @@
+@@ -6,6 +6,13 @@
  {{ $secrets = append $secrets $item }}
  {{ end }}
  {{ $_ := set $installSpec "imagePullSecrets" $secrets }}
++{{ $defaultRegistry := get $installSpec "registry" }}
++{{ $finalRegistry := coalesce .Values.global.systemDefaultRegistry $defaultRegistry }}
++{{ $_ := set $installSpec "registry" $finalRegistry }}
 +{{ $defaultipPools := get .Values.installation.calicoNetwork "ipPools" | first }}
 +{{ $defaultCIDR := get $defaultipPools "cidr" }}
 +{{ $finalCIDR := coalesce .Values.global.clusterCIDR $defaultCIDR }}

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.19.1/tigera-operator-v3.19.1-2.tgz
-packageVersion: 06
+packageVersion: 07
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
rke2-calico cni install does not honor global.systemDefaultRegistry.

Fixes https://github.com/rancher/rke2/issues/1236

Signed-off-by: Manuel Buil <mbuil@suse.com>