### PR TITLE
update hardened-cni-plugins to v1.2.0-build20231009

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
@@ -224,7 +224,7 @@
 +portmapPlugin:
 +  image:
 +    repository: "rancher/hardened-cni-plugins"
-+    tag: "v1.2.0-build20230523"
++    tag: "v1.2.0-build20231009"
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.14.2.tgz
-packageVersion: 00
+packageVersion: 01

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -118,7 +118,7 @@ manifests:
 cniplugins:
   image:
     repository: rancher/hardened-cni-plugins
-    tag: v1.2.0-build20230523
+    tag: v1.2.0-build20231009
 
   # skipcnis is a comma separated list of cni binaries to skip from
   # installing.

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Use latest hardened-cni-plugins in rke2-cilium and rke2-multus.

The image is already updated in rke2 build-images script so it could end up missing in the airgap archive.