### PR TITLE
Add support for dual-stack in Calico chart

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/crs/custom-resources.yaml
 +++ charts/templates/crs/custom-resources.yaml
-@@ -6,6 +6,13 @@
+@@ -6,6 +6,27 @@
  {{ $secrets = append $secrets $item }}
  {{ end }}
  {{ $_ := set $installSpec "imagePullSecrets" $secrets }}
@@ -9,8 +9,22 @@
 +{{ $_ := set $installSpec "registry" $finalRegistry }}
 +{{ $defaultipPools := get .Values.installation.calicoNetwork "ipPools" | first }}
 +{{ $defaultCIDR := get $defaultipPools "cidr" }}
-+{{ $finalCIDR := coalesce .Values.global.clusterCIDR $defaultCIDR }}
++{{ $finalCIDR := coalesce .Values.global.clusterCIDRv4 $defaultCIDR }}
 +{{ $_ := set $defaultipPools "cidr" $finalCIDR }}
++{{- /*
++If there is a defined ipv6 CIDR, we must add it as a new IPPool, disable any encapsulation and enable bgp
++*/}}
++{{ if not (empty .Values.global.clusterCIDRv6) }}
++{{ $myIP6Dict := dict "natOutgoing" "Enabled" "cidr" .Values.global.clusterCIDRv6 }}
++{{ $allIpPools := get .Values.installation.calicoNetwork "ipPools" }}
++{{ range $allIpPools }}
++{{ $_ := unset . "encapsulation" }}
++{{ end }}
++{{ $finalIpPoolList := append $allIpPools $myIP6Dict }}
++{{ $calicoNetwork := get .Values.installation "calicoNetwork" }}
++{{ $_ := set $calicoNetwork "ipPools" $finalIpPoolList }}
++{{ $_ := set $calicoNetwork "bgp" "Enabled" }}
++{{ end }}
  
  apiVersion: operator.tigera.io/v1
  kind: Installation

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -25,7 +25,7 @@
  
  certs:
    node:
-@@ -17,9 +33,21 @@
+@@ -17,9 +33,23 @@
  
  # Configuration for the tigera operator
  tigeraOperator:
@@ -41,6 +41,8 @@
 +
 +global:
 +  systemDefaultRegistry: ""
++  clusterCIDRv4: ""
++  clusterCIDRv6: ""
 +
 +# Config required by Windows nodes
 +ipamConfig:

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.19.2/tigera-operator-v3.19.2-2.tgz
-packageVersion: 03
+packageVersion: 04
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Linked issue: https://github.com/rancher/rke2/issues/1717

The logic should do the following if there is at least one ipv6 cidr:
- Enable BGP
- Remove the VXLAN encapsulation from ippools
- Create a new ippool dictionary with the ipv6 cidr

Signed-off-by: Manuel Buil <mbuil@suse.com>