### PR TITLE
Restore legacy app label to metrics-server pods

### DIFF
--- a/packages/rke2-metrics-server/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,6 +1,14 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -100,3 +100,11 @@
+@@ -49,6 +49,7 @@
+ Selector labels
+ */}}
+ {{- define "metrics-server.selectorLabels" -}}
++app: {{ include "metrics-server.name" . }}
+ app.kubernetes.io/name: {{ include "metrics-server.name" . }}
+ app.kubernetes.io/instance: {{ .Release.Name }}
+ {{- end }}
+@@ -100,3 +101,11 @@
      {{- print "policy/v1beta1" -}}
    {{- end -}}
  {{- end -}}

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.0/metrics-server-3.12.0.tgz
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Ref:
* https://github.com/rancher/rke2/issues/5848