### PR TITLE
Allow IPTables mark mask to be configurable for canal

### DIFF
--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -166,6 +166,8 @@ spec:
               value: {{ .Values.calico.felixFailsafeInboundHostPorts | quote }}
             - name: FELIX_FAILSAFEOUTBOUNDHOSTPORTS
               value: {{ .Values.calico.felixFailsafeOutboundHostPorts | quote }}
+            - name: FELIX_IPTABLESMARKMASK
+              value: {{ .Values.calico.felixIptablesMarkMask | quote }}
 {{- if coalesce .Values.global.clusterCIDRv4 .Values.podCidr }}
             # The method to use to autodetect the IPv4 address for this host.
             - name: IP_AUTODETECTION_METHOD

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -99,6 +99,8 @@ calico:
   felixPrometheusMetricsEnabled: true
   # Disable XDP Acceleration as we do not support it with our ubi7 base image
   felixXDPEnabled: false
+  # Configure the mask that felix selects its iptables mark bits from
+  felixIptablesMarkMask: "0xffff0000"
   # Whether or not to masquerade traffic to destinations not within
   # the pod network.
   masquerade: true

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
Expose FELIX_IPTABLESMARKMASK to the canal charts to make it configurable. 

Related Issue: https://github.com/tailscale/tailscale/issues/591

> Calico takes the upper 16 bits of the netfilter packet mark for itself (aka 0xffff0000). This conflicts with Tailscale's use of 0x40000 and 0x80000, so trying to use Calico and Tailscale on the same Kubernetes machines will probably break Tailscale, or Calico, or both.