### PR TITLE
Remove `kubernetes.io/arch` nodeSelector

### DIFF
--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -76,9 +76,8 @@ pod:
   #      - chart-example.local
 
 labels:
-  nodeSelector: 
+  nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
 
 # Multus configuration
 # For more details, see https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#entrypoint-script-parameters

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 01
+packageVersion: 02

--- a/packages/rke2-whereabouts/charts/values.yaml
+++ b/packages/rke2-whereabouts/charts/values.yaml
@@ -38,7 +38,7 @@ resources:
     memory: "100Mi"
 
 nodeSelector:
-  kubernetes.io/arch: amd64
+  kubernetes.io/os: linux
 
 tolerations:
   - operator: Exists

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,5 +1,5 @@
 url: local
 workingDir: charts
-packageVersion: 01
+packageVersion: 02
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
Adapt the multus and whereabouts charts to allow arm64 based images

Also adds a `kubernetes.io/os: linux` nodeSelector to the whereabouts chart

Issue: https://github.com/rancher/rke2/issues/5538