### PR TITLE
Correct cilium preflight charts

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-preflight/daemonset.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-preflight/daemonset.yaml.patch
@@ -5,7 +5,7 @@
        initContainers:
          - name: clean-cilium-state
 -          image: {{ include "cilium.image" .Values.preflight.image | quote }}
-+          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.image | quote }}"
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.image }}"
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            command: ["/bin/echo"]
            args:
@@ -13,7 +13,7 @@
        containers:
          - name: cilium-pre-flight-check
 -          image: {{ include "cilium.image" .Values.preflight.image | quote }}
-+          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.image | quote }}"
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.image }}"
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            command: ["/bin/sh"]
            args:
@@ -22,7 +22,7 @@
          {{- if ne .Values.preflight.tofqdnsPreCache "" }}
          - name: cilium-pre-flight-fqdn-precache
 -          image: {{ include "cilium.image" .Values.preflight.image | quote }}
-+          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.image | quote }}"
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.image }}"
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            name: cilium-pre-flight-fqdn-precache
            command: ["/bin/sh"]

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.12.1.tgz
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
This changes the cilium preflight image format to match the one we use when consuming the image.

The additional `| quote` was causing the helm charts/templates to fail parsing.