### PR TITLE
Update 1.21.11 kube-proxy charts

### DIFF
--- a/packages/rke2-kube-proxy-1.21/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy-1.21/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.21.10-rke2r2-build20220304
+version: v1.21.11-rke2r1-build20220316
 appVersion: v1.21.10-rke2r1
 keywords:
   - kube-proxy

--- a/packages/rke2-kube-proxy-1.21/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.21/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kubernetes
-  tag: v1.21.10-rke2r2-build20220304
+  tag: v1.21.11-rke2r1-build20220316
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)


### PR DESCRIPTION
Update kube-proxy with `rancher/hardened-kubernetes:v1.21.11-rke2r1-build20220316`