### PR TITLE
Revert "Bump ingress-nginx to v1.4.1"

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -13,7 +13,7 @@
 -    tag: "v1.2.0"
 -    digest: sha256:d8196e3bc1e72547c5dec66d6556c0ff92a23f6d0919b206be170bc90d5f9185
 -    digestChroot: sha256:fb17f1700b77d4fcc52ca6f83ffc2821861ae887dbb87149cf5cbc52bea425e5
-+    tag: "nginx-1.4.1-hardened1"
++    tag: "nginx-1.2.1-hardened9"
      pullPolicy: IfNotPresent
      # www-data -> uid 101
      runAsUser: 101

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.1.0/ingress-nginx-4.1.0.tgz
-packageVersion: 06
+packageVersion: 05
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Reverts rancher/rke2-charts#308
While s390x images were published, AMD64 images were never published due to a [bug in the build system for 1.4.1](https://drone-publish.rancher.io/rancher/ingress-nginx/205), more work is needed.