### PR TITLE
Updating to CSI 2.5.0 from vSphere Charts to support 1.23.

### DIFF
--- a/packages/rancher-vsphere-csi/package.yaml
+++ b/packages/rancher-vsphere-csi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-csi
-commit: 81da645ddf86370fc5d1e35dc4711a45b3cea929
-version: 100.2.0
+commit: 4655abc8049b22acae61444be5ac41f481bfa666
+packageVersion: 01


### PR DESCRIPTION
This is pulling the newly update CSI 2.5.0 chart. 

* https://github.com/rancher/rancher/issues/36764