### PR TITLE
update rke2-whereabouts to v0.6.2

### DIFF
--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/k8snetworkplumbingwg/helm-charts.git
 subdirectory: multus 
 commit: ca7c0a7549952660eab8f4b12e7ec7be133b381c
-packageVersion: 02
+packageVersion: 03

--- a/packages/rke2-whereabouts/generated-changes/patch/templates/cluster_role.yaml.patch
+++ b/packages/rke2-whereabouts/generated-changes/patch/templates/cluster_role.yaml.patch
@@ -1,0 +1,14 @@
+--- charts-original/templates/cluster_role.yaml
++++ charts/templates/cluster_role.yaml
+@@ -28,6 +28,11 @@
+   verbs:
+   - list
+   - watch
++- apiGroups: [""]
++  resources:
++  - nodes
++  verbs:
++  - get
+ - apiGroups: ["k8s.cni.cncf.io"]
+   resources:
+   - network-attachment-definitions

--- a/packages/rke2-whereabouts/generated-changes/patch/templates/daemonset.yaml.patch
+++ b/packages/rke2-whereabouts/generated-changes/patch/templates/daemonset.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/daemonset.yaml
 +++ charts/templates/daemonset.yaml
-@@ -32,9 +32,15 @@
+@@ -32,11 +32,22 @@
          {{- toYaml .Values.podSecurityContext | nindent 8 }}
        containers:
          - name: {{ .Chart.Name }}
@@ -16,4 +16,11 @@
 +          image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
            imagePullPolicy: {{ .Values.image.pullPolicy }}
            env:
++          - name: NODENAME
++            valueFrom:
++              fieldRef:
++                apiVersion: v1
++                fieldPath: spec.nodeName
            - name: WHEREABOUTS_NAMESPACE
+             valueFrom:
+               fieldRef:

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/k8snetworkplumbingwg/helm-charts.git
 commit: ca7c0a7549952660eab8f4b12e7ec7be133b381c
 subdirectory: whereabouts
-packageVersion: 01
+packageVersion: 02
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
Update DaemonSet to pass `spec.nodeName` via the env to the pod
fixup for ee7586b6b3f55f810ab10b7f4fc2aea2846f8d78


Fixes whereabouts pod CrashLoopBackoff when deployed via chart [rke2-multus-v4.0.2-build2023070702](https://github.com/rancher/rke2-charts/tree/main/charts/rke2-multus/rke2-multus/v4.0.2-build2023070702)
```
$ kubectl logs -n kube-system  rke2-multus-rke2-whereabouts-dhjf2 
Done configuring CNI.  Sleep=false
2023-08-03T22:47:33Z [debug] Filtering pods with filter key 'spec.nodeName' and filter value ''
2023-08-03T22:47:33Z [error] could not create the pod networks controller: Could not find node with node name ''.: resource name may not be empty
```