### PR TITLE
WIP update kube-proxy for v1.21.11-rke2r2

### DIFF
--- a/packages/rke2-kube-proxy-1.21/charts/Chart.yaml
+++ b/packages/rke2-kube-proxy-1.21/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-kube-proxy
 description: Install Kube Proxy.
-version: v1.21.11-rke2r1-build20220316
-appVersion: v1.21.10-rke2r1
+version: v1.21.11-rke2r2-build20220324
+appVersion: v1.21.11-rke2r2
 keywords:
   - kube-proxy
 sources:

--- a/packages/rke2-kube-proxy-1.21/charts/values.yaml
+++ b/packages/rke2-kube-proxy-1.21/charts/values.yaml
@@ -3,7 +3,7 @@
 # image for kubeproxy
 image:
   repository: rancher/hardened-kubernetes
-  tag: v1.21.11-rke2r1-build20220316
+  tag: v1.21.11-rke2r2-build20220324
 
 # The IP address for the proxy server to serve on 
 # (set to '0.0.0.0' for all IPv4 interfaces and '::' for all IPv6 interfaces)


### PR DESCRIPTION
_This PR is for staging purposes only, if the case for an r2 arrises. 🚧_

update kube-proxy for v1.21.11-rke2r2