### PR TITLE
Bump harvester cloud provider 0.1.11

### DIFF
--- a/packages/harvester-cloud-provider/package.yaml
+++ b/packages/harvester-cloud-provider/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.1.10/harvester-cloud-provider-0.1.10.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.1.11/harvester-cloud-provider-0.1.11.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
Related issue: https://github.com/rancher/rke2/issues/2765

Bump harvester cloud provider 0.1.11