### PR TITLE
Fix RBAC for calico-kube-controllers

### DIFF
--- a/packages/rke2-canal/charts/templates/rbac.yaml
+++ b/packages/rke2-canal/charts/templates/rbac.yaml
@@ -204,10 +204,9 @@ rules:
       - get
       - list
       - watch
-  # IPAM resources are manipulated when nodes are deleted.
+  # IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - ippools
       - ipreservations
     verbs:
       - list
@@ -222,6 +221,13 @@ rules:
       - create
       - update
       - delete
+      - watch
+  # Pools are watched to maintain a mapping of blocks to IP pools.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
       - watch
   # kube-controllers manages hostendpoints.
   - apiGroups: ["crd.projectcalico.org"]

--- a/packages/rke2-canal/charts/templates/rbac.yaml
+++ b/packages/rke2-canal/charts/templates/rbac.yaml
@@ -245,8 +245,10 @@ rules:
       - clusterinformations
     verbs:
       - get
+      - list
       - create
       - update
+      - watch
   # KubeControllersConfiguration is where it gets its config
   - apiGroups: ["crd.projectcalico.org"]
     resources:

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
We've run into a problem with missing permissions for callico-kube-controllers after upgrade to RKE2 1.24.

Steps to reproduce:
1) Install RKE2 with canal CNI >= v3.23.0
2) Enable kube-controllers in chart
```yaml
# rke2-canal-config.yaml
---
apiVersion: helm.cattle.io/v1
kind: HelmChartConfig
metadata:
  name: rke2-canal
  namespace: kube-system
spec:
  valuesContent: |-
    calico:
      calicoKubeControllers: true
```
3) Check the logs of canal-kube-controllers
```bash
$ kubectl logs deploy/rke2-canal-kube-controllers -n kube-system
```

It will be filled with these error messages:
```
[INFO][1] watchercache.go 248: Failed to create watcher ListRoot="/calico/resources/v3/projectcalico.org/ippools" error=connection is unauthorized: unknown (get IPPools.crd.projectcalico.org) performFullResync=false

[INFO][1] watchercache.go 194: Failed to perform list of current data during resync ListRoot="/calico/resources/v3/projectcalico.org/clusterinformations" error=connection is unauthorized: clusterinformations.crd.projectcalico.org is forbidden: User "system:serviceaccount:kube-system:calico-kube-controllers" cannot list resource "clusterinformations" in API group "crd.projectcalico.org" at the cluster scope

[INFO][1] watchercache.go 248: Failed to create watcher ListRoot="/calico/resources/v3/projectcalico.org/clusterinformations" error=connection is unauthorized: unknown (get ClusterInformations.crd.projectcalico.org) performFullResync=false
```
---
We've found out that calico-kube-controllers requires additional permissions from version v3.23.0. Here are the two upstream commits that add the additional permissions:
- https://github.com/projectcalico/calico/commit/a9ea2ad91f735c5d8decf8cf3bde5c3c51695152 - IP Pools 
- https://github.com/projectcalico/calico/commit/20b14f22a80f76587e987c2dd938165bf50013ae - ClusterInformation