### PR TITLE
Update patches for new upstream chart version

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
@@ -9,7 +9,7 @@
      kubernetes.io/cluster-service: "true"
      kubernetes.io/name: "CoreDNS"
      {{- end }}
-@@ -24,7 +24,7 @@
+@@ -27,7 +27,7 @@
      {{- if .port }}:{{ .port }} {{ end -}}
      {
        {{- range .plugins }}

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -33,7 +33,7 @@
  
  # Default zone is what Kubernetes recommends:
  # https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options
-@@ -162,21 +162,21 @@
+@@ -169,21 +169,21 @@
    successThreshold: 1
  
  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
@@ -67,7 +67,7 @@
  
  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
  # for example:
-@@ -185,7 +185,13 @@
+@@ -192,7 +192,13 @@
  #     operator: Equal
  #     value: master
  #     effect: NoSchedule
@@ -82,7 +82,7 @@
  
  # https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
  podDisruptionBudget: {}
-@@ -233,7 +239,7 @@
+@@ -240,7 +246,7 @@
  # See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
  autoscaler:
    # Enabled the cluster-proportional-autoscaler
@@ -91,7 +91,7 @@
  
    # Number of cores in the cluster per coredns replica
    coresPerReplica: 256
-@@ -249,8 +255,8 @@
+@@ -256,8 +262,8 @@
    preventSinglePointFailure: true
  
    image:
@@ -102,7 +102,7 @@
      pullPolicy: IfNotPresent
      ## Optionally specify an array of imagePullSecrets.
      ## Secrets must be manually created in the namespace.
-@@ -267,19 +273,26 @@
+@@ -274,19 +280,26 @@
  
    # Node labels for pod assignment
    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -133,7 +133,7 @@
  
    # Options for autoscaler configmap
    configmap:
-@@ -291,11 +304,28 @@
+@@ -298,11 +311,28 @@
    livenessProbe:
      enabled: true
      initialDelaySeconds: 10

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.16.4/coredns-1.16.4.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Fixes regression from https://github.com/rancher/rke2-charts/pull/185. The fuzzing on application of the current patches is creating `.orig` files that mess up chart application.  This should be handled by charts-build-scripts but we're on an old version that doesn't.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>