### PR TITLE
Pass featureDetectOverride

### DIFF
--- a/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
+++ b/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: crd.projectcalico.org/v1
+kind: FelixConfiguration
+metadata:
+  name: default
+spec:
+  featureDetectOverride: {{ .Values.felixConfiguration.featureDetectOverride }}

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -25,7 +25,7 @@
  
  certs:
    node:
-@@ -17,9 +33,16 @@
+@@ -17,9 +33,21 @@
  
  # Configuration for the tigera operator
  tigeraOperator:
@@ -42,6 +42,11 @@
 +global:
 +  systemDefaultRegistry: ""
 +
++# Config required by Windows nodes
 +ipamConfig:
 +  strictAffinity: true
 +  autoAllocateBlocks: true
++
++# Config required to fix RKE2 issue #1541
++felixConfiguration:
++  featureDetectOverride: "ChecksumOffloadBroken=true"

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.19.2/tigera-operator-v3.19.2-2.tgz
-packageVersion: 02
+packageVersion: 03
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Creates a felixonfiguration CR with featureDetectOverride. The default is `ChecksumOffloadBroken=true` which disables the `tx-checksum-ip-generic` always to avoid problem https://github.com/rancher/rke2/issues/1541

Signed-off-by: Manuel Buil <mbuil@suse.com>