### PR TITLE
Serve v1beta1 snapshot CRDs

### DIFF
--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -123,7 +123,7 @@ spec:
         - deletionPolicy
         - driver
         type: object
-    served: false
+    served: true
     storage: false
     subresources: {}
 status:

--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -384,7 +384,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}

--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -296,7 +296,7 @@ spec:
         required:
         - spec
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}

--- a/packages/rke2-snapshot-controller/package.yaml
+++ b/packages/rke2-snapshot-controller/package.yaml
@@ -1,7 +1,7 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-controller
 commit: 100f3d3c3513e14b423093cbb1a6f8fdd38fafd1  # snapshot-controller-1.7.2
-packageVersion: 00
+packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
LH team has requested that we still serve the v1beta1 CRD versions, in order to support upgrade from previous LH releases.