### PR TITLE
Added system_default_registry on cilium

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-agent/daemonset.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-agent/daemonset.yaml.patch
@@ -39,6 +39,24 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          env:
          - name: CGROUP_ROOT
+@@ -464,7 +472,7 @@
+               - SYS_PTRACE
+           {{- end}}
+       - name: apply-sysctl-overwrites
+-        image: {{ include "cilium.image" .Values.image | quote }}
++        image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.image }}"
+         imagePullPolicy: {{ .Values.image.pullPolicy }}
+         env:
+         - name: BIN_PATH
+@@ -512,7 +520,7 @@
+       # from a privileged container because the mount propagation bidirectional
+       # only works from privileged containers.
+       - name: mount-bpf-fs
+-        image: {{ include "cilium.image" .Values.image | quote }}
++        image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.image }}"
+         imagePullPolicy: {{ .Values.image.pullPolicy }}
+         args:
+         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
 @@ -532,7 +540,7 @@
        {{- end }}
        {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
@@ -61,3 +79,12 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          command:
          - /init-container.sh
+@@ -627,7 +637,7 @@
+         {{- end }}
+       {{- if and .Values.waitForKubeProxy (ne $kubeProxyReplacement "strict") }}
+       - name: wait-for-kube-proxy
+-        image: {{ include "cilium.image" .Values.image | quote }}
++        image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.image }}"
+         imagePullPolicy: {{ .Values.image.pullPolicy }}
+         securityContext:
+           privileged: true

--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-preflight/deployment.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-preflight/deployment.yaml.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/cilium-preflight/deployment.yaml
++++ charts/templates/cilium-preflight/deployment.yaml
+@@ -28,7 +28,7 @@
+       {{- end }}
+       containers:
+         - name: cnp-validator
+-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.image }}"
+           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
+           command: ["/bin/sh"]
+           args:

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.12.1.tgz
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
Updated Cilium chart to add `{{ template "system_default_registry" . }}` on every mirrored used images to fix https://github.com/rancher/rke2/issues/3479