### PR TITLE
Add cni path config in whereabouts to make it work in k3s

### DIFF
--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 02
+packageVersion: 03

--- a/packages/rke2-whereabouts/charts/templates/daemonset.yaml
+++ b/packages/rke2-whereabouts/charts/templates/daemonset.yaml
@@ -67,10 +67,10 @@ spec:
       volumes:
         - name: cnibin
           hostPath:
-            path: /opt/cni/bin
+            path: {{ .Values.cniConf.binDir }}
         - name: cni-net-dir
           hostPath:
-            path: /etc/cni/net.d
+            path: {{ .Values.cniConf.confDir }}
         - name: cron-scheduler-configmap
           configMap:
             name: {{ include "whereabouts.fullname" . }}-config

--- a/packages/rke2-whereabouts/charts/values.yaml
+++ b/packages/rke2-whereabouts/charts/values.yaml
@@ -46,5 +46,9 @@ tolerations:
 
 affinity: {}
 
+cniConf:
+  confDir: /etc/cni/net.d
+  binDir: /opt/cni/bin
+
 global:
   systemDefaultRegistry: ""

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,5 +1,5 @@
 url: local
 workingDir: charts
-packageVersion: 02
+packageVersion: 03
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
The CNI binaries and CNI config files do not use the default paths in k3s, therefore, we need a way to configure those parameters if we want to use whereabouts

Multus version must be incremented because it embeds whereabouts