### PR TITLE
ipFamilyPolicy: PreferDualStack as default

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -12,7 +12,7 @@
    pullPolicy: IfNotPresent
    ## Optionally specify an array of imagePullSecrets.
    ## Secrets must be manually created in the namespace.
-@@ -54,7 +54,6 @@
+@@ -54,21 +54,20 @@
  
  service:
  # clusterIP: ""
@@ -20,7 +20,11 @@
  # loadBalancerIP: ""
  # externalIPs: []
  # externalTrafficPolicy: ""
-@@ -65,10 +64,10 @@
+-# ipFamilyPolicy: ""
++  ipFamilyPolicy: "PreferDualStack"
+   # The name of the Service
+   # If not set, a name is generated using the fullname template
+   name: ""
    annotations: {}
  
  serviceAccount:

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.24.0/coredns-1.24.0.tgz
-packageVersion: 04
+packageVersion: 05
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-service-webhook.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-service-webhook.yaml.patch
@@ -1,0 +1,10 @@
+--- charts-original/templates/controller-service-webhook.yaml
++++ charts/templates/controller-service-webhook.yaml
+@@ -37,4 +37,7 @@
+   selector:
+     {{- include "ingress-nginx.selectorLabels" . | nindent 4 }}
+     app.kubernetes.io/component: controller
++  {{- if .Values.controller.admissionWebhooks.service.ipFamilyPolicy }}
++  ipFamilyPolicy: {{ .Values.controller.admissionWebhooks.service.ipFamilyPolicy }}
++  {{- end }}
+ {{- end }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -88,7 +88,15 @@
      # -- If enabled is adding an appProtocol option for Kubernetes service. An appProtocol field replacing annotations that were
      # using for setting a backend protocol. Here is an example for AWS: service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
      # It allows choosing the protocol for each backend specified in the Kubernetes service.
-@@ -604,13 +601,11 @@
+@@ -587,6 +584,7 @@
+       loadBalancerSourceRanges: []
+       servicePort: 443
+       type: ClusterIP
++      ipFamilyPolicy: "PreferDualStack"
+     createSecretJob:
+       securityContext:
+         allowPrivilegeEscalation: false
+@@ -604,13 +602,11 @@
      patch:
        enabled: true
        image:
@@ -103,7 +111,7 @@
          pullPolicy: IfNotPresent
        # -- Provide a priority class name to the webhook patching job
        ##
-@@ -738,12 +733,11 @@
+@@ -738,12 +734,11 @@
    enabled: false
    name: defaultbackend
    image:
@@ -118,11 +126,10 @@
      pullPolicy: IfNotPresent
      # nobody user -> uid 65534
      runAsUser: 65534
-@@ -898,3 +892,6 @@
+@@ -898,3 +893,6 @@
  # This can be generated with: `openssl dhparam 4096 2> /dev/null | base64`
  ## Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
  dhParam: ""
 +
 +global:
 +  systemDefaultRegistry: ""
-\ No newline at end of file

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.6.1/ingress-nginx-4.6.1.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00

--- a/packages/rke2-metrics-server/generated-changes/patch/templates/metric-server-service.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/templates/metric-server-service.yaml.patch
@@ -1,0 +1,8 @@
+--- charts-original/templates/metric-server-service.yaml
++++ charts/templates/metric-server-service.yaml
+@@ -22,4 +22,5 @@
+     app: {{ template "metrics-server.name" . }}
+     release: {{ .Release.Name }}
+   type: {{ .Values.service.type }}
++  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+ 

--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -36,7 +36,14 @@
  
  extraVolumeMounts: []
  #  - name: secrets
-@@ -107,3 +109,6 @@
+@@ -101,9 +103,13 @@
+   #  kubernetes.io/name: "Metrics-server"
+   port: 443
+   type: ClusterIP
++  ipFamilyPolicy: "PreferDualStack"
+ 
+ podDisruptionBudget:
+   # https://kubernetes.io/docs/tasks/run-application/configure-pdb/
    enabled: false
    minAvailable:
    maxUnavailable:

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,3 +1,3 @@
 url: https://charts.helm.sh/stable/packages/metrics-server-2.11.1.tgz
-packageVersion: 09
+packageVersion: 10
 releaseCandidateVersion: 00

--- a/packages/rke2-snapshot-validation-webhook/generated-changes/patch/templates/service.yaml.patch
+++ b/packages/rke2-snapshot-validation-webhook/generated-changes/patch/templates/service.yaml.patch
@@ -1,0 +1,18 @@
+--- charts-original/templates/service.yaml
++++ charts/templates/service.yaml
+@@ -5,12 +5,13 @@
+   labels:
+     {{- include "snapshot-validation-webhook.labels" . | nindent 4 }}
+ spec:
+-  type: ClusterIP
++  type: {{ .Values.service.type }}
+   ports:
+-    - port: 443
++    - port: {{ .Values.service.port }}
+       targetPort: https
+       protocol: TCP
+       name: https
++  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+   selector:
+     {{- include "snapshot-validation-webhook.selectorLabels" . | nindent 4 }}
+ ---

--- a/packages/rke2-snapshot-validation-webhook/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-snapshot-validation-webhook/generated-changes/patch/values.yaml.patch
@@ -28,10 +28,15 @@
  
  affinity: {}
  
-@@ -75,3 +82,6 @@
+@@ -75,3 +82,11 @@
  
  rbac:
    create: true
++
++service:
++  port: 443
++  ipFamilyPolicy: "PreferDualStack"
++  type: "ClusterIP"
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-snapshot-validation-webhook/package.yaml
+++ b/packages/rke2-snapshot-validation-webhook/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-validation-webhook
 commit: 994dde7e93cda78eaf098e5c39889c95be928b32  # snapshot-validation-webhook-1.7.3
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Changing default ipFamilyPolicy to preferDualStack in the services:
* coredns
* ingress-nginx
* metrics-server
* snapshot-validation-webhook

This has no impact on ipv4-only deployments. It just adds the ipv6 address on dual-stack deployments

Issue: https://github.com/rancher/rke2/issues/4776