### PR TITLE
Update dns cache image

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -96,10 +96,10 @@
 +  ipvs: false
 +  image:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.20.0-build20210802"
++    tag: "1.20.0-build20210803"
 +  initimage:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.20.0-build20210802"
++    tag: "1.20.0-build20210803"
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.16.2/coredns-1.16.2.tgz
-packageVersion: 04
+packageVersion: 05
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
The old image did not have iptables binaries in it and we need them

Signed-off-by: Manuel Buil <mbuil@suse.com>