### PR TITLE
Use the provided cni bin directory in the DHCP daemonset of Multus

### DIFF
--- a/packages/rke2-multus/charts/templates/daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/daemonSet.yaml
@@ -41,11 +41,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
+      {{- with .Values.tolerations }}
       tolerations:
-      - operator: Exists
-        effect: NoSchedule
-      - operator: Exists
-        effect: NoExecute
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       initContainers:
       - name: cni-plugins

--- a/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
@@ -24,6 +24,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
       initContainers:
       - name: kube-{{ .Chart.Name }}-dhcp-cleanup
@@ -42,7 +46,7 @@ spec:
           privileged: true
         volumeMounts:
         - name: binpath
-          mountPath: /opt/cni
+          mountPath: /opt/cni/bin
         - name: socketpath
           mountPath: /run/cni
         - name: netnspath
@@ -51,7 +55,7 @@ spec:
       volumes:
         - name: binpath
           hostPath:
-            path: /opt/cni
+            path: {{ .Values.config.cni_conf.binDir }}
         - name: socketpath
           hostPath:
             path: /run/cni

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -109,7 +109,11 @@ manifests:
   customResourceDefinition: true
   dhcpDaemonSet: false
 
-#tolerations: []
+tolerations:
+- operator: Exists 
+  effect: NoSchedule 
+- operator: Exists 
+  effect: NoExecute 
 
 #affinity: {}
 

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 03
+packageVersion: 04


### PR DESCRIPTION
The DHCP daemonset of multus is not reading the cni bin dir, which makes it unusable if the user changes it. This PR fixes that