### PR TITLE
bump coredns and fix validation

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
@@ -18,5 +18,5 @@
  sources:
  - https://github.com/coredns/coredns
  type: application
--version: 1.16.3
-+version: 1.16.301-build20211006
+-version: 1.16.4
++version: 1.16.401-build20211118

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -7,7 +7,7 @@
 -  repository: coredns/coredns
 -  tag: "1.8.4"
 +  repository: rancher/hardened-coredns
-+  tag: "v1.8.5-build20211006"
++  tag: "v1.8.5-build20211027"
    pullPolicy: IfNotPresent
    ## Optionally specify an array of imagePullSecrets.
    ## Secrets must be manually created in the namespace.
@@ -98,7 +98,7 @@
 -    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
 -    tag: "1.8.1"
 +    repository: rancher/hardened-cluster-autoscaler
-+    tag: "v1.8.5-build20211006"
++    tag: "v1.8.5-build20211027"
      pullPolicy: IfNotPresent
      ## Optionally specify an array of imagePullSecrets.
      ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Validation was failing because of the wrong version in Chart.yaml.patch