### PR TITLE
Upgrade calico to 3.21.2

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
@@ -2,10 +2,10 @@
 +++ charts/Chart.yaml
 @@ -1,5 +1,7 @@
  apiVersion: v2
- appVersion: v3.20.2
+ appVersion: v3.21.2
  description: Installs the Tigera operator for Calico
 -name: tigera-operator
 +name: rke2-calico
- version: v3.20.2
+ version: v3.21.2
 +annotations:
 +  catalog.cattle.io/namespace: tigera-operator

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -31,13 +31,13 @@
  tigeraOperator:
 -  image: tigera/operator
 +  image: rancher/mirrored-calico-operator
-   version: v1.20.4
+   version: v1.21.2
 -  registry: quay.io
 +  registry: docker.io
  calicoctl:
 -  image: quay.io/docker.io/calico/ctl
 +  image: rancher/mirrored-calico-ctl
-   tag: v3.20.2
+   tag: v3.21.2
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -31,7 +31,7 @@
  tigeraOperator:
 -  image: tigera/operator
 +  image: rancher/mirrored-calico-operator
-   version: v1.21.2
+   version: v1.23.3
 -  registry: quay.io
 +  registry: docker.io
  calicoctl:

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/projectcalico/calico/releases/download/v3.20.2/tigera-operator-v3.20.2-1.tgz
+url: https://github.com/projectcalico/calico/releases/download/v3.21.2/tigera-operator-v3.21.2-1.tgz
 packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd


### PR DESCRIPTION
Calico fixed some ingress issues with 3.21.x (so traffic coming into the calico network) when running eBPF.

We face a huge (80x) performance regression when eBPF is active when the traffic is "external to pod" - in the calico support we got suggested that 3.21.1 can fix this.

For this path to work we would need to build

- [x] image: rancher/mirrored-calico-operator:v1.23.3
- [x] image: rancher/mirrored-calico-ctl:v3.21.2

Any reasons to not upgrade calico right now?