### PR TITLE
Added autogenerated PSK field and change type to Secret

### DIFF
--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: kube-system
 stringData:
 {{- $config := (lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-config)") | default dict }}
-{{- $psk := (get $config "psk") | default (randAlphaNum 32 | b64enc) }}
+{{- $psk := (get $config "psk") | default (randAlphaNum 96 | b64enc) }}
 {{- if eq .Values.flannel.backend "ipsec" }}
   psk: {{ $psk  | quote }}
 {{- end }}

--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Release.Name }}-config
   namespace: kube-system
 stringData:
-{{- $config := (lookup "v1" "ConfigMap" .Release.Namespace "{{ .Release.Name }}-config)") | default dict }}
+{{- $config := (lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-config)") | default dict }}
 {{- $psk := (get $config "psk") | default (randAlphaNum 32 | b64enc) }}
 {{- if eq .Values.flannel.backend "ipsec" }}
   psk: {{ $psk  | quote }}

--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -7,7 +7,8 @@ metadata:
   name: {{ .Release.Name }}-config
   namespace: kube-system
 stringData:
-{{- $config := (lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-config)") | default dict }}
+{{- $secretName := print .Release.Name "-config"}}
+{{- $config := (lookup "v1" "Secret" .Release.Namespace $secretName) | default dict }}
 {{- $psk := (get $config "psk") | default (randAlphaNum 96) }}
 {{- if eq .Values.flannel.backend "ipsec" }}
   psk: {{ $psk  | quote }}

--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -1,14 +1,19 @@
 ---
 # Source: calico/templates/calico-config.yaml
 # This ConfigMap is used to configure a self-hosted Canal installation.
-kind: ConfigMap
+kind: Secret
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-config
   namespace: kube-system
-data:
+stringData:
+{{- $config := (lookup "v1" "ConfigMap" .Release.Namespace "{{ .Release.Name }}-config)") | default dict }}
+{{- $psk := (get $config "psk") | default (randAlphaNum 32 | b64enc) }}
+{{- if eq .Values.flannel.backend "ipsec" }}
+  psk: {{ $psk  | quote }}
+{{- end }}
   # Typha is disabled.
-  typha_service_name: {{ .Values.calico.typhaServiceName | quote }}
+  typha_service_name: {{ .Values.calico.typhaServiceName | b64enc | quote }}
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.
@@ -67,5 +72,8 @@ data:
 {{- end }}
       "Backend": {
         "Type": {{ .Values.flannel.backend | quote }}
+{{- if eq .Values.flannel.backend "ipsec" }}
+        "PSK": {{ $psk | quote }}
+{{- end }}
       }
     }

--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -8,12 +8,12 @@ metadata:
   namespace: kube-system
 stringData:
 {{- $config := (lookup "v1" "Secret" .Release.Namespace "{{ .Release.Name }}-config)") | default dict }}
-{{- $psk := (get $config "psk") | default (randAlphaNum 96 | b64enc) }}
+{{- $psk := (get $config "psk") | default (randAlphaNum 96) }}
 {{- if eq .Values.flannel.backend "ipsec" }}
   psk: {{ $psk  | quote }}
 {{- end }}
   # Typha is disabled.
-  typha_service_name: {{ .Values.calico.typhaServiceName | b64enc | quote }}
+  typha_service_name: {{ .Values.calico.typhaServiceName | quote }}
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.

--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   name: {{ .Release.Name }}-config
                   key: cni_network_config
             # Set the hostname based on the k8s node name.
@@ -64,7 +64,7 @@ spec:
             # CNI MTU Config variable
             - name: CNI_MTU
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   name: {{ .Release.Name }}-config
                   key: veth_mtu
             # Prevents the container from sleeping forever.
@@ -208,12 +208,12 @@ spec:
                   fieldPath: metadata.namespace
             - name: FLANNELD_IFACE
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   name: {{ .Release.Name }}-config
                   key: canal_iface
             - name: FLANNELD_IP_MASQ
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   name: {{ .Release.Name }}-config
                   key: masquerade
           volumeMounts:
@@ -239,8 +239,8 @@ spec:
             type: FileOrCreate
         # Used by flannel.
         - name: flannel-cfg
-          configMap:
-            name: {{ .Release.Name }}-config
+          secret:
+            secretName: {{ .Release.Name }}-config
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:


### PR DESCRIPTION
As specified in the [flannel docs](https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#ipsec) the ipsec variant needs to have a pre-shared key.

Also related to https://github.com/rancher/image-build-flannel/issues/7