### PR TITLE
Fix rke2-coredns deployment template

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/deployment.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/deployment.yaml.patch
@@ -10,7 +10,7 @@
  {{- if .Values.podAnnotations }}
  {{ toYaml .Values.podAnnotations | indent 8 }}
  {{- end }}
-@@ -84,8 +81,13 @@
+@@ -84,9 +81,15 @@
        topologySpreadConstraints:
  {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
        {{- end }}
@@ -23,9 +23,11 @@
 +        {{- end }}
 +        {{- if .Values.tolerations }}
  {{ toYaml .Values.tolerations | indent 8 }}
++        {{- end }}
        {{- end }}
        {{- if .Values.nodeSelector }}
-@@ -98,7 +100,7 @@
+       nodeSelector:
+@@ -98,7 +101,7 @@
        {{- end }}
        containers:
        - name: "coredns"

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.24.0/coredns-1.24.0.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
End block got missed when rebasing the template patch