### PR TITLE
Upgrade nginx controller to v1.0.2

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
@@ -1,7 +1,7 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -12,7 +12,7 @@
- kubeVersion: '>=1.16.0-0'
+@@ -15,7 +15,7 @@
+ kubeVersion: '>=1.19.0-0'
  maintainers:
  - name: ChiefAlexander
 -name: ingress-nginx

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
@@ -25,3 +25,4 @@
 +{{- define "repository_or_registry_and_image" -}}
 +{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}
 +{{- end -}}
+\ No newline at end of file

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
@@ -25,4 +25,3 @@
 +{{- define "repository_or_registry_and_image" -}}
 +{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}
 +{{- end -}}
-\ No newline at end of file

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/controller-daemonset.yaml
 +++ charts/templates/controller-daemonset.yaml
-@@ -64,9 +64,7 @@
+@@ -67,9 +67,7 @@
      {{- end }}
        containers:
          - name: {{ .Values.controller.containerName }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
@@ -1,6 +1,15 @@
 --- charts-original/templates/controller-deployment.yaml
 +++ charts/templates/controller-deployment.yaml
-@@ -68,9 +68,7 @@
+@@ -23,7 +23,7 @@
+   replicas: {{ .Values.controller.replicaCount }}
+   {{- end }}
+   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+-  {{- if .Values.controller.updateStrategy }}
++  {{- if .Values.controller.updateStrfategy }}
+   strategy:
+     {{ toYaml .Values.controller.updateStrategy | nindent 4 }}
+   {{- end }}
+@@ -71,9 +71,7 @@
      {{- end }}
        containers:
          - name: {{ .Values.controller.containerName }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -115,4 +115,3 @@
 +
 +global:
 +  systemDefaultRegistry: ""
-\ No newline at end of file

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -10,9 +10,9 @@
      # for backwards compatibility consider setting the full image url via the repository value below
      # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
      # repository:
--    tag: "v0.47.0"
--    digest: sha256:a1e4efc107be0bb78f32eaec37bef17d7a0c81bec8066cdf2572508d21351d0b
-+    tag: "nginx-0.47.0-hardened1"
+-    tag: "v1.0.2"
+-    digest: sha256:85b53b493d6d658d8c013449223b0ffd739c76d76dc9bf9000786669ec04e049
++    tag: "nginx-1.0.2-hardened1"
      pullPolicy: IfNotPresent
      # www-data -> uid 101
      runAsUser: 101
@@ -25,7 +25,7 @@
  
    # Configures the ports the nginx-controller listens on
    containerPort:
-@@ -52,7 +50,7 @@
+@@ -55,7 +53,7 @@
    # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
    # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
    # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
@@ -34,7 +34,7 @@
  
    # Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
    # Ingress status was blank because there is no Service exposing the NGINX Ingress controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
-@@ -61,13 +59,13 @@
+@@ -78,13 +76,13 @@
    # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
    # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
    # is merged
@@ -50,7 +50,7 @@
      ports:
        http: 80
        https: 443
-@@ -111,7 +109,7 @@
+@@ -126,7 +124,7 @@
    ## by the service. If disable, the status field reports the IP address of the
    ## node or nodes where an ingress controller pod is running.
    publishService:
@@ -59,7 +59,7 @@
      ## Allows overriding of the publish service to bind to
      ## Must be <namespace>/<service_name>
      ##
-@@ -162,7 +160,7 @@
+@@ -177,7 +175,7 @@
  
    ## DaemonSet or Deployment
    ##
@@ -68,7 +68,7 @@
  
    ## Annotations to be added to the controller Deployment or DaemonSet
    ##
-@@ -394,7 +392,7 @@
+@@ -427,7 +425,7 @@
      configMapKey: ""
  
    service:
@@ -77,27 +77,23 @@
  
      annotations: {}
      labels: {}
-@@ -529,8 +527,7 @@
+@@ -574,13 +572,12 @@
      patch:
        enabled: true
        image:
--        registry: docker.io
--        image: jettech/kube-webhook-certgen
-+        repository: rancher/mirrored-jettech-kube-webhook-certgen
+-        registry: k8s.gcr.io
+-        image: ingress-nginx/kube-webhook-certgen
++        repository: rancher/mirrored-ingress-nginx-kube-webhook-certgen
          # for backwards compatibility consider setting the full image url via the repository value below
          # use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
          # repository:
-@@ -540,7 +537,8 @@
+         tag: v1.0
+-        digest: sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
++        digest: sha256:6b91d0434942504defa54cd50b15cddda0df58b4cc99cf5ec365762f295306ea
+         pullPolicy: IfNotPresent
+       ## Provide a priority class name to the webhook patching job
        ##
-       priorityClassName: ""
-       podAnnotations: {}
--      nodeSelector: {}
-+      nodeSelector:
-+        kubernetes.io/os: linux
-       tolerations: []
-       runAsUser: 2000
- 
-@@ -650,12 +648,11 @@
+@@ -697,12 +694,11 @@
  
    name: defaultbackend
    image:
@@ -112,20 +108,11 @@
      pullPolicy: IfNotPresent
      # nobody user -> uid 65534
      runAsUser: 65534
-@@ -717,7 +714,8 @@
-   ## Node labels for default backend pod assignment
-   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-   ##
--  nodeSelector: {}
-+  nodeSelector:
-+    kubernetes.io/os: linux
- 
-   ## Annotations to be added to default backend pods
-   ##
-@@ -806,3 +804,6 @@
+@@ -854,3 +850,6 @@
  # This can be generated with: openssl dhparam 4096 2> /dev/null | base64
- # Ref: https://github.com/krmichel/ingress-nginx/blob/master/docs/examples/customization/ssl-dh-param
+ # Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
  dhParam:
 +
 +global:
 +  systemDefaultRegistry: ""
+\ No newline at end of file

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-3.34.0/ingress-nginx-3.34.0.tgz
-packageVersion: 03
+url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.0.3/ingress-nginx-4.0.3.tgz
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Since the helm chart for v1.0.2 was also updated upstream, I had to delete the patches and prepare as if its a new chart, then added our patches to the chart