### PR TITLE
Use mirrored-library-busybox image

### DIFF
--- a/packages/rke2-metrics-server/generated-changes/patch/templates/tests/test-version.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/templates/tests/test-version.yaml.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/tests/test-version.yaml
++++ charts/templates/tests/test-version.yaml
+@@ -12,7 +12,7 @@
+ spec:
+   containers:
+   - name: wget
+-    image: busybox
++    image: {{ template "system_default_registry" . }}mirrored-library-busybox:1.36.1
+     command: ['/bin/sh']
+     args:
+     - -c

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,3 +1,3 @@
 url: https://charts.helm.sh/stable/packages/metrics-server-2.11.1.tgz
-packageVersion: 11
+packageVersion: 12
 releaseCandidateVersion: 00

--- a/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
@@ -27,7 +27,7 @@ spec:
       nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
       initContainers:
       - name: kube-{{ .Chart.Name }}-dhcp-cleanup
-        image: busybox
+        image: {{ template "system_default_registry" . }}mirrored-library-busybox:1.36.1
         command: ["rm", "-f", "/run/cni/dhcp.sock"]
         securityContext:
           privileged: true
@@ -36,7 +36,7 @@ spec:
           mountPath: /host/run/cni
       containers:
       - name: kube-{{ .Chart.Name }}-dhcp
-        image: busybox
+        image: {{ template "system_default_registry" . }}mirrored-library-busybox:1.36.1
         command: ["/opt/cni/bin/dhcp", "daemon"]
         securityContext:
           privileged: true

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 04
+packageVersion: 05


### PR DESCRIPTION
Use mirrored-library-busybox image for the following charts:
- rke2-metrics-server
- rke2-multus

This will allow us to make the busybox image available in the airgap archive and to use system_default_registry