### PR TITLE
Update coredns helm version

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
@@ -1,12 +1,13 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -17,7 +17,7 @@
-   name: andor44
- - email: manuel@rueg.eu
-   name: mrueg
+@@ -14,8 +14,8 @@
+ maintainers:
+ - name: mrueg
+ - name: haad
 -name: coredns
 +name: rke2-coredns
  sources:
  - https://github.com/coredns/coredns
--version: 1.10.1
-+version: 1.10.101-build20210223
+ type: application
+-version: 1.16.2
++version: 1.16.201-build20210723

--- a/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,14 +1,6 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -137,6 +137,7 @@
-     {{- end -}}
- {{- end -}}
- 
-+
- {{/*
- Create the name of the service account to use
- */}}
-@@ -147,3 +148,11 @@
+@@ -147,3 +147,11 @@
      {{ default "default" .Values.serviceAccount.name }}
  {{- end -}}
  {{- end -}}

--- a/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/configmap.yaml
 +++ charts/templates/configmap.yaml
-@@ -7,7 +7,7 @@
+@@ -9,7 +9,7 @@
      app.kubernetes.io/instance: {{ .Release.Name | quote }}
      helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
      {{- if .Values.isClusterService }}
@@ -9,7 +9,7 @@
      kubernetes.io/cluster-service: "true"
      kubernetes.io/name: "CoreDNS"
      {{- end }}
