### PR TITLE
Bump harvester cloud provider 0.2.2

### DIFF
--- a/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
+++ b/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
@@ -1,3 +1,3 @@
 workingDir: ""
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.1/harvester-cloud-provider-0.2.1.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.2/harvester-cloud-provider-0.2.2.tgz
 subdirectory: dependency_charts/kube-vip

--- a/packages/harvester-cloud-provider/package.yaml
+++ b/packages/harvester-cloud-provider/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.1/harvester-cloud-provider-0.2.1.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.2/harvester-cloud-provider-0.2.2.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
Bump harvester cloud provider 0.2.2 where we use the kube-vip mirrored image.

Related issue: https://github.com/rancher/rke2/issues/4184