### PR TITLE
rke2-snapshot-validation-webhook: Bump the chart version

### DIFF
--- a/packages/rke2-snapshot-validation-webhook/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-snapshot-validation-webhook/generated-changes/patch/Chart.yaml.patch
@@ -5,6 +5,6 @@
  type: application
 -name: snapshot-validation-webhook
 +name: rke2-snapshot-validation-webhook
- version: 1.7.1
+ version: 1.7.3
  appVersion: "v6.2.1"
  icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg

--- a/packages/rke2-snapshot-validation-webhook/package.yaml
+++ b/packages/rke2-snapshot-validation-webhook/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-validation-webhook
-commit: bc135abc9dff8e96cdb9efea56328032391ec0d0  # snapshot-validation-webhook-1.7.1
-packageVersion: 01
+commit: 994dde7e93cda78eaf098e5c39889c95be928b32  # snapshot-validation-webhook-1.7.3
+packageVersion: 00


### PR DESCRIPTION
Current version is not validating requests to create/update `VolumeSnapshotClass` resources. This means it doesn't guarantee one default class.

Add VolumeSnapshotClass in the `validatingWebhookConfiguration`  resource list https://github.com/piraeusdatastore/helm-charts/pull/25