### PR TITLE
Fix rke2-snapshot-validation-webhook

### DIFF
--- a/packages/rke2-snapshot-validation-webhook/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-snapshot-validation-webhook/generated-changes/patch/Chart.yaml.patch
@@ -6,5 +6,5 @@
 -name: snapshot-validation-webhook
 +name: rke2-snapshot-validation-webhook
  version: 1.7.3
- appVersion: "v6.2.1"
+ appVersion: "v6.2.2"
  icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg

--- a/packages/rke2-snapshot-validation-webhook/package.yaml
+++ b/packages/rke2-snapshot-validation-webhook/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-validation-webhook
 commit: 994dde7e93cda78eaf098e5c39889c95be928b32  # snapshot-validation-webhook-1.7.3
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
When running:
```
1 - PACKAGE=rke2-snapshot-validation-webhook make prepare
2 - PACKAGE=rke2-snapshot-validation-webhook make patch
3 - PACKAGE=rke2-snapshot-validation-webhook make clean
```

There is a change in a patch file. That should not happen. This PR fixes it