### PR TITLE
Generate rke2-canal resource bounds from template values rather than hardcoding.

### DIFF
--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -181,9 +181,9 @@ spec:
 {{- end }}
           securityContext:
             privileged: true
-          resources:
-            requests:
-              cpu: 250m
+          {{- if .Values.calico.resources }}
+          resources: {{- toYaml .Values.calico.resources | nindent 12 }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -239,6 +239,9 @@ spec:
           {{- end }}
           securityContext:
             privileged: true
+          {{- if .Values.flannel.resources }}
+          resources: {{- toYaml .Values.flannel.resources | nindent 12 }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -46,6 +46,14 @@ flannel:
   #tunnelMode: "separate"
   # Persistent keep interval to use
   keepaliveInterval: 0
+  # Resource bounds for the kube-flannel daemon container
+  resources: ~
+    # requests:
+    #   memory: 32Mi
+    #   cpu: 100m
+    # limits:
+    #   memory: 128Mi
+    #   cpu: 500m
 
 calico:
   # CNI installation image.
@@ -112,6 +120,14 @@ calico:
   ip6AutoDetectionMethod: "first-found"
   # Enable calico kube-controllers
   calicoKubeControllers: false
+  # Resource bounds for the calico-node daemon container
+  resources:
+    requests:
+      cpu: 250m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 250m
+    #   memory: 256Mi
 
 global:
   systemDefaultRegistry: ""

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 03
+packageVersion: 04


### PR DESCRIPTION
#### Proposed Changes ####

This PR adds additional `resources` helm value configuration options to `rke2-canal`. It replaces the previously-hardcoded 250m CPU request on the `calico-node` container with a helm-configured request, and also adds the option to the `flannel-node` container.

I've added the remaining unused resource bound keys as comments for documentation purposes (aside from the `calico.resources.requests.cpu` key that's set by default to preserve the existing 250m bound). I don't know if the bounds the comments suggest are reasonable for the same median use-case as that 250m bound, but I don't figure it matters much; anyone configuring them should be doing their own profiling on their own hardware anyway.

#### Types of Changes ####

This is a non-breaking change to enhance existing functionality with the addition of a standard feature.

#### Verification ####

This patch does not result in any changes to the template output from helm, unless the new configuration keys it adds are overridden; the default rendered output manifests is byte-for-byte identical to the pre-patch version.

The code pattern used in the added code is the standard way to implement resource bounds configuration in helm, as seen already in use in other packages in this repository such as `rke2-multus` or `rke2-coredns`.

#### Further Comments ####

For my specific use case, this change makes it possible for me to scale the default request down, and make it a better fit for the small 4-core nodes I'm running. With this change I can just add a `HelmChartConfig` with the appropriate resource bounds keys to my RKE2 server manifests folder (i.e. `/var/lib/rancher/rke2/server/manifests/canal-resources.yaml`), rather than needing Kustomize or some other workaround.