### PR TITLE
Updated calico chart to support IPv6 only setup

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/crs/custom-resources.yaml
 +++ charts/templates/crs/custom-resources.yaml
-@@ -6,6 +6,27 @@
+@@ -6,6 +6,30 @@
  {{ $secrets = append $secrets $item }}
  {{ end }}
  {{ $_ := set $installSpec "imagePullSecrets" $secrets }}
@@ -16,11 +16,14 @@
 +*/}}
 +{{ if not (empty .Values.global.clusterCIDRv6) }}
 +{{ $myIP6Dict := dict "natOutgoing" "Enabled" "cidr" .Values.global.clusterCIDRv6 }}
++{{ $finalIpPoolList := list $myIP6Dict }}
++{{ if not (empty .Values.global.clusterCIDRv4) }}
 +{{ $allIpPools := get .Values.installation.calicoNetwork "ipPools" }}
 +{{ range $allIpPools }}
 +{{ $_ := set . "encapsulation" "None" }}
 +{{ end }}
 +{{ $finalIpPoolList := append $allIpPools $myIP6Dict }}
++{ end }}
 +{{ $calicoNetwork := get .Values.installation "calicoNetwork" }}
 +{{ $_ := set $calicoNetwork "ipPools" $finalIpPoolList }}
 +{{ $_ := set $calicoNetwork "bgp" "Enabled" }}

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.22.2/tigera-operator-v3.22.2.tgz
-packageVersion: 01
+packageVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Signed-off-by: Roberto Bonafiglia <roberto.bonafiglia@suse.com>

Updated calico chart to disable IPv4 in case of an IPv6 only setup.