### PR TITLE
Add new value and fix bug in calico

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1,11 +1,23 @@
+@@ -1,11 +1,24 @@
  imagePullSecrets: {}
  
  installation:
@@ -12,6 +12,7 @@
 +    operator: "Exists"
 +    effect: "NoExecute"
    enabled: true
++  kubeletVolumePluginPath: "None"
    kubernetesProvider: ""
 +  calicoNetwork:
 +    bgp: Disabled
@@ -25,7 +26,7 @@
  
  certs:
    node:
-@@ -40,9 +52,32 @@
+@@ -40,9 +53,30 @@
  
  # Image and registry configuration for the tigera/operator pod.
  tigeraOperator:
@@ -54,10 +55,8 @@
 +  # Config required to fix RKE2 issue #1541
 +  featureDetectOverride: "ChecksumOffloadBroken=true"
 +  healthPort: 9099
-+  defaultEndpointToHostAction: Drop
++  defaultEndpointToHostAction: "Drop"
 +  failsafeInboundHostPorts: ""
 +  failsafeOutboundHostPorts: ""
-+  iptablesRefreshInterval: 90s
-+  iptablesBackend: auto
-+  logSeveritySys: Info
++  logSeveritySys: "Info"
 +  xdpEnabled: true

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.24.1/tigera-operator-v3.24.1.tgz
-packageVersion: 01
+packageVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Added kubeletVolumePluginPath: "None" to avoid Calico CSI plugin to get deployed

Removed the iptables parameters which does not work correctly in v3.24 when being passed to the felix component

Signed-off-by: Manuel Buil <mbuil@suse.com>