### PR TITLE
Update flannel to v0.24.4

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
@@ -9,4 +9,4 @@
  sources:
 -- https://github.com/flannel-io/flannel
 +- https://github.com/rancher/rke2-charts
- version: v0.24.2
+ version: v0.24.4

--- a/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/config.yaml
 +++ charts/templates/config.yaml
-@@ -29,19 +29,19 @@
+@@ -29,13 +29,13 @@
      }
    net-conf.json: |
      {
@@ -18,20 +18,3 @@
        "EnableIPv6": true,
  {{- end }}
        "Backend": {
- {{- if eq .Values.flannel.backend "vxlan" }}
--{{- if .Values.flannel.backendPort }}
--        "Port": {{ .Values.flannel.backendPort }},
-+{{- if .Values.flannel.vxlanBackendPort }}
-+        "Port": {{ .Values.flannel.vxlanBackendPort }},
- {{- end }}
- {{- if .Values.flannel.vni }}
-         "VNI": {{ .Values.flannel.vni }},
-@@ -56,7 +56,7 @@
-         "MTU": {{ .Values.flannel.mtu }},
- {{- end }}
- {{- if .Values.flannel.macPrefix }}
--        "MacPrefix": {{ .Values.flannel.macPrefix }},
-+        "MacPrefix": {{ .Values.flannel.macPrefix | quote }},
- {{- end }}
-         "Type": {{ .Values.flannel.backend | quote }}
- {{- else if eq .Values.flannel.backend "wireguard" }}

--- a/packages/rke2-flannel/generated-changes/patch/templates/daemonset.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/templates/daemonset.yaml.patch
@@ -1,7 +1,7 @@
 --- charts-original/templates/daemonset.yaml
 +++ charts/templates/daemonset.yaml
-@@ -32,19 +32,13 @@
-         effect: NoSchedule
+@@ -33,19 +33,13 @@
+       {{- end }}
        serviceAccountName: flannel
        initContainers:
 -      - name: install-cni-plugin
@@ -24,7 +24,7 @@
          command:
          - cp
          args:
-@@ -58,7 +52,7 @@
+@@ -59,7 +53,7 @@
            mountPath: /etc/kube-flannel/
        containers:
        - name: kube-flannel
@@ -33,7 +33,7 @@
          command:
          - "/opt/bin/flanneld"
          {{- range .Values.flannel.args }}
-@@ -97,6 +91,7 @@
+@@ -98,6 +92,7 @@
        - name: cni-plugin
          hostPath:
            path: /opt/cni/bin

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1,21 +1,13 @@
+@@ -1,21 +1,12 @@
  ---
 -global:
 -  imagePullSecrets:
@@ -10,66 +10,37 @@
 -# chosen from this range.
 -podCidr: "10.244.0.0/16"
 -podCidrv6: ""
- 
+-
  flannel:
    # kube-flannel image
    image:
 -    repository: docker.io/flannel/flannel
--    tag: v0.24.2
+-    tag: v0.24.4
 +    repository: rancher/hardened-flannel
-+    tag: v0.24.2-build20240122
++    tag: v0.24.4-build20240321
    image_cni:
 -    repository: docker.io/flannel/flannel-cni-plugin
--    tag: v1.2.0
+-    tag: v1.4.0-flannel1
 +    repository: rancher/hardened-cni-plugins
-+    tag: v1.4.0-build20240122
++    tag: v1.4.1-build20240322
    # flannel command arguments
    args:
    - "--ip-masq"
-@@ -25,28 +17,36 @@
+@@ -25,7 +16,7 @@
    # Documentation at https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md
    backend: "vxlan"
    # Port used by the backend 0 means default value (VXLAN: 8472, Wireguard: 51821, UDP: 8285)
 -  #backendPort: 0
-+  backendPort: 0
++  backendPort: 4789
    # MTU to use for outgoing packets (VXLAN and Wiregurad) if not defined the MTU of the external interface is used.
--  #mtu: 1500 
-+  mtu: 1500 
+   # mtu: 1500
    #
-   # VXLAN Configs:
-   #
-   # VXLAN Identifier to be used. On Linux default is 1.
--  #vni: 1
-+  vni: 4096
-   # Enable VXLAN Group Based Policy (Default false)
--  #GBP: false
-+  GBP: false
-   # Enable direct routes (default is false)
--  #directRouting: false
-+  directRouting: false
-   # MAC prefix to be used on Windows. (Defaults is 0E-2A)
--  #macPrefix: "0E-2A"
-+  macPrefix: "0E-2A"
-+  vxlanBackendPort: 4789
-   #
-   # Wireguard Configs:
-   #
-   # UDP listen port used with IPv6
--  #backendPortv6: 51821
-+  backendPortv6: 51821
-   # Pre shared key to use
--  #psk: 0
-+  psk: 0
-   # IP version to use on Wireguard
--  #tunnelMode: "separate"
-+  tunnelMode: "separate"
-   # Persistent keep interval to use
--  #keepaliveInterval: 0
-+  keepaliveInterval: 0
-+  #
+@@ -64,3 +55,8 @@
+   - key: "node-role.kubernetes.io/etcd"
+     operator: "Exists"
+     effect: "NoExecute"
 +
 +global:
 +  systemDefaultRegistry: ""
 +  clusterCIDRv4: ""
 +  clusterCIDRv6: ""
-+

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/flannel-io/flannel/releases/download/v0.24.2/flannel.tgz
-packageVersion: 01
+url: https://github.com/flannel-io/flannel/releases/download/v0.24.4/flannel.tgz
+packageVersion: 00


### PR DESCRIPTION
This PR does a couple more things:
* Does not uncomment the values.yaml variables
* Removes the vxlanPortBackend variables and uses the backendPort as upstream does
* Updates rancher/hardened-cni-plugins to 0.4.1