### PR TITLE
bump rke2-whereabouts version and upgrade multus to 3.9

### DIFF
--- a/packages/rke2-multus/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-multus/generated-changes/patch/Chart.yaml.patch
@@ -3,7 +3,7 @@
 @@ -1,16 +1,17 @@
  apiVersion: v2
 -appVersion: 0.1.0
-+appVersion: 3.8
++appVersion: 3.9
  dependencies:
  - condition: rke2-whereabouts.enabled
    name: rke2-whereabouts
@@ -23,4 +23,4 @@
  - https://github.com/intel/multus-cni
  type: application
 -version: 0.1.2
-+version: v3.8-build20221011
++version: v3.9-build20221028

--- a/packages/rke2-multus/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-multus/generated-changes/patch/values.yaml.patch
@@ -7,7 +7,7 @@
 -  repository: ghcr.io/k8snetworkplumbingwg/multus-cni
 -  tag: v3.8
 +  repository: rancher/hardened-multus-cni
-+  tag: v3.8-build20221011
++  tag: v3.9-build20221028
    pullPolicy: IfNotPresent
  
  #imagePullSecrets: []

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/k8snetworkplumbingwg/helm-charts.git
 subdirectory: multus 
 commit: 7d79cc653d543bf2ac5075274082e1053884b64e
-packageVersion: 03
+packageVersion: 04

--- a/packages/rke2-whereabouts/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-whereabouts/generated-changes/patch/Chart.yaml.patch
@@ -17,4 +17,4 @@
  # incremented each time you make changes to the application. Versions are not expected to
  # follow Semantic Versioning. They should reflect the version the application is using.
 -appVersion: 1.16.0
-+appVersion: 0.5.2
++appVersion: 0.5.3

--- a/packages/rke2-whereabouts/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-whereabouts/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
    pullPolicy: IfNotPresent
    # Overrides the image tag whose default is the chart appVersion.
 -  tag: "latest"
-+  tag: v0.5.3-build20220610
++  tag: v0.5.3-build20221027
  
  updateStrategy: RollingUpdate
  imagePullSecrets: []

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/k8snetworkplumbingwg/helm-charts.git
 commit: 7d79cc653d543bf2ac5075274082e1053884b64e
 subdirectory: whereabouts
-packageVersion: 01
+packageVersion: 02
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
This PR updates whereabouts to use the BCI image.
The multus chart needs to be bumped as well because whereabouts is a dependency.

Issue: https://github.com/rancher/rke2/issues/3260