### PR TITLE
Added caliconodestatuses resource on canal clusterRole

### DIFF
--- a/packages/rke2-canal/charts/templates/rbac.yaml
+++ b/packages/rke2-canal/charts/templates/rbac.yaml
@@ -72,6 +72,7 @@ rules:
   # Calico monitors various CRDs for config.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
+      - caliconodestatuses
       - globalfelixconfigs
       - felixconfigurations
       - bgppeers


### PR DESCRIPTION
fix https://github.com/rancher/rke2/issues/2605