### PR TITLE
Explicitly disable encapsulation in dual-stack env for Calico

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
@@ -18,7 +18,7 @@
 +{{ $myIP6Dict := dict "natOutgoing" "Enabled" "cidr" .Values.global.clusterCIDRv6 }}
 +{{ $allIpPools := get .Values.installation.calicoNetwork "ipPools" }}
 +{{ range $allIpPools }}
-+{{ $_ := unset . "encapsulation" }}
++{{ $_ := set . "encapsulation" "None" }}
 +{{ end }}
 +{{ $finalIpPoolList := append $allIpPools $myIP6Dict }}
 +{{ $calicoNetwork := get .Values.installation "calicoNetwork" }}

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.19.2/tigera-operator-v3.19.2-2.tgz
-packageVersion: 04
+packageVersion: 05
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
When not specified, the encapsulation of ipv4 traffic becomes IPIP.

That encapsulation is the least recommended one by Calico ==> https://docs.projectcalico.org/networking/determine-best-networking

Linked issue: https://github.com/rancher/rke2/issues/1876

Signed-off-by: Manuel Buil <mbuil@suse.com>