### PR TITLE
Add nodeSelector and tolerations to snapshot controller charts

### DIFF
--- a/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,26 @@
    pullPolicy: IfNotPresent
    # Overrides the image tag whose default is the chart appVersion.
    tag: ""
-@@ -54,3 +54,6 @@
+@@ -27,9 +27,16 @@
+ 
+ resources: {}
+ 
+-nodeSelector: {}
++nodeSelector:
++  kubernetes.io/os: linux
+ 
+-tolerations: []
++tolerations:
++- key: "node-role.kubernetes.io/control-plane"
++  operator: "Exists"
++  effect: "NoSchedule"
++- key: "node-role.kubernetes.io/etcd"
++  operator: "Exists"
++  effect: "NoExecute"
+ 
+ affinity: {}
+ 
+@@ -54,3 +61,6 @@
  #      velero.io/csi-volumesnapshot-class: "true"
  #    driver: linstor.csi.linbit.com
  #    deletionPolicy: Delete

--- a/packages/rke2-snapshot-controller/package.yaml
+++ b/packages/rke2-snapshot-controller/package.yaml
@@ -1,7 +1,7 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-controller
 commit: 100f3d3c3513e14b423093cbb1a6f8fdd38fafd1  # snapshot-controller-1.7.2
-packageVersion: 01
+packageVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rke2-snapshot-validation-webhook/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-snapshot-validation-webhook/generated-changes/patch/Chart.yaml.patch
@@ -6,5 +6,5 @@
 -name: snapshot-validation-webhook
 +name: rke2-snapshot-validation-webhook
  version: 1.7.1
- appVersion: "v6.2.0"
+ appVersion: "v6.2.1"
  icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg

--- a/packages/rke2-snapshot-validation-webhook/generated-changes/patch/templates/deployment.yaml.patch
+++ b/packages/rke2-snapshot-validation-webhook/generated-changes/patch/templates/deployment.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/deployment.yaml
 +++ charts/templates/deployment.yaml
-@@ -29,7 +29,7 @@
+@@ -32,7 +32,7 @@
          - name: {{ .Chart.Name }}
            securityContext:
              {{- toYaml .Values.securityContext | nindent 12 }}

--- a/packages/rke2-snapshot-validation-webhook/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-snapshot-validation-webhook/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,26 @@
    pullPolicy: IfNotPresent
    # Overrides the image tag whose default is the chart appVersion.
    tag: ""
-@@ -49,3 +49,6 @@
+@@ -63,9 +63,16 @@
+ 
+ resources: {}
+ 
+-nodeSelector: {}
++nodeSelector:
++  kubernetes.io/os: linux
+ 
+-tolerations: []
++tolerations:
++- key: "node-role.kubernetes.io/control-plane"
++  operator: "Exists"
++  effect: "NoSchedule"
++- key: "node-role.kubernetes.io/etcd"
++  operator: "Exists"
++  effect: "NoExecute"
+ 
+ affinity: {}
+ 
+@@ -75,3 +82,6 @@
  
  rbac:
    create: true

--- a/packages/rke2-snapshot-validation-webhook/package.yaml
+++ b/packages/rke2-snapshot-validation-webhook/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-validation-webhook
 commit: bc135abc9dff8e96cdb9efea56328032391ec0d0  # snapshot-validation-webhook-1.7.1
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
Ensures that the CSI snapshot stuff runs on linux nodes in a mixed linux/windows cluster
For: 
* https://github.com/rancher/rke2/issues/4264