### PR TITLE
Use windows values and fix mac bug

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/config.yaml
 +++ charts/templates/config.yaml
-@@ -29,13 +29,13 @@
+@@ -29,19 +29,19 @@
      }
    net-conf.json: |
      {
@@ -18,3 +18,20 @@
        "EnableIPv6": true,
  {{- end }}
        "Backend": {
+ {{- if eq .Values.flannel.backend "vxlan" }}
+-{{- if .Values.flannel.backendPort }}
+-        "Port": {{ .Values.flannel.backendPort }},
++{{- if .Values.flannel.vxlanBackendPort }}
++        "Port": {{ .Values.flannel.vxlanBackendPort }},
+ {{- end }}
+ {{- if .Values.flannel.vni }}
+         "VNI": {{ .Values.flannel.vni }},
+@@ -56,7 +56,7 @@
+         "MTU": {{ .Values.flannel.mtu }},
+ {{- end }}
+ {{- if .Values.flannel.macPrefix }}
+-        "MacPrefix": {{ .Values.flannel.macPrefix }},
++        "MacPrefix": {{ .Values.flannel.macPrefix | quote }},
+ {{- end }}
+         "Type": {{ .Values.flannel.backend | quote }}
+ {{- else if eq .Values.flannel.backend "wireguard" }}

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -26,7 +26,7 @@
    # flannel command arguments
    args:
    - "--ip-masq"
-@@ -25,28 +17,35 @@
+@@ -25,28 +17,36 @@
    # Documentation at https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md
    backend: "vxlan"
    # Port used by the backend 0 means default value (VXLAN: 8472, Wireguard: 51821, UDP: 8285)
@@ -40,7 +40,7 @@
    #
    # VXLAN Identifier to be used. On Linux default is 1.
 -  #vni: 1
-+  vni: 1
++  vni: 4096
    # Enable VXLAN Group Based Policy (Default false)
 -  #GBP: false
 +  GBP: false
@@ -50,6 +50,7 @@
    # MAC prefix to be used on Windows. (Defaults is 0E-2A)
 -  #macPrefix: "0E-2A"
 +  macPrefix: "0E-2A"
++  vxlanBackendPort: 4789
    #
    # Wireguard Configs:
    #

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.24.2/flannel.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
This PR:
* fixes a bug in flannel chart related to `macPrefix`
* updates values to use as default what vxlan windows interface is expecting (as flannel cni plugin will be mainly used for windows)