### PR TITLE
Add CoreDNS tolerations for cloud provider

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -137,6 +137,7 @@
+@@ -150,6 +150,7 @@
      {{- end -}}
  {{- end -}}
  
@@ -8,7 +8,7 @@
  {{/*
  Create the name of the service account to use
  */}}
-@@ -147,3 +148,44 @@
+@@ -160,3 +161,44 @@
      {{ default "default" .Values.serviceAccount.name }}
  {{- end -}}
  {{- end -}}

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -67,7 +67,7 @@
  
  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
  # for example:
-@@ -195,7 +195,13 @@
+@@ -195,7 +195,16 @@
  #     operator: Equal
  #     value: master
  #     effect: NoSchedule
@@ -79,10 +79,13 @@
 +- key: "node-role.kubernetes.io/etcd"
 +  operator: "Exists"
 +  effect: "NoExecute"
++- key: "node.cloudprovider.kubernetes.io/uninitialized"
++  operator: "Exists"
++  effect: "NoSchedule"
  
  # https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
  podDisruptionBudget: {}
-@@ -243,7 +249,7 @@
+@@ -243,7 +252,7 @@
  # See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
  autoscaler:
    # Enabled the cluster-proportional-autoscaler
@@ -91,7 +94,7 @@
  
    # Number of cores in the cluster per coredns replica
    coresPerReplica: 256
-@@ -264,8 +270,8 @@
+@@ -264,8 +273,8 @@
    #   - --nodelabels=topology.kubernetes.io/zone=us-east-1a
  
    image:
@@ -102,7 +105,7 @@
      pullPolicy: IfNotPresent
      ## Optionally specify an array of imagePullSecrets.
      ## Secrets must be manually created in the namespace.
-@@ -282,19 +288,26 @@
+@@ -282,19 +291,29 @@
  
    # Node labels for pod assignment
    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -119,6 +122,9 @@
 +  - key: "node-role.kubernetes.io/etcd"
 +    operator: "Exists"
 +    effect: "NoExecute"
++  - key: "node.cloudprovider.kubernetes.io/uninitialized"
++    operator: "Exists"
++    effect: "NoSchedule"
  
    # resources for autoscaler pod
    resources:
@@ -133,7 +139,7 @@
  
    # Options for autoscaler configmap
    configmap:
-@@ -306,11 +319,28 @@
+@@ -306,11 +325,28 @@
    livenessProbe:
      enabled: true
      initialDelaySeconds: 10


### PR DESCRIPTION
When creating a cluster with an external cloud provider controller enabled (AWS CCM for example), initially the nodes will have a `node.cloudprovider.kubernetes.io/uninitialized` taint.

This prevents CoreDNS pods from starting, and in turn the CCM is unable to resolve and initialise the node.

Adding the toleration allows CoreDNS to tolerate this condition.

Note: example here required the HelmChartConfig to get a working cluster with the AWS CCM, can be used for QA by removing the HelmChartConfig.
  * https://gist.github.com/dkeightley/26607d6739429a174675a81cd6fe65d6