### PR TITLE
Bump harvester-cloud-provider to v0.2.3

### DIFF
--- a/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
+++ b/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
@@ -1,3 +1,3 @@
 workingDir: ""
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.2/harvester-cloud-provider-0.2.2.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.3/harvester-cloud-provider-0.2.3.tgz
 subdirectory: dependency_charts/kube-vip

--- a/packages/harvester-cloud-provider/package.yaml
+++ b/packages/harvester-cloud-provider/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.2/harvester-cloud-provider-0.2.2.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.3/harvester-cloud-provider-0.2.3.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
issue: https://github.com/harvester/harvester/issues/4678 the dependency chart `kube-vip` does not have enough tolerances for all scenarios

solution: add tolerances to kube-vip, and bump charts to upstream