### PR TITLE
Update calico chart to 3.19.2

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
@@ -2,11 +2,10 @@
 +++ charts/Chart.yaml
 @@ -1,5 +1,7 @@
  apiVersion: v2
--appVersion: v3.19.1-e9e1e40ca
-+appVersion: v3.19.1-2
+ appVersion: v3.19.2
  description: Installs the Tigera operator for Calico
 -name: tigera-operator
 +name: rke2-calico
- version: v3.19
+ version: v3.19.2-2
 +annotations:
 +  catalog.cattle.io/namespace: tigera-operator

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1,8 +1,25 @@
+@@ -1,8 +1,24 @@
  imagePullSecrets: {}
  
  installation:
@@ -22,23 +22,22 @@
 +      blockSize: 24
 +  imagePath: "rancher"
 +  imagePrefix: "mirrored-calico-"
-+
  
  certs:
    node:
-@@ -17,9 +34,16 @@
+@@ -17,9 +33,16 @@
  
  # Configuration for the tigera operator
  tigeraOperator:
 -  image: tigera/operator
 +  image: rancher/mirrored-calico-operator
-   version: v1.17.4
+   version: v1.17.6
 -  registry: quay.io
 +  registry: docker.io
  calicoctl:
 -  image: quay.io/docker.io/calico/ctl
 +  image: rancher/mirrored-calico-ctl
-   tag: v3.19.1
+   tag: v3.19.2
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
-url: https://github.com/projectcalico/calico/releases/download/v3.19.1/tigera-operator-v3.19.1-2.tgz
-packageVersion: 08
+url: https://github.com/projectcalico/calico/releases/download/v3.19.2/tigera-operator-v3.19.2-2.tgz
+packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rke2-calico/templates/crd-template/Chart.yaml
+++ b/packages/rke2-calico/templates/crd-template/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: v1.0.0
+version: v1.0.1
 description: Installs the CRDs for rke2-calico
 name: rke2-calico-crd
 type: application


### PR DESCRIPTION
The version 3.19.2 fixes the clusterIP access issue from the host ==> https://github.com/rancher/rke2/issues/1541

We need to wait first to have the mirrored images ready ==> https://github.com/rancher/image-mirror/pull/148

Signed-off-by: Manuel Buil <mbuil@suse.com>