### PR TITLE
Changed API version for poddisturtionbudget

### DIFF
--- a/packages/rke2-canal/charts/templates/kube-controllers-deployment.yaml
+++ b/packages/rke2-canal/charts/templates/kube-controllers-deployment.yaml
@@ -62,7 +62,7 @@ spec:
 ---
 # This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: calico-kube-controllers

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
In kubernetes version 1.25 the API policy/v1beta1 for PDB was removed The helm chart still uses this old API and is making upgrading impossible