### PR TITLE
Updating CPI to have an image override to use 1.22 on 1.23.

### DIFF
--- a/packages/rancher-vsphere-cpi/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-vsphere-cpi/generated-changes/patch/values.yaml.patch
@@ -1,0 +1,12 @@
+--- charts-original/values.yaml
++++ charts/values.yaml
+@@ -11,6 +11,9 @@
+ 
+ cloudControllerManager:
+   image:
++    "1.23":
++      repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
++      tag: v1.22.5
+     "1.22":
+       repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
+       tag: v1.22.5

--- a/packages/rancher-vsphere-cpi/package.yaml
+++ b/packages/rancher-vsphere-cpi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-cpi
 commit: 81da645ddf86370fc5d1e35dc4711a45b3cea929
-version: 100.2.0
+packageVersion: 02


### PR DESCRIPTION
Since the chart uses a template helper to determine the CPI image version to use, we need to specify an image override by patching the chart for 1.23.