### PR TITLE
Updated calico chart to expose felix cfg props exposed in canal

### DIFF
--- a/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
+++ b/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
@@ -6,3 +6,10 @@ spec:
   wireguardEnabled: {{ .Values.felixConfiguration.wireguardEnabled }}
   featureDetectOverride: {{ .Values.felixConfiguration.featureDetectOverride }}
   healthPort: {{ .Values.felixConfiguration.healthPort }}
+  defaultEndpointToHostAction: {{ .Values.felixConfiguration.defaultEndpointToHostAction }}
+  failsafeInboundHostPorts: {{ .Values.felixConfiguration.failsafeInboundHostPorts }}
+  failsafeOutboundHostPorts: {{ .Values.felixConfiguration.failsafeOutboundHostPorts }}
+  iptablesRefreshInterval: {{ .Values.felixConfiguration.iptablesRefreshInterval }}
+  iptablesBackend: {{ .Values.felixConfiguration.iptablesBackend }}
+  logSeveritySys: {{ .Values.felixConfiguration.logSeveritySys }}
+  xdpEnabled: {{ .Values.felixConfiguration.xdpEnabled }}

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -54,3 +54,10 @@
 +  # Config required to fix RKE2 issue #1541
 +  featureDetectOverride: "ChecksumOffloadBroken=true"
 +  healthPort: 9099
++  defaultEndpointToHostAction: Drop
++  failsafeInboundHostPorts: ""
++  failsafeOutboundHostPorts: ""
++  iptablesRefreshInterval: 90s
++  iptablesBackend: auto
++  logSeveritySys: Info
++  xdpEnabled: true

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.23.1/tigera-operator-v3.23.1.tgz
-packageVersion: 03
+packageVersion: 04
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Updated calico chart to expose felix config properties exposed in canal chart. See issue https://github.com/rancher/rke2/issues/3091