### PR TITLE
Add prometheusMetricsEnabled option to rke2-calico

### DIFF
--- a/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
+++ b/packages/rke2-calico/generated-changes/overlay/templates/felixconfig.yaml
@@ -13,3 +13,4 @@ spec:
   iptablesBackend: {{ .Values.felixConfiguration.iptablesBackend }}
   logSeveritySys: {{ .Values.felixConfiguration.logSeveritySys }}
   xdpEnabled: {{ .Values.felixConfiguration.xdpEnabled }}
+  prometheusMetricsEnabled: {{ .Values.felixConfiguration.prometheusMetricsEnabled }}

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -26,7 +26,7 @@
  
  certs:
    node:
-@@ -40,9 +53,30 @@
+@@ -40,9 +53,31 @@
  
  # Image and registry configuration for the tigera/operator pod.
  tigeraOperator:
@@ -60,3 +60,4 @@
 +  failsafeOutboundHostPorts: ""
 +  logSeveritySys: "Info"
 +  xdpEnabled: true
++  prometheusMetricsEnabled: false

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.26.1/tigera-operator-v3.26.1.tgz
-packageVersion: 00
+packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Add to rke2-calico FelixConfiguration template `prometheusMetricsEnabled` option which is required for enabling [metrics exporter.](https://docs.tigera.io/calico/latest/operations/monitor/monitor-component-metrics#1-configure-calico-to-enable-metrics-reporting)