### PR TITLE
Fix the liveness path for calico-node

### DIFF
--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -188,12 +188,12 @@ spec:
             preStop:
               exec:
                 command:
-                - /bin/calico-node
+                - /usr/bin/calico-node
                 - -shutdown
           livenessProbe:
             exec:
               command:
-              - /bin/calico-node
+              - /usr/bin/calico-node
               - -felix-live
             periodSeconds: 10
             initialDelaySeconds: 10

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
After moving to BCI, `/bin/calico-node` is a wrong path. Cluster is alive and working but we get annoying error messages in the events of the canal pod:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/calico-node": stat /bin/calico-node: no such file or directory: unknown
  Warning  Unhealthy  17s (x16 over 2m47s)  kubelet            (combined from similar events): Liveness probe errored: rpc error: code = Unknown desc = failed to exec in container: failed to start exec "19b4e046649d360c7196ff44e910cf1e7038d9fdfd1c568368d9e33b21e0ed46": OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/calico-node": stat /bin/calico-node: no such file or directory: unknown
```

Signed-off-by: Manuel Buil <mbuil@suse.com>