### PR TITLE
Bump Harvester CSI driver v0.1.18

### DIFF
--- a/packages/harvester-csi-driver/package.yaml
+++ b/packages/harvester-csi-driver/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-csi-driver-0.1.17/harvester-csi-driver-0.1.17.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-csi-driver-0.1.18/harvester-csi-driver-0.1.18.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/6216

We need a new release to have arm-based images.