### PR TITLE
Update calico version to 3.23.3 in rke2-calico package

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
@@ -10,6 +10,6 @@
  - https://github.com/projectcalico/calico/tree/master/calico/_includes/charts/tigera-operator
  - https://github.com/tigera/operator
  - https://github.com/projectcalico/calico
- version: v3.23.1
+ version: v3.23.3
 +annotations:
 +  catalog.cattle.io/namespace: tigera-operator

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -31,13 +31,13 @@
  tigeraOperator:
 -  image: tigera/operator
 +  image: rancher/mirrored-calico-operator
-   version: v1.27.1
+   version: v1.27.12
 -  registry: quay.io
 +  registry: docker.io
  calicoctl:
 -  image: docker.io/calico/ctl
 +  image: rancher/mirrored-calico-ctl
-   tag: v3.23.1
+   tag: v3.23.3
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
-url: https://github.com/projectcalico/calico/releases/download/v3.23.1/tigera-operator-v3.23.1.tgz
-packageVersion: 04
+url: https://github.com/projectcalico/calico/releases/download/v3.23.3/tigera-operator-v3.23.3.tgz
+packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rke2-calico/templates/crd-template/Chart.yaml
+++ b/packages/rke2-calico/templates/crd-template/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: v3.23.1
+version: v3.23.3
 description: Installs the CRDs for rke2-calico
 name: rke2-calico-crd
 type: application


### PR DESCRIPTION
Hi, 
There is a bug with ip_autodetection mode "k8s-internal-ip" in calico 3.23.1 projectcalico/calico#6142 and it was fixed in 3.23.2 version projectcalico/calico#6228.