### PR TITLE
Remove the -build suffix in Multus Chart

### DIFF
--- a/packages/rke2-multus/charts/Chart.yaml
+++ b/packages/rke2-multus/charts/Chart.yaml
@@ -14,4 +14,4 @@ name: rke2-multus
 sources:
 - https://github.com/intel/multus-cni
 type: application
-version: v4.0.2-build20240208
+version: v4.0.2


### PR DESCRIPTION
If the chart uses the -build suffix it is considered as prerelease and it does not get available via the normal helm repo commands