### PR TITLE
Fix Cilium typo

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-configmap.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-configmap.yaml.patch
@@ -6,9 +6,9 @@
    # address.
 -  enable-ipv6: {{ .Values.ipv6.enabled | quote }}
 +{{- if coalesce .Values.global.clusterCIDRv6 .Values.ipv6.enabled }}
-+  enable-ipv6: true
++  enable-ipv6: "true"
 +{{ else }}
-+  enable-ipv6: false
++  enable-ipv6: "false"
 +{{- end }}
  
  {{- if .Values.cleanState }}

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.11.2.tgz
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
It throws an error:

"Error: INSTALLATION FAILED: ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal bool into Go struct field ConfigMap.data of type string"

The value needs to be a string

Signed-off-by: Manuel Buil <mbuil@suse.com>