### PR TITLE
Bump coredns versions

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/Chart.yaml.patch
@@ -1,9 +1,9 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -16,7 +16,7 @@
- - name: mrueg
+@@ -19,7 +19,7 @@
  - name: haad
- - name: HagaiBarel
+ - name: hagaibarel
+ - name: shubham-cmyk
 -name: coredns
 +name: rke2-coredns
  sources:

--- a/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -24,7 +24,7 @@
+@@ -57,7 +57,7 @@
  Allow k8s-app label to be overridden
  */}}
  {{- define "coredns.k8sapplabel" -}}
@@ -9,7 +9,7 @@
  {{- end -}}
  
  {{/*
-@@ -191,3 +191,72 @@
+@@ -224,3 +224,72 @@
      {{ default "default" .Values.serviceAccount.name }}
  {{- end -}}
  {{- end -}}

--- a/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/configmap.yaml
 +++ charts/templates/configmap.yaml
-@@ -31,7 +31,7 @@
+@@ -23,7 +23,7 @@
      {{- if .port }}:{{ .port }} {{ end -}}
      {
        {{- range .plugins }}

--- a/packages/rke2-coredns/generated-changes/patch/templates/deployment-autoscaler.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/deployment-autoscaler.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/deployment-autoscaler.yaml
 +++ charts/templates/deployment-autoscaler.yaml
-@@ -74,7 +74,7 @@
+@@ -66,7 +66,7 @@
        {{- end }}
        containers:
        - name: autoscaler

--- a/packages/rke2-coredns/generated-changes/patch/templates/deployment.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/deployment.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/deployment.yaml
 +++ charts/templates/deployment.yaml
-@@ -56,9 +56,6 @@
+@@ -48,9 +48,6 @@
  {{- end }}
        annotations:
          checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -10,9 +10,9 @@
  {{- if .Values.podAnnotations }}
  {{ toYaml .Values.podAnnotations | indent 8 }}
  {{- end }}
-@@ -84,9 +81,15 @@
+@@ -76,9 +73,15 @@
        topologySpreadConstraints:
- {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+ {{ tpl (toYaml .Values.topologySpreadConstraints) $ | indent 8 }}
        {{- end }}
 -      {{- if .Values.tolerations }}
 +      {{- if or (.Values.isClusterService) (.Values.tolerations) }}
@@ -27,7 +27,7 @@
        {{- end }}
        {{- if .Values.nodeSelector }}
        nodeSelector:
-@@ -98,7 +101,7 @@
+@@ -90,7 +93,7 @@
        {{- end }}
        containers:
        - name: "coredns"

--- a/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/service.yaml.patch
@@ -7,7 +7,7 @@
  ---
  apiVersion: v1
  kind: Service
-@@ -33,12 +35,12 @@
+@@ -25,12 +27,12 @@
      k8s-app: {{ template "coredns.k8sapplabel" . }}
      {{- end }}
      app.kubernetes.io/name: {{ template "coredns.name" . }}
@@ -25,7 +25,7 @@
    {{- end }}
    {{- if .Values.service.externalIPs }}
    externalIPs:
-@@ -53,7 +55,5 @@
+@@ -45,7 +47,5 @@
    ports:
  {{ include "coredns.servicePorts" . | indent 2 -}}
    type: {{ default "ClusterIP" .Values.serviceType }}

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -8,11 +8,11 @@
 +  repository: rancher/hardened-coredns
    # Overrides the image tag whose default is the chart appVersion.
 -  tag: ""
-+  tag: "v1.10.1-build20231009"
++  tag: "v1.11.1-build20240123"
    pullPolicy: IfNotPresent
    ## Optionally specify an array of imagePullSecrets.
    ## Secrets must be manually created in the namespace.
-@@ -54,21 +54,20 @@
+@@ -50,21 +50,20 @@
  
  service:
  # clusterIP: ""
@@ -37,7 +37,7 @@
    annotations: {}
  
  rbac:
-@@ -84,7 +83,7 @@
+@@ -80,7 +79,7 @@
  isClusterService: true
  
  # Optional priority class to be used for the coredns pods. Used for autoscaler if autoscaler.priorityClassName not set.
@@ -46,7 +46,7 @@
  
  # Configure the pod level securityContext.
  podSecurityContext: {}
-@@ -172,17 +171,16 @@
+@@ -168,17 +167,16 @@
    successThreshold: 1
  
  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
@@ -73,8 +73,8 @@
 +          - kube-dns
  
  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#topologyspreadconstraint-v1-core
- # for example:
-@@ -197,16 +195,17 @@
+ # and supports Helm templating.
+@@ -202,16 +200,17 @@
  
  # Node labels for pod assignment
  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -100,7 +100,7 @@
  
  # https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
  podDisruptionBudget: {}
-@@ -281,7 +280,7 @@
+@@ -293,7 +292,7 @@
  # See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
  autoscaler:
    # Enabled the cluster-proportional-autoscaler
@@ -109,18 +109,18 @@
  
    # Number of cores in the cluster per coredns replica
    coresPerReplica: 256
-@@ -302,8 +301,8 @@
+@@ -317,8 +316,8 @@
    #   - --nodelabels=topology.kubernetes.io/zone=us-east-1a
  
    image:
 -    repository: registry.k8s.io/cpa/cluster-proportional-autoscaler
 -    tag: "1.8.5"
 +    repository: rancher/hardened-cluster-autoscaler
-+    tag: "v1.8.6-build20231009"
++    tag: "v1.8.10-build20240124"
      pullPolicy: IfNotPresent
      ## Optionally specify an array of imagePullSecrets.
      ## Secrets must be manually created in the namespace.
-@@ -321,19 +320,26 @@
+@@ -336,19 +335,26 @@
  
    # Node labels for pod assignment
    # Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -153,7 +153,7 @@
  
    # Options for autoscaler configmap
    configmap:
-@@ -345,8 +351,8 @@
+@@ -360,8 +366,8 @@
    livenessProbe:
      enabled: true
      initialDelaySeconds: 10
@@ -164,7 +164,7 @@
      failureThreshold: 3
      successThreshold: 1
  
-@@ -355,3 +361,21 @@
+@@ -376,3 +382,21 @@
    name: ""
    ## Annotations for the coredns deployment
    annotations: {}
@@ -177,10 +177,10 @@
 +  ipvs: false
 +  image:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.22.20-build20231010"
++    tag: "1.22.28-build20240125"
 +  initimage:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.22.20-build20231010"
++    tag: "1.22.28-build20240125"
 +  nodeSelector:
 +    kubernetes.io/os: linux
 +

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,4 +1,2 @@
-url: https://github.com/coredns/helm/releases/download/coredns-1.24.0/coredns-1.24.0.tgz
-packageVersion: 09
-# This repository does not use releaseCandidateVersions, so you can leave this as 00.
-releaseCandidateVersion: 00
+url: https://github.com/coredns/helm/releases/download/coredns-1.29.0/coredns-1.29.0.tgz
+packageVersion: 00


### PR DESCRIPTION
It updates the version of the following elements:
* chart
* rancher/hardened-cluster-autoscaler (now using scratch as base image)
* rancher/hardened-dns-node-cache (now using bci-busybox as base image)
* rancher/hardened-coredns (now using scratch as base image)