### PR TITLE
Change the name of the CR

### DIFF
--- a/packages/rke2-calico/generated-changes/overlay/templates/ipamconfig.yaml
+++ b/packages/rke2-calico/generated-changes/overlay/templates/ipamconfig.yaml
@@ -1,7 +1,7 @@
 apiVersion: crd.projectcalico.org/v1
 kind: IPAMConfig
 metadata:
-  name: rancher-config
+  name: default
 spec:
   strictAffinity: {{ .Values.ipamConfig.strictAffinity }}
   autoAllocateBlocks: {{ .Values.ipamConfig.autoAllocateBlocks }}

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.19.2/tigera-operator-v3.19.2-2.tgz
-packageVersion: 01
+packageVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
According to Tigera, only if the name is default, it will be consumed by calico

Signed-off-by: Manuel Buil <mbuil@suse.com>