### PR TITLE
Uncomment some multus options

### DIFF
--- a/packages/rke2-multus/charts/templates/daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/daemonSet.yaml
@@ -73,12 +73,6 @@ spec:
         {{- if .Values.config.cni_conf.cniVersion }}
         - "--cni-version={{ .Values.config.cni_conf.cniVersion }}"
         {{- end }}
-        {{- if .Values.config.cni_conf.confDir }}
-        - "--cni-conf-dir=={{ .Values.config.cni_conf.confDir }}"
-        {{- end }}
-        {{- if .Values.config.cni_conf.binDir }}
-        - "--cni-bin-dir={{ .Values.config.cni_conf.binDir }}"
-        {{- end }}
         {{- if .Values.config.cni_conf.multusAutoconfigDir }}
         - "--multus-autoconfig-dir={{ .Values.config.cni_conf.multusAutoconfigDir }}"
         {{- end }}
@@ -130,10 +124,10 @@ spec:
       volumes:
         - name: cni
           hostPath:
-            path: /etc/cni/net.d
+            path: {{ .Values.config.cni_conf.confDir }}
         - name: cnibin
           hostPath:
-            path: /opt/cni/bin
+            path: {{ .Values.config.cni_conf.binDir }}
         {{- if .Values.manifests.configMap }}
         - name: multus-cfg
           configMap:

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -84,8 +84,8 @@ labels:
 # For more details, see https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#entrypoint-script-parameters
 config:
   cni_conf:
-    #confDir: /etc/cni/net.d
-    #binDir: /opt/cni/bin
+    confDir: /etc/cni/net.d
+    binDir: /opt/cni/bin
     #namespaceIsolation: false
     #globalNamespaces: default,foo,bar
     #skipMultusBinaryCopy: false
@@ -93,7 +93,7 @@ config:
     multusConfFile: auto #or specify a file to be copied on each node
     #The following options can be used only when multusConfFile=auto
     #multusAutoconfigDir: /host/etc/cni/net.d
-    #kubeconfig: /etc/cni/net.d/multus.d/multus.kubeconfig
+    kubeconfig: /etc/cni/net.d/multus.d/multus.kubeconfig
     #masterCniFilename:
     #logFile: /var/log/multus.log
     #logLevel: panic

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
We need this to make it work in k3s

I removed the variables "confDir:" and "binDir:" from the daemonset command becuase they don't make sense there. They make sense in the volume definition, so I placed them there