### PR TITLE
Enable legacy watchIngressWithoutClass behavior when ingress-nginx is the default ingress controller

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/_params.tpl.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/_params.tpl.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/_params.tpl
++++ charts/templates/_params.tpl
+@@ -51,7 +51,7 @@
+ {{- if .Values.controller.ingressClassByName }}
+ - --ingress-class-by-name=true
+ {{- end }}
+-{{- if .Values.controller.watchIngressWithoutClass }}
++{{- if or (.Values.controller.watchIngressWithoutClass) (eq .Values.global.systemDefaultIngressClass "ingress-nginx") }}
+ - --watch-ingress-without-class=true
+ {{- end }}
+ {{- if not .Values.controller.metrics.enabled }}

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.10.1/ingress-nginx-4.10.1.tgz
-packageVersion: 03
+packageVersion: 04
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Enabling this behavior only for backwards-compatibility with previous releases of the chart.

Traefik's `providers.kubernetesCRD.ingressClass` value works differently and we do not have to be backwards compatible so we are not changing that:
> If the parameter is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed.

We have always shipped with that set to `traefik`, and with the ingressClass set to default in coordination with the RKE2 CLI flag values, so it only watches Ingress with the ingressClassName set.