### PR TITLE
Allow multus on arm64 nodes

### DIFF
--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -78,7 +78,6 @@ pod:
 labels:
   nodeSelector: 
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
 # Multus configuration
 # For more details, see https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#entrypoint-script-parameters


### PR DESCRIPTION
Multus already supports arm64 but nodeSelector was restricting it to amd64 only