### PR TITLE
Make kube-flannel container privileged

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/templates/daemonset.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/templates/daemonset.yaml.patch
@@ -33,6 +33,15 @@
          command:
          - "/opt/bin/flanneld"
          {{- range .Values.flannel.args }}
+@@ -70,7 +64,7 @@
+             cpu: "100m"
+             memory: "50Mi"
+         securityContext:
+-          privileged: false
++          privileged: true
+           capabilities:
+             add: ["NET_ADMIN", "NET_RAW"]
+         env:
 @@ -98,6 +92,7 @@
        - name: cni-plugin
          hostPath:

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.25.1/flannel.tgz
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
kube-flannel container is not privileged and that creates issues with OSs that use selinux. This PR changes following along what other CNI plugins do 