### PR TITLE
Fix clusterdns for dualStack

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
@@ -9,7 +9,7 @@
  {{- end -}}
  
  {{/*
-@@ -191,3 +191,44 @@
+@@ -191,3 +191,72 @@
      {{ default "default" .Values.serviceAccount.name }}
  {{- end -}}
  {{- end -}}
@@ -27,9 +27,19 @@
 +*/}}
 +{{- define "clusterDNSServerIP" -}}
 +{{- if .Values.service.clusterIP }}
-+{{- .Values.service.clusterIP }}
++    {{- .Values.service.clusterIP }}
 +{{ else }}
-+{{- coalesce .Values.global.clusterDNS "10.43.0.10" }}
++    {{- $dnsIPs := split "," .Values.global.clusterDNS }}
++    {{- $dnsCount := len $dnsIPs }}
++    {{- if eq $dnsCount 1 }}
++        {{- .Values.global.clusterDNS }}
++    {{- else }}
++        {{- if gt $dnsCount 1 }}
++            {{- $dnsIPs._0 }}
++        {{ else }}
++            {{- "10.43.0.10" }}
++        {{- end }}
++    {{- end }}
 +{{- end }}
 +{{- end }}
 +
@@ -54,3 +64,21 @@
 +{{- printf ",%s" (include "clusterDNSServerIP" .) -}}
 +{{- end }}
 +{{- end }}
++
++{{/*
++Fill the ipFamily correctly
++*/}}
++{{- define "ipFamilyPolicy" -}}
++{{- if .Values.service.ipFamilyPolicy }}
++    {{- .Values.service.ipFamilyPolicy }}
++{{ else }}
++    {{- $dnsIPs := split "," .Values.global.clusterDNS }}
++    {{- $dnsCount := len $dnsIPs }}
++    {{- if gt $dnsCount 1 }}
++        {{- "PreferDualStack" }}
++    {{ else }}
++        {{- "SingleStack" }}
++    {{- end }}
++{{- end }}
++{{- end }}
++    

--- a/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
@@ -1,6 +1,13 @@
 --- charts-original/templates/service.yaml
 +++ charts/templates/service.yaml
-@@ -33,13 +33,7 @@
+@@ -1,4 +1,6 @@
+ {{- if .Values.deployment.enabled }}
++{{- $dnsIPs := split "," .Values.global.clusterDNS }}
++{{- $dnsCount := len $dnsIPs }}
+ ---
+ apiVersion: v1
+ kind: Service
+@@ -33,12 +35,12 @@
      k8s-app: {{ template "coredns.k8sapplabel" . }}
      {{- end }}
      app.kubernetes.io/name: {{ template "coredns.name" . }}
@@ -8,10 +15,22 @@
 -  clusterIP: {{ .Values.service.clusterIP }}
 -  {{- end }}
 -  {{- if .Values.service.clusterIPs }}
--  clusterIPs:
--  {{ toYaml .Values.service.clusterIPs | nindent 4 }}
--  {{- end }}
 +  clusterIP: {{ template "clusterDNSServerIP" . }}
++  {{- if gt $dnsCount 1 }}
+   clusterIPs:
+-  {{ toYaml .Values.service.clusterIPs | nindent 4 }}
++  {{- range $dnsIP := $dnsIPs }}
++  - {{ $dnsIP }}
++  {{- end }}
+   {{- end }}
    {{- if .Values.service.externalIPs }}
    externalIPs:
-   {{- toYaml .Values.service.externalIPs | nindent 4 }}
+@@ -53,7 +55,5 @@
+   ports:
+ {{ include "coredns.servicePorts" . | indent 2 -}}
+   type: {{ default "ClusterIP" .Values.serviceType }}
+-  {{- if .Values.service.ipFamilyPolicy }}
+-  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+-  {{- end }}
++  ipFamilyPolicy: {{ template "ipFamilyPolicy" . }}
+ {{- end }}

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -21,7 +21,7 @@
  # externalIPs: []
  # externalTrafficPolicy: ""
 -# ipFamilyPolicy: ""
-+  ipFamilyPolicy: "PreferDualStack"
++  ipFamilyPolicy: ""
    # The name of the Service
    # If not set, a name is generated using the fullname template
    name: ""

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.24.0/coredns-1.24.0.tgz
-packageVersion: 05
+packageVersion: 06
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
This PR mimics the k3s behaviour:
- If clusterDNS has more than 1 IP, then IPFamily=PreferDualStack. If not IPFamily=SingleStack
- clusterIP will be the first value set in clusterDNS