### PR TITLE
bump harvester-cloud-provider to v0.2.4

### DIFF
--- a/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
+++ b/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
@@ -1,3 +1,3 @@
 workingDir: ""
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.3/harvester-cloud-provider-0.2.3.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.4/harvester-cloud-provider-0.2.4.tgz
 subdirectory: dependency_charts/kube-vip

--- a/packages/harvester-cloud-provider/package.yaml
+++ b/packages/harvester-cloud-provider/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.3/harvester-cloud-provider-0.2.3.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.4/harvester-cloud-provider-0.2.4.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
harvester-cloud-provider 0.2.4 is the latest release;
it has also been merged to rancher-charts per https://github.com/rancher/charts/pull/3576

Harvester related issues:

https://github.com/harvester/harvester/issues/4947
https://github.com/harvester/harvester/issues/5247
https://github.com/harvester/charts/pull/230