### PR TITLE
cilium: Update to 1.10.4

### DIFF
--- a/packages/cilium/generated-changes/patch/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl.patch
+++ b/packages/cilium/generated-changes/patch/templates/_clustermesh-apiserver-generate-certs-job-spec.tpl.patch
@@ -8,8 +8,8 @@
 -        {{- toYaml . | nindent 8 }}
 -        {{- end }}
      spec:
-       serviceAccount: clustermesh-apiserver-generate-certs
-       serviceAccountName: clustermesh-apiserver-generate-certs
+       serviceAccount: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
+       serviceAccountName: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
        containers:
          - name: certgen
 -          image: {{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}

--- a/packages/cilium/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/cilium/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -122,3 +122,11 @@
+@@ -126,3 +126,11 @@
  tls.crt: {{ $cert.Cert | b64enc }}
  tls.key: {{ $cert.Key | b64enc }}
  {{- end }}

--- a/packages/cilium/generated-changes/patch/templates/_hubble-generate-certs-job-spec.tpl.patch
+++ b/packages/cilium/generated-changes/patch/templates/_hubble-generate-certs-job-spec.tpl.patch
@@ -8,8 +8,8 @@
 -        {{- toYaml . | nindent 8 }}
 -        {{- end }}
      spec:
-       serviceAccount: hubble-generate-certs
-       serviceAccountName: hubble-generate-certs
+       serviceAccount: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
+       serviceAccountName: {{ .Values.serviceAccounts.hubblecertgen.name | quote }}
        containers:
          - name: certgen
 -          image: {{ .Values.certgen.image.repository }}:{{ .Values.certgen.image.tag }}

--- a/packages/cilium/generated-changes/patch/templates/cilium-agent-daemonset.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-agent-daemonset.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/cilium-agent-daemonset.yaml
 +++ charts/templates/cilium-agent-daemonset.yaml
-@@ -56,9 +56,6 @@
+@@ -75,9 +75,6 @@
  {{- if .Values.keepDeprecatedLabels }}
          kubernetes.io/cluster-service: "true"
  {{- end }}
@@ -10,7 +10,7 @@
      spec:
  {{- if .Values.affinity }}
        affinity:
-@@ -196,7 +193,7 @@
+@@ -223,7 +220,7 @@
  {{- with .Values.extraEnv }}
  {{ toYaml . | trim | indent 8 }}
  {{- end }}
@@ -19,7 +19,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
  {{- if .Values.cni.install }}
          lifecycle:
-@@ -314,7 +311,7 @@
+@@ -358,7 +355,7 @@
  {{- range $type := .Values.monitor.eventTypes }}
          - --type={{ $type }}
  {{- end }}
@@ -28,7 +28,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          volumeMounts:
          - mountPath: /var/run/cilium
-@@ -334,8 +331,10 @@
+@@ -406,8 +403,10 @@
  {{- if and .Values.nodeinit.enabled (not (eq .Values.nodeinit.bootstrapFile "")) }}
        - name: wait-for-node-init
          command: ['sh', '-c', 'until stat {{ .Values.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
@@ -40,7 +40,7 @@
          volumeMounts:
          - mountPath: {{ .Values.nodeinit.bootstrapFile }}
            name: cilium-bootstrap-file
-@@ -372,7 +371,7 @@
+@@ -438,7 +437,7 @@
  {{- if .Values.extraEnv }}
  {{ toYaml .Values.extraEnv | indent 8 }}
  {{- end }}

--- a/packages/cilium/generated-changes/patch/templates/cilium-etcd-operator-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-etcd-operator-deployment.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/cilium-etcd-operator-deployment.yaml
 +++ charts/templates/cilium-etcd-operator-deployment.yaml
-@@ -26,9 +26,6 @@
+@@ -46,9 +46,6 @@
        labels:
          io.cilium/app: etcd-operator
          name: cilium-etcd-operator
@@ -10,7 +10,7 @@
      spec:
  {{- if .Values.etcd.affinity }}
        affinity:
-@@ -67,7 +64,7 @@
+@@ -90,7 +87,7 @@
            value: "revision"
          - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
            value: "25000"

--- a/packages/cilium/generated-changes/patch/templates/cilium-nodeinit-daemonset.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-nodeinit-daemonset.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/cilium-nodeinit-daemonset.yaml
 +++ charts/templates/cilium-nodeinit-daemonset.yaml
-@@ -18,9 +18,6 @@
+@@ -38,9 +38,6 @@
  {{- end }}
        labels:
          app: cilium-node-init
@@ -10,7 +10,7 @@
      spec:
  {{- with .Values.tolerations }}
        tolerations:
-@@ -37,7 +34,7 @@
+@@ -57,7 +54,7 @@
  {{- end }}
        containers:
          - name: node-init

--- a/packages/cilium/generated-changes/patch/templates/cilium-operator-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/cilium-operator-deployment.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/cilium-operator-deployment.yaml
 +++ charts/templates/cilium-operator-deployment.yaml
-@@ -41,9 +41,6 @@
+@@ -56,9 +56,6 @@
        labels:
          io.cilium/app: operator
          name: cilium-operator
@@ -8,17 +8,20 @@
 -        {{- toYaml . | nindent 8 }}
 -{{- end }}
      spec:
- {{- if or (ge .Capabilities.KubeVersion.Minor "14") (gt .Capabilities.KubeVersion.Major "1") }}
        # In HA mode, cilium-operator pods must not be scheduled on the same
-@@ -139,11 +136,11 @@
+       # node as they will clash with each other.
+@@ -171,13 +168,13 @@
            value: {{ $value }}
  {{- end }}
- {{- if .Values.eni }}
+ {{- if .Values.eni.enabled }}
 -        image: "{{ .Values.operator.image.repository }}-aws{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.awsDigest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.operator.image.repository }}-aws:{{ .Values.operator.image.tag }}
  {{- else if .Values.azure.enabled }}
 -        image: "{{ .Values.operator.image.repository }}-azure{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.azureDigest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.operator.image.repository }}-azure:{{ .Values.operator.image.tag }}
+ {{- else if .Values.alibabacloud.enabled }}
+-        image: "{{ .Values.operator.image.repository }}-alibabacloud{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.alibabacloudDigest }}{{ end }}"
++        image: {{ template "system_default_registry" . }}{{ .Values.operator.image.repository }}-alibabacloud:{{ .Values.operator.image.tag }}
  {{- else }}
 -        image: "{{ .Values.operator.image.repository }}-generic{{ .Values.operator.image.suffix }}:{{ .Values.operator.image.tag }}{{ if .Values.operator.image.useDigest }}@{{ .Values.operator.image.genericDigest }}{{ end }}"
 +        image: {{ template "system_default_registry" . }}{{ .Values.operator.image.repository }}-generic:{{ .Values.operator.image.tag }}

--- a/packages/cilium/generated-changes/patch/templates/clustermesh-apiserver-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/clustermesh-apiserver-deployment.yaml.patch
@@ -10,8 +10,8 @@
      spec:
  {{- with .Values.imagePullSecrets }}
        imagePullSecrets: {{- toYaml . | nindent 8 }}
-@@ -33,7 +30,7 @@
-       serviceAccount: clustermesh-apiserver
+@@ -34,7 +31,7 @@
+       serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
        initContainers:
        - name: etcd-init
 -        image: {{ .Values.clustermesh.apiserver.etcd.image.repository }}:{{ .Values.clustermesh.apiserver.etcd.image.tag }}
@@ -19,7 +19,7 @@
          imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
          env:
          - name: ETCDCTL_API
-@@ -70,7 +67,7 @@
+@@ -71,7 +68,7 @@
            name: etcd-data-dir
        containers:
        - name: etcd
@@ -28,7 +28,7 @@
          imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
          env:
          - name: ETCDCTL_API
-@@ -99,7 +96,7 @@
+@@ -100,7 +97,7 @@
          - mountPath: /var/run/etcd
            name: etcd-data-dir
        - name: "apiserver"

--- a/packages/cilium/generated-changes/patch/templates/hubble-ui-deployment.yaml.patch
+++ b/packages/cilium/generated-changes/patch/templates/hubble-ui-deployment.yaml.patch
@@ -10,7 +10,7 @@
      spec:
        {{- if .Values.hubble.ui.securityContext.enabled }}
        securityContext:
-@@ -43,7 +40,7 @@
+@@ -47,7 +44,7 @@
  {{- end }}
        containers:
          - name: frontend
@@ -19,7 +19,7 @@
            imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
            ports:
              - containerPort: 8080
-@@ -51,7 +48,7 @@
+@@ -55,7 +52,7 @@
            resources:
              {{- toYaml .Values.hubble.ui.frontend.resources | trim | nindent 12 }}
          - name: backend
@@ -28,7 +28,7 @@
            imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
            env:
              - name: EVENTS_SERVER_PORT
-@@ -64,7 +61,7 @@
+@@ -68,7 +65,7 @@
            resources:
              {{- toYaml .Values.hubble.ui.backend.resources  | trim | nindent 12 }}
          - name: proxy

--- a/packages/cilium/generated-changes/patch/values.yaml.patch
+++ b/packages/cilium/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -564,7 +564,8 @@
+@@ -658,7 +658,8 @@
  
      # -- Node labels for pod assignment
      # ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -10,7 +10,7 @@
  
      # -- Annotations to be added to hubble-relay pods
      podAnnotations: {}
-@@ -690,7 +691,8 @@
+@@ -789,7 +790,8 @@
  
      # -- Node labels for pod assignment
      # ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -20,17 +20,17 @@
  
      # -- Node tolerations for pod assignment on nodes with taints
      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-@@ -1006,7 +1008,8 @@
+@@ -1145,7 +1147,8 @@
+ 
    # -- Node labels for cilium-etcd-operator pod assignment
    # ref: https://kubernetes.io/docs/user-guide/node-selection/
-   #
 -  nodeSelector: {}
 +  nodeSelector:
 +    kubernetes.io/os: linux
  
    # -- Annotations to be added to cilium-etcd-operator pods
    podAnnotations: {}
-@@ -1151,7 +1154,8 @@
+@@ -1288,7 +1291,8 @@
    # -- Node labels for cilium-operator pod assignment
    # ref: https://kubernetes.io/docs/user-guide/node-selection/
    #
@@ -40,7 +40,7 @@
  
    # -- Annotations to be added to cilium-operator pods
    podAnnotations: {}
-@@ -1246,7 +1250,8 @@
+@@ -1394,7 +1398,8 @@
    # -- Node labels for nodeinit pod assignment
    # ref: https://kubernetes.io/docs/user-guide/node-selection/
    #
@@ -48,18 +48,9 @@
 +  nodeSelector:
 +    kubernetes.io/os: linux
  
-   # -- Annotations to be added to node-init pods
+   # -- Annotations to be added to node-init pods.
    podAnnotations: {}
-@@ -1325,6 +1330,8 @@
-   - effect: NoSchedule
-     key: node-role.kubernetes.io/master
-   - effect: NoSchedule
-+    key: node-role.kubernetes.io/control-plane
-+  - effect: NoSchedule
-     key: node.cloudprovider.kubernetes.io/uninitialized
-     value: "true"
-   - key: CriticalAddonsOnly
-@@ -1337,7 +1344,8 @@
+@@ -1488,7 +1493,8 @@
    # -- Node labels for preflight pod assignment
    # ref: https://kubernetes.io/docs/user-guide/node-selection/
    #
@@ -69,7 +60,7 @@
  
    # -- Annotations to be added to preflight pods
    podAnnotations: {}
-@@ -1424,7 +1432,8 @@
+@@ -1576,7 +1582,8 @@
  
      # -- Node labels for pod assignment
      # ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/packages/cilium/package.yaml
+++ b/packages/cilium/package.yaml
@@ -1,5 +1,5 @@
-url: https://helm.cilium.io/cilium-1.9.8.tgz
-packageVersion: 08
+url: https://helm.cilium.io/cilium-1.10.4.tgz
+packageVersion: 01
 releaseCandidateVersion: 00
 # This package is meant to be consumed as a subchart of another package,
 # not directly.

--- a/packages/rke2-cilium/charts/Chart.yaml
+++ b/packages/rke2-cilium/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rke2-cilium
 description: eBPF-based Networking, Security, and Observability
-version: 1.9.8
+version: 1.10.4
 kubeVersion: '>= 1.12.0-0'
 home: https://cilium.io/
 keywords:

--- a/packages/rke2-cilium/charts/values.yaml
+++ b/packages/rke2-cilium/charts/values.yaml
@@ -6,11 +6,11 @@ cilium:
   imagePullSecrets: []
   image:
     repository: rancher/mirrored-cilium-cilium
-    tag: v1.9.8
+    tag: v1.10.4
   operator:
     image:
       repository: rancher/mirrored-cilium-operator
-      tag: v1.9.8
+      tag: v1.10.4
   nodeinit:
     image:
       repository: rancher/mirrored-cilium-startup-script
@@ -20,7 +20,7 @@ cilium:
     enabled: false
     image:
       repository: rancher/mirrored-cilium-cilium
-      tag: v1.9.8
+      tag: v1.10.4
 
   #
   # Enable Azure integration.
@@ -50,7 +50,7 @@ cilium:
   #egressMasqueradeInterfaces: eth0
 
   ipv6:
-  # -- Enable dual stack 
+  # -- Enable dual stack
     enabled: false
 
 global:

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 09
+packageVersion: 01
 releaseCandidateVersion: 00


### PR DESCRIPTION
Update Cilium from 1.9.8 to 1.10.4. Changelog:

https://github.com/cilium/cilium/releases/tag/v1.10.4

Ref: rancher/rke2#1615

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>