### PR TITLE
Bump image tags for golang bumps

### DIFF
--- a/packages/rke2-canal/charts/Chart.yaml
+++ b/packages/rke2-canal/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-canal
 description: Install Canal Network Plugin.
-version: v3.20.1-build20211006
-appVersion: v3.20.1
+version: v3.20.1-build20211119
+appVersion: v3.20.2
 home: https://www.projectcalico.org/
 keywords:
   - canal

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -8,7 +8,7 @@ flannel:
   # kube-flannel image
   image:
     repository: rancher/hardened-flannel
-    tag: v0.15.1-build20211021
+    tag: v0.15.1-build20211119
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.
@@ -25,15 +25,15 @@ calico:
   # CNI installation image.
   cniImage:
     repository: rancher/hardened-calico
-    tag: v3.20.1-build20211006
+    tag: v3.20.2-build20211119
   # Canal node image.
   nodeImage:
     repository: rancher/hardened-calico
-    tag: v3.20.1-build20211006
+    tag: v3.20.2-build20211119
   # Flexvol Image.
   flexvolImage:
     repository: rancher/hardened-calico
-    tag: v3.20.1-build20211006
+    tag: v3.20.2-build20211119
   # Datastore type for canal. It can be either kuberentes or etcd.
   datastoreType: kubernetes
   # Wait for datastore to initialize.

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,4 +1,4 @@
 url: local
-packageVersion: 03
+packageVersion: 04
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00

--- a/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
@@ -19,4 +19,4 @@
  - https://github.com/coredns/coredns
  type: application
 -version: 1.16.4
-+version: 1.16.401-build20211118
++version: 1.16.401-build20211119

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -7,7 +7,7 @@
 -  repository: coredns/coredns
 -  tag: "1.8.4"
 +  repository: rancher/hardened-coredns
-+  tag: "v1.8.5-build20211027"
++  tag: "v1.8.5-build20211119"
    pullPolicy: IfNotPresent
    ## Optionally specify an array of imagePullSecrets.
    ## Secrets must be manually created in the namespace.
@@ -98,7 +98,7 @@
 -    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
 -    tag: "1.8.1"
 +    repository: rancher/hardened-cluster-autoscaler
-+    tag: "v1.8.5-build20211027"
++    tag: "v1.8.5-build20211119"
      pullPolicy: IfNotPresent
      ## Optionally specify an array of imagePullSecrets.
      ## Secrets must be manually created in the namespace.
@@ -156,10 +156,10 @@
 +  ipvs: false
 +  image:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.21.1-build20211006"
++    tag: "1.21.2-build20211119"
 +  initimage:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.21.1-build20211006"
++    tag: "1.21.2-build20211119"
 +  nodeSelector:
 +    kubernetes.io/os: linux
 +

--- a/packages/rke2-metrics-server/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/Chart.yaml.patch
@@ -16,4 +16,4 @@
  sources:
  - https://github.com/kubernetes-incubator/metrics-server
 -version: 2.11.1
-+version: 2.11.100-build20210915
++version: 2.11.100-build20211119

--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -7,7 +7,7 @@
 -  repository: k8s.gcr.io/metrics-server-amd64
 -  tag: v0.3.6
 +  repository: rancher/hardened-k8s-metrics-server
-+  tag: v0.5.0-build20210915
++  tag: v0.5.0-build20211119
    pullPolicy: IfNotPresent
  
  imagePullSecrets: []

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,3 +1,3 @@
 url: https://charts.helm.sh/stable/packages/metrics-server-2.11.1.tgz
-packageVersion: 03
+packageVersion: 04
 releaseCandidateVersion: 00

--- a/packages/rke2-multus/charts/Chart.yaml
+++ b/packages/rke2-multus/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rke2-multus
 description: Multus CNI enables attaching multiple network interfaces to pods in Kubernetes.
-version: v3.7.1-build20211007
+version: v3.7.1-build20211119
 appVersion: v3.7.1
 home: https://github.com/k8snetworkplumbingwg/multus-cni
 icon: https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/doc/images/Multus.png

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -1,12 +1,12 @@
 multus:
   image:
     repository: rancher/hardened-multus-cni
-    tag: v3.7.1-build20211007
+    tag: v3.7.1-build20211119
 
 cniplugins:
   image:
     repository: rancher/hardened-cni-plugins
-    tag: v0.9.1-build20211006
+    tag: v0.9.1-build20211119
 
   # skipcnis is a comma separated list of cni binaries to skip from
   # installing.

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 05
+packageVersion: 06
 releaseCandidateVersion: 00


### PR DESCRIPTION
Bumps image tags for rke2-canal, rke2-coredns, rke2-metrics-server, and rke2-multus to pull in recent golang version bump rebuilds.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>