### PR TITLE
Update rke2-kube-proxy to new images for v1.19, v1.20, v1.21

### DIFF
--- a/packages/rke2-kube-proxy-1.19/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy-1.19/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.19.14-rke2r1-build20210820
-appVersion: v1.19.14-rke2r1
+version: v1.19.15-rke2r1-build20210916
+appVersion: v1.19.15-rke2r1
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy-1.19/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.19/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kubernetes
-  tag: v1.19.14-rke2r1-build20210820
+  tag: v1.19.15-rke2r1-build20210916
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)

--- a/packages/rke2-kube-proxy-1.20/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy-1.20/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.20.10-rke2r1-build20210820
-appVersion: v1.20.10-rke2r1
+version: v1.20.11-rke2r1-build20210916
+appVersion: v1.20.11-rke2r1
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy-1.20/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.20/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kubernetes
-  tag: v1.20.10-rke2r1-build20210820
+  tag: v1.20.11-rke2r1-build20210916
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)

--- a/packages/rke2-kube-proxy-1.21/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy-1.21/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.21.4-rke2r4-build20210909
-appVersion: v1.21.4-rke2r4
+version: v1.21.5-rke2r1-build20210916
+appVersion: v1.21.5-rke2r1
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy-1.21/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.21/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kubernetes
-  tag: v1.21.4-rke2r4-build20210909
+  tag: v1.21.5-rke2r1-build20210916
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)


### PR DESCRIPTION
Rke2 updated for v1.19.15, v1.20.11, v1.21.5
Signed-off-by: dereknola <derek.nola@suse.com>