### PR TITLE
Fix bug in local-cache when using DualStack

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
@@ -35,7 +35,7 @@
 +        {{- .Values.global.clusterDNS }}
 +    {{- else }}
 +        {{- if gt $dnsCount 1 }}
-+            {{- $dnsIPs._0 }}
++            {{- $dnsIPs._0 -}}
 +        {{ else }}
 +            {{- "10.43.0.10" }}
 +        {{- end }}

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.24.0/coredns-1.24.0.tgz
-packageVersion: 07
+packageVersion: 08
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
When using dualStack,  `{{- $dnsIPs._0 }}` returns a new line which breaks the manifest yaml:
```
args: [ "-localip", "169.254.20.10,10.43.0.10
", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
```
Adding the right `-` removes that new line and the result is correct:
```
args: [ "-localip", "169.254.20.10,10.43.0.10", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" 
```
