### PR TITLE
cilium: Fix the eni value

### DIFF
--- a/packages/rke2-cilium/charts/values.schema.json
+++ b/packages/rke2-cilium/charts/values.schema.json
@@ -25,7 +25,12 @@
                     }
                 },
                 "eni": {
-                    "type": "boolean"
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
                 },
                 "image": {
                     "type": "object",

--- a/packages/rke2-cilium/charts/values.yaml
+++ b/packages/rke2-cilium/charts/values.yaml
@@ -40,7 +40,9 @@ cilium:
   #
   # Enable Elastic Network Interface (ENI) for AWS integration.
   #
-  eni: false
+  eni:
+    enabled: false
+
   ipam:
     # Set mode to "eni" for ENI AWS intetgration.
     mode: "kubernetes"

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 01
+packageVersion: 02
 releaseCandidateVersion: 00


### PR DESCRIPTION
The upstream Cilium chart changed the type of `eni` value to a nested
object. Adjust our rke2-cilium chart to that change.

Ref: rancher/rke2#1615

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>