### PR TITLE
Fix updatecli scripts

### DIFF
--- a/updatecli/scripts/update-calico.sh
+++ b/updatecli/scripts/update-calico.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 if [ -n "$CALICO_VERSION" ]; then
 	current_calico_version=$(yq '.version' packages/rke2-calico/templates/crd-template/Chart.yaml)
 	if [ "$current_calico_version" != "$CALICO_VERSION" ]; then

--- a/updatecli/scripts/update-canal.sh
+++ b/updatecli/scripts/update-canal.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 if [ -n "$FLANNEL_VERSION" ]; then
 	current_flannel_version=$(yq '.flannel.image.tag' packages/rke2-canal/charts/values.yaml)
 	if [ "$current_flannel_version" != "$FLANNEL_VERSION" ]; then

--- a/updatecli/scripts/update-cilium.sh
+++ b/updatecli/scripts/update-cilium.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
+set -eu
 if [ -n "$CILIUM_VERSION" ]; then
 	current_cilium_version=$(sed -nr 's/^\ version: ('[0-9]+.[0-9]+.[0-9]+')/\1/p' packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch)
 	if [ "v$current_cilium_version" != "$CILIUM_VERSION" ]; then
 		echo "Updating Cilium chart to $CILIUM_VERSION"
-		cilium_major=$(echo "$CILIUM_VERSION" | grep -Eo '[0-9]+.[0-9]+')
 		cilium_num_version=$(echo "$CILIUM_VERSION" | grep -Eo '[0-9]+.[0-9]+.[0-9]+')
 		mkdir workdir
 		sed -i "s/ appVersion: .*/ appVersion: $cilium_num_version/g" packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch
-		sed -i "s/-icon: .*/-icon: https:\/\/cdn.jsdelivr.net\/gh\/cilium\/cilium@v$cilium_major\/Documentation\/images\/logo-solo.svg/g" packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch
 		sed -i "s/ version: .*/ version: $cilium_num_version/g" packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch
 		yq -i ".url = \"https://helm.cilium.io/cilium-$cilium_num_version.tgz\" |
 			.packageVersion = 00" packages/rke2-cilium/package.yaml
@@ -63,7 +62,7 @@ if [ -n "$CILIUM_VERSION" ]; then
 		rm -fr workdir
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-cilium' make prepare
 		find packages/rke2-cilium/charts -name '*.orig' -delete 
-		GOCACHE='/home/runner/.cache/go-0build' GOPATH='/home/runner/go' PACKAGE='rke2-cilium' make patch
+		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-cilium' make patch
 		make clean
 	fi
 fi

--- a/updatecli/scripts/update-flannel.sh
+++ b/updatecli/scripts/update-flannel.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 if [ -n "$FLANNEL_VERSION" ]; then
 	app_version=$(echo "$FLANNEL_VERSION" | grep -Eo 'v[0-9]+.[0-9]+.[0-9]+')
 	current_flannel_version=$(sed -nr 's/^\+    tag: ('v[0-9]+.[0-9]+.[0-9]+')/\1/p' packages/rke2-flannel/generated-changes/patch/values.yaml.patch  | head -1)

--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -13,6 +13,7 @@ sources:
         release: true
         draft: false
         prerelease: false
+        latest: true
       versionfilter:
         kind: latest
 
@@ -27,6 +28,7 @@ targets:
       environments:
         - name: CALICO_VERSION
           value: '{{ source "calico" }}'
+        - name: PATH
 
 
 scms:

--- a/updatecli/updatecli.d/updatecanal.yaml
+++ b/updatecli/updatecli.d/updatecanal.yaml
@@ -60,6 +60,7 @@ targets:
       environments:
         - name: CALICO_VERSION
           value: '{{ source "calico" }}'
+        - name: PATH
 
 
 scms:

--- a/updatecli/updatecli.d/updatecilium.yaml
+++ b/updatecli/updatecli.d/updatecilium.yaml
@@ -13,6 +13,7 @@ sources:
         release: true
         draft: false
         prerelease: false
+        latest: true
       versionfilter:
         kind: latest
 
@@ -27,6 +28,7 @@ targets:
       environments:
         - name: CILIUM_VERSION
           value: '{{ source "cilium" }}'
+        - name: PATH
 
 
 scms:

--- a/updatecli/updatecli.d/updateflannel.yaml
+++ b/updatecli/updatecli.d/updateflannel.yaml
@@ -31,6 +31,7 @@ targets:
       environments:
         - name: FLANNEL_VERSION
           value: '{{ source "flannel" }}'
+        - name: PATH
 
 
 scms:


### PR DESCRIPTION
This PR adds few fixes for updatecli updates for the CNI:
- Adds `PATH` env to the updatecli scripts to fix an issue with `make prepare`
- Adds `set -e` to the updacli scripts to exit in case of errors and avoids to create a wrong update automated PR
- Sets `latest: true` to be sure to get the latest released version