### PR TITLE
update hardened-multus-cni to v4.0.2-build20231009

### DIFF
--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -20,7 +20,7 @@
 
 image:
   repository: rancher/hardened-multus-cni
-  tag: v4.0.2-build20230811
+  tag: v4.0.2-build20231009
   pullPolicy: IfNotPresent
 
 #imagePullSecrets: []

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
This image is updated in rke2 build-images but not in the chart