### PR TITLE
Move kube-proxy to newer images

### DIFF
--- a/packages/rke2-kube-proxy-1.19/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.19/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kube-proxy
-  tag: v1.19.12-build20210617
+  tag: v1.19.12-build20210714
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)

--- a/packages/rke2-kube-proxy-1.19/package.yaml
+++ b/packages/rke2-kube-proxy-1.19/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00

--- a/packages/rke2-kube-proxy-1.20/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.20/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kube-proxy
-  tag: v1.20.8-build20210617
+  tag: v1.20.8-build20210714
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)

--- a/packages/rke2-kube-proxy-1.20/package.yaml
+++ b/packages/rke2-kube-proxy-1.20/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00

--- a/packages/rke2-kube-proxy-1.21/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.21/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kube-proxy
-  tag: v1.21.2-build20210617
+  tag: v1.21.2-build20210714
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)

--- a/packages/rke2-kube-proxy-1.21/package.yaml
+++ b/packages/rke2-kube-proxy-1.21/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
There is a fix in ip6tables in the new images.
New versions for 1.19, 1.20 and 1.21

Signed-off-by: Manuel Buil <mbuil@suse.com>