### PR TITLE
Bump to include CPI v1.24.3

### DIFF
--- a/packages/rancher-vsphere-cpi/package.yaml
+++ b/packages/rancher-vsphere-cpi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-cpi
-commit: ba41db5e0814f719722954441edf409c12c45dd4
-packageVersion: 00
+commit: 96687762c6642efc3650626a0738c8caa45ae7c3
+packageVersion: 01


### PR DESCRIPTION
Pulls in https://github.com/rancher/vsphere-charts/commit/96687762c6642efc3650626a0738c8caa45ae7c3
Tracking with https://github.com/rancher/rke2/issues/3754
Signed-off-by: Derek Nola <derek.nola@suse.com>