### PR TITLE
Fix k8sApp default value

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
@@ -5,7 +5,7 @@
  */}}
  {{- define "coredns.k8sapplabel" -}}
 -{{- default .Chart.Name .Values.k8sAppLabelOverride | trunc 63 | trimSuffix "-" -}}
-+{{- .Values.k8sApp | default .Chart.Name .Values.k8sAppLabelOverride | trunc 63 | trimSuffix "-" -}}
++{{- coalesce .Values.k8sApp .Values.k8sAppLabelOverride .Chart.Name | trunc 63 | trimSuffix "-" -}}
  {{- end -}}
  
  {{/*

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -165,7 +165,7 @@
    ## Annotations for the coredns deployment
    annotations: {}
 +
-+k8sApp : "kube-dns"
++k8sApp: "kube-dns"
 +
 +nodelocal:
 +  enabled: false

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.24.0/coredns-1.24.0.tgz
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
The `k8s-app` label wasn't getting passed through properly, breaking conformance tests