### PR TITLE
Allow enabling Calico WireGuard encryption

### DIFF
--- a/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
+++ b/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
@@ -3,4 +3,5 @@ kind: FelixConfiguration
 metadata:
   name: default
 spec:
+  wireguardEnabled: {{ .Values.felixConfiguration.wireguardEnabled }}
   featureDetectOverride: {{ .Values.felixConfiguration.featureDetectOverride }}

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -25,7 +25,7 @@
  
  apiServer:
    enabled: true
-@@ -20,9 +36,23 @@
+@@ -20,9 +36,24 @@
  
  # Configuration for the tigera operator
  tigeraOperator:
@@ -49,6 +49,7 @@
 +  strictAffinity: true
 +  autoAllocateBlocks: true
 +
-+# Config required to fix RKE2 issue #1541
 +felixConfiguration:
++  wireguardEnabled: false
++  # Config required to fix RKE2 issue #1541
 +  featureDetectOverride: "ChecksumOffloadBroken=true"

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.20.1/tigera-operator-v3.20.1.tgz
-packageVersion: 01
+packageVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Provide Helm values and templates to allow easy Helm-based configuration of Calico WireGuard encryption.

Linked issue https://github.com/rancher/rke2/issues/1608.