### PR TITLE
Fix bug in canal init container

### DIFF
--- a/packages/rke2-canal-1.19-1.20/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal-1.19-1.20/charts/templates/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         # and CNI network config file on each node.
         - name: install-cni
           image: {{ template "system_default_registry" . }}{{ .Values.calico.cniImage.repository }}:{{ .Values.calico.cniImage.tag }}
-          command: ["/opt/cni/bin/install"]
+          command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME

--- a/packages/rke2-canal-1.19-1.20/package.yaml
+++ b/packages/rke2-canal-1.19-1.20/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
We were using a script that does not exist in canal-1.19-1.20

Signed-off-by: Manuel Buil <mbuil@suse.com>