### PR TITLE
Added Calico update chart with updatecli

### DIFF
--- a/updatecli/scripts/update-calico.sh
+++ b/updatecli/scripts/update-calico.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+if [ -n "$CALICO_VERSION" ]; then
+	current_calico_version=$(yq '.version' packages/rke2-calico/templates/crd-template/Chart.yaml)
+	if [ "$current_calico_version" != "$CALICO_VERSION" ]; then
+		echo "Updating Calico chart to $CALICO_VERSION"
+		mkdir workdir
+		wget -P workdir/ https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz
+		tar --directory=workdir -xf workdir/tigera-operator-$CALICO_VERSION.tgz tigera-operator/values.yaml
+		current_tigera_operator_version=$(yq '.tigeraOperator.version' workdir/tigera-operator/values.yaml)
+		rm -fr workdir
+		sed -i "s/ version: .*/ version: $CALICO_VERSION/g" packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
+		sed -i "s/   version: .*/   version: $current_tigera_operator_version/g" packages/rke2-calico/generated-changes/patch/values.yaml.patch
+		sed -i "s/   tag: .*/   tag: $CALICO_VERSION/g" packages/rke2-calico/generated-changes/patch/values.yaml.patch
+		yq -i ".version = \"$CALICO_VERSION\"" packages/rke2-calico/templates/crd-template/Chart.yaml
+		yq -i ".url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz\" |
+			.packageVersion = 00" packages/rke2-calico/package.yaml
+		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make prepare
+		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make patch
+		make clean
+	fi
+fi

--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -1,0 +1,54 @@
+---
+name: "Update Calico version" 
+
+sources:
+  calico:
+    name: Get calico version
+    kind: githubrelease
+    spec:
+      owner: projectcalico
+      repository: calico
+      token: '{{ requiredEnv .github.token }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: latest
+
+targets:
+  calicoImage:
+    name: "Bump to latest calico version on the chart"
+    kind: shell
+    scmid: default
+    sourceid: calico
+    spec:
+      command: 'updatecli/scripts/update-calico.sh'
+      environments:
+        - name: CALICO_VERSION
+          value: '{{ source "calico" }}'
+
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.username }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+  default:
+    title: 'Update Calico version to {{ source "calico" }}'
+    kind: github/pullrequest
+    spec:
+      automerge: false
+      labels:
+        - chore
+        - skip-changelog
+        - status/auto-created 
+    scmid: default


### PR DESCRIPTION
this PR adds a new updatecli yaml that checks if there is a new calico version, updates it on the chart and creates a new PR.
This only works in case there aren't updates on the calico chart that have conflicts with our. In case of conflicts a manual update is required.