### PR TITLE
Add the addon-resizer to the metrics-server chart

### DIFF
--- a/packages/rke2-metrics-server/generated-changes/patch/templates/deployment.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/templates/deployment.yaml.patch
@@ -1,11 +1,20 @@
 --- charts-original/templates/deployment.yaml
 +++ charts/templates/deployment.yaml
+@@ -59,7 +59,7 @@
+           securityContext:
+             {{- toYaml . | nindent 12 }}
+           {{- end }}
+-          image: {{ include "metrics-server.image" . }}
++          image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+           imagePullPolicy: {{ .Values.image.pullPolicy }}
+           args:
+             - {{ printf "--secure-port=%d" (int .Values.containerPort) }}
 @@ -100,7 +100,7 @@
            securityContext:
              {{- toYaml . | nindent 12 }}
            {{- end }}
 -          image: {{ include "metrics-server.addonResizer.image" . }}
-+          image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
++          image: {{ template "system_default_registry" . }}{{ .Values.addonResizer.image.repository }}:{{ .Values.addonResizer.image.tag }}
            env:
              - name: MY_POD_NAME
                valueFrom:

--- a/packages/rke2-metrics-server/generated-changes/patch/templates/service.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/templates/service.yaml.patch
@@ -4,6 +4,6 @@
        port: {{ .Values.service.port }}
        protocol: TCP
        targetPort: https
-+      ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
++  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
    selector:
      {{- include "metrics-server.selectorLabels" . | nindent 4 }}

--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -20,6 +20,17 @@
    #  Add these labels to have metrics-server show up in `kubectl cluster-info`
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
+@@ -128,8 +129,8 @@
+ addonResizer:
+   enabled: false
+   image:
+-    repository: registry.k8s.io/autoscaling/addon-resizer
+-    tag: 1.8.20
++    repository: rancher/hardened-addon-resizer
++    tag: 1.8.20-build20240410
+   securityContext:
+     allowPrivilegeEscalation: false
+     readOnlyRootFilesystem: true
 @@ -180,7 +181,8 @@
  
  extraVolumes: []

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.0/metrics-server-3.12.0.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
The new chart of metrics server includes a new optional container called addon-resizer. This PR points to its hardened image