### PR TITLE
Change the chart name to rke2-flannel

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
@@ -1,0 +1,12 @@
+--- charts-original/Chart.yaml
++++ charts/Chart.yaml
+@@ -3,7 +3,7 @@
+ description: Install Flannel Network Plugin.
+ keywords:
+ - Flannel
+-name: flannel
++name: rke2-flannel
+ sources:
+-- https://github.com/flannel-io/flannel
++- https://github.com/rancher/rke2-charts
+ version: v0.24.0

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,3 +1,4 @@
 url: https://github.com/flannel-io/flannel.git
 subdirectory: chart/kube-flannel
 commit: v0.24.0
+packageVersion: 01


### PR DESCRIPTION
The built chart name is not following the convention that other CNI plugins follow with `rke2-$CNIName`

This PR fixes that