### PR TITLE
Increase memory resources for autoscaler

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -68,7 +68,7 @@
      pullPolicy: IfNotPresent
  
    # Optional priority class to be used for the autoscaler pods. priorityClassName used if not set.
-@@ -258,7 +264,13 @@
+@@ -258,16 +264,22 @@
    nodeSelector: {}
  
    # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
@@ -83,6 +83,17 @@
  
    # resources for autoscaler pod
    resources:
+     requests:
+       cpu: "20m"
+-      memory: "10Mi"
++      memory: "20Mi"
+     limits:
+       cpu: "20m"
+-      memory: "10Mi"
++      memory: "20Mi"
+ 
+   # Options for autoscaler configmap
+   configmap:
 @@ -287,3 +299,19 @@
  deployment:
    enabled: true

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.16.2/coredns-1.16.2.tgz
-packageVersion: 05
+packageVersion: 06
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
After deploying a couple of times with the latest rke2, the autoscaler crashes because of OOM. When increasing the resources to 20Mi, I get no problems

Signed-off-by: Manuel Buil <mbuil@suse.com>