### PR TITLE
rke2-cilium: Disable image digest usage

### DIFF
--- a/packages/rke2-cilium/charts/values.yaml
+++ b/packages/rke2-cilium/charts/values.yaml
@@ -7,6 +7,7 @@ cilium:
   image:
     repository: rancher/mirrored-cilium-cilium
     tag: v1.10.4
+    useDigest: false
   operator:
     image:
       repository: rancher/mirrored-cilium-operator

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 02
+packageVersion: 03
 releaseCandidateVersion: 00


### PR DESCRIPTION
Upstream Cilium helm chart looks for the specific image digest for a
given release. Since we use different mirrored images, we need to
disable that check on our side.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>