### PR TITLE
updatecli: use `semver` versionfilter

### DIFF
--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -13,9 +13,8 @@ sources:
         release: true
         draft: false
         prerelease: false
-        latest: true
       versionfilter:
-        kind: latest
+        kind: semver
 
 targets:
   calicoImage:
@@ -31,7 +30,6 @@ targets:
         - name: PATH
         - name: UPDATECLI_GITHUB_WORKFLOW_URL
         - name: GH_TOKEN
-
 
 scms:
   default:

--- a/updatecli/updatecli.d/updatecanal.yaml
+++ b/updatecli/updatecli.d/updatecanal.yaml
@@ -11,7 +11,6 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       username: '{{ requiredEnv .github.username }}'
       typefilter:
-        latest: true
         release: true
         draft: false
         prerelease: false
@@ -19,6 +18,7 @@ sources:
         kind: regex
         # pattern accepts any semver constraint
         pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+
   calico:
     name: Get calico version
     kind: githubrelease
@@ -28,7 +28,6 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       username: '{{ requiredEnv .github.username }}'
       typefilter:
-        latest: true
         release: true
         draft: false
         prerelease: false
@@ -65,7 +64,7 @@ scms:
       owner: '{{ .github.owner }}'
       repository: '{{ .github.repository }}'
       branch: '{{ .github.branch }}'
-      
+
 actions:
   default:
     title: 'Bump flannel version to {{ source "flannel" }} and Calico to {{ source "calico" }} on Canal'

--- a/updatecli/updatecli.d/updatecilium.yaml
+++ b/updatecli/updatecli.d/updatecilium.yaml
@@ -13,9 +13,9 @@ sources:
         release: true
         draft: false
         prerelease: false
-        latest: true
       versionfilter:
-        kind: latest
+        kind: semver
+
   cni_plugins:
     name: Get CNI plugins version
     kind: githubrelease
@@ -25,7 +25,6 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       username: '{{ requiredEnv .github.username }}'
       typefilter:
-        latest: true
         release: true
         draft: false
         prerelease: false
@@ -50,7 +49,6 @@ targets:
         - name: PATH
         - name: UPDATECLI_GITHUB_WORKFLOW_URL
         - name: GH_TOKEN
-
 
 scms:
   default:

--- a/updatecli/updatecli.d/updateflannel.yaml
+++ b/updatecli/updatecli.d/updateflannel.yaml
@@ -11,7 +11,6 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       username: '{{ requiredEnv .github.username }}'
       typefilter:
-        latest: true
         release: true
         draft: false
         prerelease: false
@@ -19,6 +18,7 @@ sources:
         kind: regex
         # pattern accepts any semver constraint
         pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+
   cni_plugins:
     name: Get CNI plugins version
     kind: githubrelease
@@ -28,7 +28,6 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       username: '{{ requiredEnv .github.username }}'
       typefilter:
-        latest: true
         release: true
         draft: false
         prerelease: false
@@ -53,7 +52,6 @@ targets:
         - name: PATH
         - name: UPDATECLI_GITHUB_WORKFLOW_URL
         - name: GH_TOKEN
-
 
 scms:
   default:

--- a/updatecli/updatecli.d/updatemultus.yaml
+++ b/updatecli/updatecli.d/updatemultus.yaml
@@ -13,9 +13,11 @@ sources:
         release: true
         draft: false
         prerelease: false
-        latest: true
       versionfilter:
-        kind: latest
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+
   cni_plugins:
     name: Get CNI plugins version
     kind: githubrelease
@@ -25,7 +27,6 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       username: '{{ requiredEnv .github.username }}'
       typefilter:
-        latest: true
         release: true
         draft: false
         prerelease: false
@@ -50,7 +51,6 @@ targets:
         - name: PATH
         - name: UPDATECLI_GITHUB_WORKFLOW_URL
         - name: GH_TOKEN
-
 
 scms:
   default:

--- a/updatecli/updatecli.d/updatewhereabouts.yaml
+++ b/updatecli/updatecli.d/updatewhereabouts.yaml
@@ -13,9 +13,10 @@ sources:
         release: true
         draft: false
         prerelease: false
-        latest: true
       versionfilter:
-        kind: latest
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
 
 targets:
   whereaboutsImage:
@@ -31,7 +32,6 @@ targets:
         - name: PATH
         - name: UPDATECLI_GITHUB_WORKFLOW_URL
         - name: GH_TOKEN
-
 
 scms:
   default:


### PR DESCRIPTION
Version bump PRs should use the semver instead of the latest tag

Issue: https://github.com/rancher/rke2/issues/6402