### PR TITLE
Go back to name: rke2-canal in rke2-canal-1.19-1.20

### DIFF
--- a/packages/rke2-canal-1.19-1.20/charts/Chart.yaml
+++ b/packages/rke2-canal-1.19-1.20/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: rke2-canal-1.19-1.20
+name: rke2-canal
 description: Install Canal Network Plugin.
 version: v3.13.3-build20211022
 appVersion: v3.13.3

--- a/packages/rke2-canal-1.19-1.20/package.yaml
+++ b/packages/rke2-canal-1.19-1.20/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 03
+packageVersion: 04


### PR DESCRIPTION
As explained in the comment of https://github.com/rancher/rke2/pull/2009, we should keep the same name

Signed-off-by: Manuel Buil <mbuil@suse.com>