### PR TITLE
Bump canal chart version

### DIFF
--- a/packages/rke2-canal/charts/Chart.yaml
+++ b/packages/rke2-canal/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-canal
 description: Install Canal Network Plugin.
-version: v3.19.1-build20210611
-appVersion: v3.19.1
+version: v3.20.1-build20211006
+appVersion: v3.20.1
 home: https://www.projectcalico.org/
 keywords:
   - canal

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 11
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
This is a local chart, so we should bump the chart and app version when bumping image versions.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>