### PR TITLE
Provide dual-stack support to canal

### DIFF
--- a/packages/rke2-canal/charts/templates/config.yaml
+++ b/packages/rke2-canal/charts/templates/config.yaml
@@ -36,7 +36,20 @@ data:
           "mtu": __CNI_MTU__,
           "ipam": {
               "type": "host-local",
-              "subnet": "usePodCidr"
+              "ranges": [
+                  [
+                      {
+                          "subnet": "usePodCidr"
+                      }
+{{- if coalesce .Values.global.clusterCIDRv6 .Values.podCidrv6 }}
+                  ],
+                  [
+                      {
+                          "subnet": "usePodCidrIPv6"
+                      }
+{{- end }}
+                  ]
+              ]
           },
           "policy": {
               "type": "k8s"

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -25,15 +25,15 @@ calico:
   # CNI installation image.
   cniImage:
     repository: rancher/hardened-calico
-    tag: v3.20.2-build20211119
+    tag: v3.20.3-build20220114
   # Canal node image.
   nodeImage:
     repository: rancher/hardened-calico
-    tag: v3.20.2-build20211119
+    tag: v3.20.3-build20220114
   # Flexvol Image.
   flexvolImage:
     repository: rancher/hardened-calico
-    tag: v3.20.2-build20211119
+    tag: v3.20.3-build20220114
   # Datastore type for canal. It can be either kuberentes or etcd.
   datastoreType: kubernetes
   # Wait for datastore to initialize.

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,4 +1,2 @@
 url: local
-packageVersion: 04
-# This repository does not use releaseCandidateVersions, so you can leave this as 00.
-releaseCandidateVersion: 00
+packageVersion: 05


### PR DESCRIPTION
Update the calico image to `v3.20.3-build20220114`, which supports dual-stack.

Change the config.yaml so that the ipv6 config only applies when clustercidr contains ipv6

Issue: https://github.com/rancher/rke2/issues/2342

Signed-off-by: Manuel Buil <mbuil@suse.com>