### PR TITLE
Remove dual-stack logic from 1.19&1.20 canal chart

### DIFF
--- a/packages/rke2-canal-1.19-1.20/charts/templates/config.yaml
+++ b/packages/rke2-canal-1.19-1.20/charts/templates/config.yaml
@@ -60,11 +60,7 @@ data:
   # Flannel network configuration. Mounted into the flannel container.
   net-conf.json: |
     {
-      "Network": {{ coalesce .Values.global.clusterCIDRv4 .Values.podCidr | quote }},
-{{- if coalesce .Values.global.clusterCIDRv6 .Values.podCidrv6 }}
-      "IPv6Network": {{ coalesce .Values.global.clusterCIDRv6 .Values.podCidrv6 | quote }},
-      "EnableIPv6": true,
-{{- end }}
+      "Network": {{ coalesce .Values.global.clusterCIDR .Values.podCidr | quote }},
       "Backend": {
         "Type": {{ .Values.flannel.backend | quote }}
       }

--- a/packages/rke2-canal-1.19-1.20/charts/values.yaml
+++ b/packages/rke2-canal-1.19-1.20/charts/values.yaml
@@ -78,5 +78,3 @@ calico:
 
 global:
   systemDefaultRegistry: ""
-  clusterCIDRv4: ""
-  clusterCIDRv6: ""

--- a/packages/rke2-canal-1.19-1.20/package.yaml
+++ b/packages/rke2-canal-1.19-1.20/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 04
+packageVersion: 05


### PR DESCRIPTION
Issue: https://github.com/rancher/rke2/issues/2309

Signed-off-by: Manuel Buil <mbuil@suse.com>