### PR TITLE
add optional dhcp daemonset to rke2-multus

### DIFF
--- a/packages/rke2-multus/charts/templates/daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/daemonSet.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ .Release.Name }}-ds
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{- include "multus.labels" . | indent 4 }}

--- a/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
@@ -1,9 +1,8 @@
----
 {{- if .Values.manifests.dhcpDaemonSet }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: multus-dhcp-ds
+  name: {{ .Release.Name }}-dhcp
   namespace: {{ .Release.Namespace }}
   labels:
 {{- include "multus.labels" . | indent 4 }}

--- a/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
@@ -1,0 +1,62 @@
+---
+{{- if .Values.manifests.dhcpDaemonSet }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: multus-dhcp-ds
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "multus.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+{{- include "multus.labels" . | indent 8 }}
+    spec:
+      hostNetwork: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
+      initContainers:
+      - name: kube-{{ .Chart.Name }}-dhcp-cleanup
+        image: busybox
+        command: ["rm", "-f", "/run/cni/dhcp.sock"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: socketpath
+          mountPath: /host/run/cni
+      containers:
+      - name: kube-{{ .Chart.Name }}-dhcp
+        image: busybox
+        command: ["/opt/cni/bin/dhcp", "daemon"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: binpath
+          mountPath: /opt/cni
+        - name: socketpath
+          mountPath: /run/cni
+        - name: netnspath
+          mountPath: /var/run/netns
+          mountPropagation: HostToContainer
+      volumes:
+        - name: binpath
+          hostPath:
+            path: /opt/cni
+        - name: socketpath
+          hostPath:
+            path: /run/cni
+        - name: netnspath
+          hostPath:
+            path: /run/netns
+{{- end }}

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -108,6 +108,7 @@ manifests:
   configMap: false
   daemonSet: true
   customResourceDefinition: true
+  dhcpDaemonSet: false
 
 #tolerations: []
 

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 03
+packageVersion: 04


### PR DESCRIPTION
This PR adds an optional daemonSet to the multus chart.
It is required to use the dhcp ipam plugin with multus.