-@@ -19,7 +19,7 @@
+@@ -24,7 +24,7 @@
      {{- if .port }}:{{ .port }} {{ end -}}
      {
        {{- range .plugins }}

--- a/packages/rke2-coredns/generated-changes/patch/templates/deployment.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/deployment.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/deployment.yaml
 +++ charts/templates/deployment.yaml
-@@ -7,7 +7,7 @@
+@@ -9,7 +9,7 @@
      app.kubernetes.io/instance: {{ .Release.Name | quote }}
      helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
      {{- if .Values.isClusterService }}
@@ -9,7 +9,7 @@
      kubernetes.io/cluster-service: "true"
      kubernetes.io/name: "CoreDNS"
      {{- end }}
-@@ -28,14 +28,14 @@
+@@ -31,14 +31,14 @@
      matchLabels:
        app.kubernetes.io/instance: {{ .Release.Name | quote }}
        {{- if .Values.isClusterService }}
@@ -26,15 +26,15 @@
          {{- end }}
          app.kubernetes.io/name: {{ template "coredns.name" . }}
          app.kubernetes.io/instance: {{ .Release.Name | quote }}
-@@ -46,7 +46,6 @@
+@@ -49,7 +49,6 @@
          checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
          {{- if .Values.isClusterService }}
          scheduler.alpha.kubernetes.io/critical-pod: ''
 -        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
          {{- end }}
-     spec:
-       serviceAccountName: {{ template "coredns.serviceAccountName" . }}
-@@ -60,9 +59,15 @@
+ {{- if .Values.podAnnotations }}
+ {{ toYaml .Values.podAnnotations | indent 8 }}
+@@ -69,9 +68,15 @@
        affinity:
  {{ toYaml .Values.affinity | indent 8 }}
        {{- end }}
@@ -51,7 +51,7 @@
        {{- end }}
        {{- if .Values.nodeSelector }}
        nodeSelector:
-@@ -70,7 +75,7 @@
+@@ -79,7 +84,7 @@
        {{- end }}
        containers:
        - name: "coredns"

--- a/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/service.yaml
 +++ charts/templates/service.yaml
-@@ -7,7 +7,7 @@
+@@ -9,7 +9,7 @@
      app.kubernetes.io/instance: {{ .Release.Name | quote }}
      helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
      {{- if .Values.isClusterService }}
@@ -9,7 +9,7 @@
      kubernetes.io/cluster-service: "true"
      kubernetes.io/name: "CoreDNS"
      {{- end }}
-@@ -21,11 +21,13 @@
+@@ -23,11 +23,13 @@
    selector:
      app.kubernetes.io/instance: {{ .Release.Name | quote }}
      {{- if .Values.isClusterService }}
@@ -22,5 +22,5 @@
 +  {{ else }}
 +  clusterIP: {{ coalesce .Values.global.clusterDNS "10.43.0.10" }}
    {{- end }}
-   {{- if .Values.service.externalTrafficPolicy }}
-   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+   {{- if .Values.service.externalIPs }}
+   externalIPs:

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -5,26 +5,26 @@
  
  image:
 -  repository: coredns/coredns
--  tag: "1.6.9"
+-  tag: "1.8.4"
 +  repository: rancher/hardened-coredns
 +  tag: "v1.8.3-build20210720"
    pullPolicy: IfNotPresent
  
  replicaCount: 1
-@@ -34,10 +34,10 @@
-     prometheus.io/port: "9153"
+@@ -69,10 +69,10 @@
+   annotations: {}
  
  serviceAccount:
 -  create: false
 +  create: true
    # The name of the ServiceAccount to use
    # If not set and create is true, a name is generated using the fullname template
--  name:
-+  name: coredns
+-  name: ""
++  name: "coredns"
+   annotations: {}
  
  rbac:
-   # If true, create & use RBAC resources
-@@ -52,7 +52,7 @@
+@@ -88,7 +88,7 @@
  isClusterService: true
  
  # Optional priority class to be used for the coredns pods. Used for autoscaler if autoscaler.priorityClassName not set.
@@ -33,12 +33,12 @@
  
  # Default zone is what Kubernetes recommends:
  # https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options
-@@ -126,7 +126,13 @@
+@@ -179,7 +179,13 @@
  #     operator: Equal
  #     value: master
  #     effect: NoSchedule
 -tolerations: []
-+tolerations: 
++tolerations:
 +- key: "node-role.kubernetes.io/control-plane"
 +  operator: "Exists"
 +  effect: "NoSchedule"
@@ -48,7 +48,7 @@
  
  # https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
  podDisruptionBudget: {}
-@@ -157,7 +163,7 @@
+@@ -227,7 +233,7 @@
  # See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
  autoscaler:
    # Enabled the cluster-proportional-autoscaler
@@ -57,18 +57,18 @@
  
    # Number of cores in the cluster per coredns replica
    coresPerReplica: 256
-@@ -165,8 +171,8 @@
-   nodesPerReplica: 16
+@@ -243,8 +249,8 @@
+   preventSinglePointFailure: true
  
    image:
 -    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
--    tag: "1.7.1"
+-    tag: "1.8.1"
 +    repository: rancher/mirrored-cluster-proportional-autoscaler
 +    tag: "1.8.3"
      pullPolicy: IfNotPresent
  
    # Optional priority class to be used for the autoscaler pods. priorityClassName used if not set.
-@@ -180,7 +186,13 @@
+@@ -258,7 +264,13 @@
    nodeSelector: {}
  
    # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
@@ -83,10 +83,11 @@
  
    # resources for autoscaler pod
    resources:
-@@ -196,3 +208,7 @@
-     ## Annotations for the coredns-autoscaler configmap
-     # i.e. strategy.spinnaker.io/versioned: "false" to ensure configmap isn't renamed
-     annotations: {}
+@@ -287,3 +299,8 @@
+ deployment:
+   enabled: true
+   name: ""
++
 +k8sApp : "kube-dns"
 +
 +global:

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
-url: https://charts.helm.sh/stable/packages/coredns-1.10.1.tgz
-packageVersion: 05
+url: https://github.com/coredns/helm/releases/download/coredns-1.16.2/coredns-1.16.2.tgz
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
We were using an old version of the coredns helm chart. This PR updates it

Linked issue: https://github.com/rancher/rke2/issues/1023

Signed-off-by: Manuel Buil <mbuil@suse.com>