### PR TITLE
Add CODEOWNERS, MAINTAINERS, enable DCO

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rancher/k3s

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,19 @@
+# The following is the list of current RKE2 maintainers
+# Github ID, Name, Email Address
+
+brandond, Brad Davidson, brad.davidson@suse.com
+briandowns, Brian Downs, brian.downs@suse.com
+brooksn, Brooks Newberry, brooks.newberry@suse.com
+caroline-suse-rancher, Caroline Davis, caroline.davis@suse.com
+cwayne18, Chris Wayne, chris.wayne@suse.com
+dereknola, Derek Nola, derek.nola@suse.com
+galal-hussein, Hussein Galal, hussein.galalabdelazizahmed@suse.com
+manuelbuil, Manuel Buil, mbuil@suse.com
+matttrach, Matt Trachier, matt.trachier@suse.com
+mdrahman-suse, MD Rahman, md.rahman@suse.com
+Oats87, Chris Kim, chris.kim@suse.com
+rancher-max, Max Ross, max.ross@suse.com
+rbrtbnfgl, Roberto Bonafiglia, roberto.bonafiglia@suse.com
+ShylajaDevadiga, Shylaja Devadiga, shylaja.devadiga@suse.com
+thomasferrandiz, Thomas Ferrandiz, thomas.ferrandiz@suse.com
+VestigeJ, Justin Janes, justin.janes@suse.com


### PR DESCRIPTION
Enable DCO now that we're starting to get community contributions to this repo.

Add CODEOWNERS and MAINTAINERS for parity with RKE2 and K3s repos.