### PR TITLE
Bug: Remove extra right space coreDNS

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
@@ -32,7 +32,7 @@
 +    {{- $dnsIPs := split "," .Values.global.clusterDNS }}
 +    {{- $dnsCount := len $dnsIPs }}
 +    {{- if eq $dnsCount 1 }}
-+        {{- .Values.global.clusterDNS }}
++        {{- .Values.global.clusterDNS -}}
 +    {{- else }}
 +        {{- if gt $dnsCount 1 }}
 +            {{- $dnsIPs._0 -}}

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.24.0/coredns-1.24.0.tgz
-packageVersion: 08
+packageVersion: 09
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Before this PR, when running node-local-dns, we are getting the error:
```
2024/01/23 09:18:45 [FATAL] Error parsing flags - invalid localip specified - "10.43.0.10 ", Exiting
```
The reason is an extra space added to the right of the clusterDNS. This PR fixes it