### PR TITLE
Fixed CSI node config on Calico

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -31,7 +31,7 @@
  
  certs:
    node:
-@@ -51,11 +64,28 @@
+@@ -51,11 +64,30 @@
  
  # Image and registry configuration for the tigera/operator pod.
  tigeraOperator:
@@ -46,6 +46,8 @@
    tag: v3.27.0
  
 -kubeletVolumePluginPath: /var/lib/kubelet
++kubeletVolumePluginPath: "None"
++
 +global:
 +  systemDefaultRegistry: ""
 +  clusterCIDRv4: ""

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.27.0/tigera-operator-v3.27.0.tgz
-packageVersion: 01
+packageVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Set `kubeletVolumePluginPath` to None to remove deployment of csi-node.