### PR TITLE
Enable nodelocal coredns with cilium replacing kube-proxy

### DIFF
--- a/packages/rke2-coredns/generated-changes/overlay/templates/configmap-nodelocal.yaml
+++ b/packages/rke2-coredns/generated-changes/overlay/templates/configmap-nodelocal.yaml
@@ -17,19 +17,33 @@ data:
         }
         reload
         loop
+{{- if .Values.nodelocal.use_cilium_lrp }}
+        bind 0.0.0.0
+{{- else }}
         bind {{ .Values.nodelocal.ip_address }} {{ template "nodelocalUpstreamDNSServerIP" . }}
+{{- end}}
         forward . {{ ternary (include "clusterDNSServerIP" .) "__PILLAR__CLUSTER__DNS__" .Values.nodelocal.ipvs  }} {
                 force_tcp
         }
         prometheus :9253
+{{- if .Values.nodelocal.use_cilium_lrp }}
+        health
+{{- else }}
         health {{ .Values.nodelocal.ip_address }}:8080
+{{- end}}
+
+        
         }
     in-addr.arpa:53 {
         errors
         cache 30
         reload
         loop
+{{- if .Values.nodelocal.use_cilium_lrp }}
+        bind 0.0.0.0
+{{- else }}
         bind {{ .Values.nodelocal.ip_address }} {{ template "nodelocalUpstreamDNSServerIP" . }}
+{{- end}}
         forward . {{ ternary (include "clusterDNSServerIP" .) "__PILLAR__CLUSTER__DNS__" .Values.nodelocal.ipvs  }} {
                 force_tcp
         }
@@ -40,7 +54,11 @@ data:
         cache 30
         reload
         loop
+{{- if .Values.nodelocal.use_cilium_lrp }}
+        bind 0.0.0.0
+{{- else }}
         bind {{ .Values.nodelocal.ip_address }} {{ template "nodelocalUpstreamDNSServerIP" . }}
+{{- end}}
         forward . {{ ternary (include "clusterDNSServerIP" .) "__PILLAR__CLUSTER__DNS__" .Values.nodelocal.ipvs  }} {
                 force_tcp
         }
@@ -51,7 +69,11 @@ data:
         cache 30
         reload
         loop
+{{- if .Values.nodelocal.use_cilium_lrp }}
+        bind 0.0.0.0
+{{- else }}
         bind {{ .Values.nodelocal.ip_address }} {{ template "nodelocalUpstreamDNSServerIP" . }}
+{{- end}}
         forward . __PILLAR__UPSTREAM__SERVERS__ {
                 force_tcp
         }

--- a/packages/rke2-coredns/generated-changes/overlay/templates/daemonset-nodelocal.yaml
+++ b/packages/rke2-coredns/generated-changes/overlay/templates/daemonset-nodelocal.yaml
@@ -29,7 +29,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodelocal.nodeSelector | indent 8 }}
 {{- end }}
-      hostNetwork: true
+      hostNetwork: {{not .Values.nodelocal.use_cilium_lrp }}
       dnsPolicy: Default  # Don't use cluster DNS.
       tolerations:
       - operator: Exists
@@ -46,7 +46,18 @@ spec:
           requests:
             cpu: 25m
             memory: 5Mi
-        args: [ "-localip", "{{.Values.nodelocal.ip_address}}{{ template "nodelocalLocalIPFlag" . }}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
+        args: 
+          - "-localip"
+          - "{{.Values.nodelocal.ip_address}}{{ template "nodelocalLocalIPFlag" . }}"
+          - "-conf"
+          - "/etc/Corefile"
+          - "-upstreamsvc"
+          - "kube-dns-upstream"
+{{- if .Values.nodelocal.use_cilium_lrp }}
+          - "-skipteardown=true"
+          - "-setupinterface=false"
+          - "-setupiptables=false"
+{{- end}}
         securityContext:
           privileged: true
         ports:
@@ -61,15 +72,19 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
+{{- if not .Values.nodelocal.use_cilium_lrp }}
             host: {{.Values.nodelocal.ip_address}}
+{{- end}}
             path: /health
             port: 8080
           initialDelaySeconds: 60
           timeoutSeconds: 5
         volumeMounts:
+{{- if not .Values.nodelocal.use_cilium_lrp }}
         - mountPath: /run/xtables.lock
           name: xtables-lock
           readOnly: false
+{{- end}}
         - name: config-volume
           mountPath: /etc/coredns
         - name: kube-dns-config

--- a/packages/rke2-coredns/generated-changes/overlay/templates/lrp-nodelocal.yaml
+++ b/packages/rke2-coredns/generated-changes/overlay/templates/lrp-nodelocal.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.nodelocal.enabled .Values.nodelocal.use_cilium_lrp }}
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-nodelocal"
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: {{ template "coredns.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        k8s-app: node-local-dns
+    toPorts:
+      - port: "53"
+        name: udp-53
+        protocol: UDP
+      - port: "53"
+        name: tcp-53
+        protocol: TCP
+{{- end }}

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -164,7 +164,7 @@
      failureThreshold: 3
      successThreshold: 1
  
-@@ -376,3 +382,21 @@
+@@ -376,3 +382,23 @@
    name: ""
    ## Annotations for the coredns deployment
    annotations: {}
@@ -175,6 +175,10 @@
 +  enabled: false
 +  ip_address: "169.254.20.10"
 +  ipvs: false
++  # set to true, if you wish to use nodelocal with cilium in kube-proxy replacement mode.
++  # This sets up a Cilium Local Redirect Policy (LRP) to steer DNS traffic to the nodelocal dns cache.
++  # See https://docs.cilium.io/en/v1.15/network/kubernetes/local-redirect-policy/#node-local-dns-cache for reference
++  use_cilium_lrp: false
 +  image:
 +    repository: rancher/hardened-dns-node-cache
 +    tag: "1.22.28-build20240125"

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.29.0/coredns-1.29.0.tgz
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
This PR allows the user to configure coredns to use nodelocal cache with cilium and no kube-proxy.
It requires cilium Local Redirect Policy to be used.

Related issue: https://github.com/rancher/rke2/issues/5832

Ref: https://docs.cilium.io/en/v1.14/network/kubernetes/local-redirect-policy/#node-local-dns-cache