### PR TITLE
Don't specify digest for certgen image

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -77,7 +77,7 @@
  
      annotations: {}
      labels: {}
-@@ -574,13 +572,12 @@
+@@ -574,13 +572,11 @@
      patch:
        enabled: true
        image:
@@ -89,11 +89,10 @@
          # repository:
          tag: v1.0
 -        digest: sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068
-+        digest: sha256:6b91d0434942504defa54cd50b15cddda0df58b4cc99cf5ec365762f295306ea
          pullPolicy: IfNotPresent
        ## Provide a priority class name to the webhook patching job
        ##
-@@ -697,12 +694,11 @@
+@@ -697,12 +693,11 @@
  
    name: defaultbackend
    image:
@@ -108,7 +107,7 @@
      pullPolicy: IfNotPresent
      # nobody user -> uid 65534
      runAsUser: 65534
-@@ -854,3 +850,6 @@
+@@ -854,3 +849,6 @@
  # This can be generated with: openssl dhparam 4096 2> /dev/null | base64
  # Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
  dhParam:

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.0.3/ingress-nginx-4.0.3.tgz
-packageVersion: 02
+packageVersion: 03
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
The current digest is for arm anyway.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>