### PR TITLE
Fix canal network configuration when ipv6 not enabled

### DIFF
--- a/packages/rke2-canal/charts/templates/_helpers.tpl
+++ b/packages/rke2-canal/charts/templates/_helpers.tpl
@@ -5,9 +5,3 @@
 {{- "" -}}
 {{- end -}}
 {{- end -}}
-
-{{- define "enableIPv6?" -}}
-{{- $cidrv6 := coalesce .Values.global.clusterCIDRv6 .Values.podCidrv6 -}}
-{{- ternary "false" "true" (empty .Values.global.clusterCIDRv6) -}}
-{{- end -}}
-

--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -61,8 +61,10 @@ data:
   net-conf.json: |
     {
       "Network": {{ coalesce .Values.global.clusterCIDRv4 .Values.podCidr | quote }},
+{{- if coalesce .Values.global.clusterCIDRv6 .Values.podCidrv6 }}
       "IPv6Network": {{ coalesce .Values.global.clusterCIDRv6 .Values.podCidrv6 | quote }},
-      "EnableIPv6": {{ template "enableIPv6?" . }},
+      "EnableIPv6": true,
+{{- end }}
       "Backend": {
         "Type": {{ .Values.flannel.backend | quote }}
       }

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 09
+packageVersion: 10
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
The IPv6 options shouldn't be specified if IPv6 isn't enabled, as the CIDR will be empty and cause an error:
`E0930 21:37:00.268466       1 main.go:251] Failed to create SubnetManager: error parsing subnet config: invalid character ',' looking for beginning of value`