### PR TITLE
Add automatic support for dual-stack

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-configmap.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-configmap.yaml.patch
@@ -1,0 +1,15 @@
+--- charts-original/templates/cilium-configmap.yaml
++++ charts/templates/cilium-configmap.yaml
+@@ -195,7 +195,11 @@
+ 
+   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
+   # address.
+-  enable-ipv6: {{ .Values.ipv6.enabled | quote }}
++{{- if coalesce .Values.global.clusterCIDRv6 .Values.ipv6.enabled }}
++  enable-ipv6: true
++{{ else }}
++  enable-ipv6: false
++{{- end }}
+ 
+ {{- if .Values.cleanState }}
+   # If a serious issue occurs during Cilium startup, this

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.11.2.tgz
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Canal and Calico read the .Values.global.clusterCIDRv6 parameter to enable ipv6 config or not. In Cilium we are asking the user to enable it manually. This PR aligns Cilium with the rest of CNIs so that the ipv6 parameters are set automatically when cluster-cidr or ipv6 is true 

Issue: https://github.com/rancher/rke2/issues/2741

Signed-off-by: Manuel Buil <mbuil@suse.com>