### PR TITLE
Bump ingress-nginx helm chart to 4.3.0

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -28,7 +28,7 @@
+@@ -19,7 +19,7 @@
  - name: rikatz
  - name: strongjz
  - name: tao12345666333
@@ -8,4 +8,4 @@
 +name: rke2-ingress-nginx
  sources:
  - https://github.com/kubernetes/ingress-nginx
- type: application
+ version: 4.3.0

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/clusterrole.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/clusterrole.yaml.patch
@@ -1,26 +1,12 @@
 --- charts-original/templates/clusterrole.yaml
 +++ charts/templates/clusterrole.yaml
-@@ -82,6 +82,23 @@
-       - get
-       - list
-       - watch
-+  - apiGroups:
-+      - coordination.k8s.io
-+    resources:
-+      - leases
-+    verbs:
+@@ -34,6 +34,9 @@
+     resources:
+       - leases
+     verbs:
 +      - create
 +      - update
 +      - get
-+      - list
-+      - watch
-+  - apiGroups:
-+      - discovery.k8s.io
-+    resources:
-+      - endpointslices
-+    verbs:
-+      - list
-+      - watch
- {{- end }}
- 
- {{- end }}
+       - list
+       - watch
+ {{- if and .Values.controller.scope.enabled .Values.controller.scope.namespace }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -4,15 +4,15 @@
    image:
      ## Keep false as default for now!
      chroot: false
--    registry: k8s.gcr.io
+-    registry: registry.k8s.io
 -    image: ingress-nginx/controller
 +    repository: rancher/nginx-ingress-controller
      ## for backwards compatibility consider setting the full image url via the repository value below
      ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
      ## repository:
--    tag: "v1.2.0"
--    digest: sha256:d8196e3bc1e72547c5dec66d6556c0ff92a23f6d0919b206be170bc90d5f9185
--    digestChroot: sha256:fb17f1700b77d4fcc52ca6f83ffc2821861ae887dbb87149cf5cbc52bea425e5
+-    tag: "v1.4.0"
+-    digest: sha256:34ee929b111ffc7aa426ffd409af44da48e5a0eea1eb2207994d9e0c0882d143
+-    digestChroot: sha256:b67e889f1db8692de7e41d4d9aef8de56645bf048261f31fa7f8bfc6ea2222a0
 +    tag: "nginx-1.4.1-hardened2"
      pullPolicy: IfNotPresent
      # www-data -> uid 101
@@ -89,26 +89,27 @@
  
      # -- If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were
      # using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-@@ -630,13 +627,11 @@
+@@ -641,13 +638,11 @@
      patch:
        enabled: true
        image:
--        registry: k8s.gcr.io
+-        registry: registry.k8s.io
 -        image: ingress-nginx/kube-webhook-certgen
 +        repository: rancher/mirrored-ingress-nginx-kube-webhook-certgen
          ## for backwards compatibility consider setting the full image url via the repository value below
          ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
          ## repository:
-         tag: v1.1.1
--        digest: sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
+-        tag: v20220916-gd32f8c343
+-        digest: sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
++        tag: v1.5.2
          pullPolicy: IfNotPresent
        # -- Provide a priority class name to the webhook patching job
        ##
-@@ -757,12 +752,11 @@
+@@ -772,12 +767,11 @@
  
    name: defaultbackend
    image:
--    registry: k8s.gcr.io
+-    registry: registry.k8s.io
 -    image: defaultbackend-amd64
 +    repository: rancher/nginx-ingress-controller-defaultbackend
      ## for backwards compatibility consider setting the full image url via the repository value below
@@ -119,7 +120,7 @@
      pullPolicy: IfNotPresent
      # nobody user -> uid 65534
      runAsUser: 65534
-@@ -924,3 +918,6 @@
+@@ -943,3 +937,6 @@
  # This can be generated with: `openssl dhparam 4096 2> /dev/null | base64`
  ## Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
  dhParam:

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.1.0/ingress-nginx-4.1.0.tgz
-packageVersion: 08
+url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.3.0/ingress-nginx-4.3.0.tgz
+packageVersion: 00
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
This is a transitional PR. It bumps the helm chart  we use from a old 4.1.0 (april 2022) to 4.3.0 (Oct 2022) which was the last helm chart that shipped with a controller-v1.4.X (ie our nginx-1.4.1-hardened2). It **does not** bump the actual controller itself

Some notes:
- This pulls in https://github.com/kubernetes/ingress-nginx/pull/8733 and https://github.com/kubernetes/ingress-nginx/pull/8890, which covers most of the bugs in `clusterrole.yaml`, so a smaller patch is now needed.
- The upstream helm chart now pulls from `registry.k8s.io`, they moved away from `k8s.gcr.io`. Doesn't affect us, but makes our patches look slightly different going forward.

Once this merges and is tested with a full rke2 release, we can move on to the most recent helm chart 4.5.2 and the contoller-v1.6.X (ie our nginx-1.6.4-hardened1)