### PR TITLE
Added updatecli and Canal update automation.

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,55 @@
+name: "Updatecli: Dependency Management"
+
+on:
+  schedule:
+    # Runs at 06 PM UTC
+    - cron: '0 18 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main-source'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Delete leftover UpdateCLI branches
+        run: |
+          gh pr list \
+            --search "is:closed is:pr head:updatecli_" \
+            --json headRefName \
+            --jq ".[].headRefName" | sort -u > closed_prs_branches.txt
+          gh pr list \
+            --search "is:open is:pr head:updatecli_" \
+            --json headRefName \
+            --jq ".[].headRefName" | sort -u > open_prs_branches.txt
+          for branch in $(comm -23 closed_prs_branches.txt open_prs_branches.txt); do
+            if (git ls-remote --exit-code --heads origin "$branch"); then
+              echo "Deleting leftover UpdateCLI branch - $branch";
+              git push origin --delete "$branch";
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply Updatecli
+        # Never use '--debug' option, because it might leak the access tokens.
+        run: "updatecli apply --clean --config ./updatecli/updatecli.d/ --values ./updatecli/values.yaml"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/scripts/update-canal.sh
+++ b/updatecli/scripts/update-canal.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+if [ -n "$FLANNEL_VERSION" ]; then
+	current_flannel_version=$(yq '.flannel.image.tag' packages/rke2-canal/charts/values.yaml)
+	if [ "$current_flannel_version" != "$FLANNEL_VERSION" ]; then
+		echo "Updating flannel image to $FLANNEL_VERSION"
+		yq -i ".flannel.image.tag = \"$FLANNEL_VERSION\"" packages/rke2-canal/charts/values.yaml
+		package_version=$(yq '.packageVersion' packages/rke2-canal/package.yaml)
+		new_version=$(printf "%02d" $(($package_version + 1)))
+		yq -i ".packageVersion = $new_version" packages/rke2-canal/package.yaml
+	fi
+fi
+if [ -n "$CALICO_VERSION" ]; then
+	current_calico_version=$(yq '.calico.cniImage.tag' packages/rke2-canal/charts/values.yaml)
+	if [ "$current_calico_version" != "$CALICO_VERSION" ]; then
+		echo "Updating flannel image to $CALICO_VERSION"
+		yq -i ".calico.cniImage.tag = \"$CALICO_VERSION\" |
+			.calico.flexvolImage.tag = \"$CALICO_VERSION\" |
+			.calico.kubeControllerImage.tag = \"$CALICO_VERSION\"" packages/rke2-canal/charts/values.yaml
+		app_version=$(echo "$CALICO_VERSION" | grep -Eo 'v[0-9]+.[0-9]+.[0-9+]')
+		yq -i ".version = \"$CALICO_VERSION\" |
+			.appVersion = \"$app_version\"" packages/rke2-canal/charts/Chart.yaml
+		yq -i ".packageVersion = 00" packages/rke2-canal/package.yaml
+	fi
+fi

--- a/updatecli/updatecli.d/updatecanal.yaml
+++ b/updatecli/updatecli.d/updatecanal.yaml
@@ -1,0 +1,87 @@
+---
+name: "Update Canal version" 
+
+sources:
+  flannel:
+    name: Get flannel version
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-flannel
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        latest: true
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+  calico:
+    name: Get calico version
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-calico
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        latest: true
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+
+targets:
+  flannelImage:
+    name: "Bump to latest flannel version on the chart"
+    kind: shell
+    scmid: default
+    sourceid: flannel
+    spec:
+      command: 'updatecli/scripts/update-canal.sh'
+      environments:
+        - name: FLANNEL_VERSION
+          value: '{{ source "flannel" }}'
+  calicoImage:
+    name: "Bump to latest calico version on the chart"
+    kind: shell
+    scmid: default
+    sourceid: calico
+    dependson:
+      - flannelImage
+    spec:
+      command: 'updatecli/scripts/update-canal.sh'
+      environments:
+        - name: CALICO_VERSION
+          value: '{{ source "calico" }}'
+
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.username }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+  default:
+    title: 'Bump flannel version to {{ source "flannel" }} and Calico to {{ source "calico" }} on Canal'
+    kind: github/pullrequest
+    spec:
+      automerge: false
+      labels:
+        - chore
+        - skip-changelog
+        - status/auto-created 
+    scmid: default

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "github-actions[bot]"
+  email: "41898282+github-actions[bot]@users.noreply.github.com"
+  username: "UPDATECLI_GITHUB_ACTOR"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  repository: "rke2-charts"
+  branch: "main-source"
+  owner: "rancher"


### PR DESCRIPTION
This PR adds updatecli for version update automation with the update for the Canal charts.
The update for the Canal chart checks if a new image is released for flannel (https://github.com/rancher/image-build-flannel) and Calico (https://github.com/rancher/image-build-calico) and updates the image tag version.
`packageVersion` and the chart `version` are updated accordingly.