### PR TITLE
Fix invalid kube-webwook-certgen

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -95,13 +95,13 @@
        image:
 -        registry: registry.k8s.io
 -        image: ingress-nginx/kube-webhook-certgen
-+        repository: rancher/mirrored-ingress-nginx-kube-webhook-certgen
++        repository: rancher/mirrored-jettech-kube-webhook-certgen
          ## for backwards compatibility consider setting the full image url via the repository value below
          ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
          ## repository:
 -        tag: v20220916-gd32f8c343
 -        digest: sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
-+        tag: v1.3.0
++        tag: v1.5.2
          pullPolicy: IfNotPresent
        # -- Provide a priority class name to the webhook patching job
        ##

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -101,7 +101,7 @@
          ## repository:
 -        tag: v20220916-gd32f8c343
 -        digest: sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
-+        tag: v1.5.2
++        tag: v1.3.0
          pullPolicy: IfNotPresent
        # -- Provide a priority class name to the webhook patching job
        ##

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.3.0/ingress-nginx-4.3.0.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
In https://github.com/rancher/rke2-charts/pull/323, rancher/mirrored-ingress-nginx-kube-webhook-certgen was incorrectly set to v1.5.2, which does not exist. This is a mirror of a mirror (jettech -> ingress-nginx -> rancher). Instead we will cut out the middle man and use the rancher mirror of jettech directly (jettech -> rancher), which does have a v1.5.2.