### PR TITLE
Disable calico apiServer by default

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1,8 +1,24 @@
+@@ -1,11 +1,27 @@
  imagePullSecrets: {}
  
  installation:
@@ -24,7 +24,11 @@
 +  imagePrefix: "mirrored-calico-"
  
  apiServer:
-   enabled: true
+-  enabled: true
++  enabled: false
+ 
+ certs:
+   node:
 @@ -20,9 +36,24 @@
  
  # Configuration for the tigera operator

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.22.1/tigera-operator-v3.22.1.tgz
-packageVersion: 01
+packageVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
calico APIServer is required for a very specific use case: be able to query calico resources by using kubectl. Forcing this apiserver pod to run and consume resources by default, seems like a not very good idea. Consequently, I think we should disable it by default.

This component is part of Calico since v3.22, so there is no need to backport

Signed-off-by: Manuel Buil <mbuil@suse.com>