### PR TITLE
Bump whereabouts and multus versions

### DIFF
--- a/packages/rke2-multus/charts/Chart.yaml
+++ b/packages/rke2-multus/charts/Chart.yaml
@@ -14,4 +14,4 @@ name: rke2-multus
 sources:
 - https://github.com/intel/multus-cni
 type: application
-version: v4.0.2-build20230811
+version: v4.0.2-build20240208

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -20,7 +20,7 @@
 
 image:
   repository: rancher/hardened-multus-cni
-  tag: v4.0.2-build20231009
+  tag: v4.0.2-build20240208
   pullPolicy: IfNotPresent
 
 #imagePullSecrets: []
@@ -119,7 +119,7 @@ manifests:
 cniplugins:
   image:
     repository: rancher/hardened-cni-plugins
-    tag: v1.2.0-build20231009
+    tag: v1.4.0-build20240122
 
   # skipcnis is a comma separated list of cni binaries to skip from
   # installing.

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 08
+packageVersion: 00

--- a/packages/rke2-whereabouts/charts/values.yaml
+++ b/packages/rke2-whereabouts/charts/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: rancher/hardened-whereabouts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.6.3-build20240109
+  tag: v0.6.3-build20240208
 
 updateStrategy: RollingUpdate
 imagePullSecrets: []


### PR DESCRIPTION
Bump versions of:
* Whereabouts
* Multus
* cni-plugins

The main change in those image versions is that we are not using bci-base anymore but a smaller base image: scratch or bci-busybox