### PR TITLE
Fix bug in the canal chart name

### DIFF
--- a/packages/rke2-canal-1.19-1.20/charts/Chart.yaml
+++ b/packages/rke2-canal-1.19-1.20/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: rke2-canal
+name: rke2-canal-1.19-1.20
 description: Install Canal Network Plugin.
 version: v3.13.3-build20211022
 appVersion: v3.13.3

--- a/packages/rke2-canal-1.19-1.20/package.yaml
+++ b/packages/rke2-canal-1.19-1.20/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Without this patch, it is impossible to find the chart:

```
#25 0.637 + : https://rke2-charts.rancher.io/assets/rke2-canal-1.19-1.20/rke2-canal-1.19-1.20-v3.13.3-build2021102201.tgz
#25 0.637 ++ mktemp
#25 0.638 + curl -fsSL https://rke2-charts.rancher.io/assets/rke2-canal-1.19-1.20/rke2-canal-1.19-1.20-v3.13.3-build2021102201.tgz -o /tmp/tmp.70nhumpXcP
#25 0.780 curl: (22) The requested URL returned error: 404
```
And we have https://rke2-charts.rancher.io/assets/rke2-canal-1.19-1.20/rke2-canal-v3.13.3-build2021102201.tgz

Signed-off-by: Manuel Buil <mbuil@suse.com>