### PR TITLE
Bump ingress-nginx to v1.10.4-hardened1

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
@@ -8,4 +8,4 @@
 +name: rke2-ingress-nginx
  sources:
  - https://github.com/kubernetes/ingress-nginx
- version: 4.10.1
+ version: 4.10.4

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
@@ -15,16 +15,7 @@
  {{- end }}
  {{- end -}}
  
-@@ -237,7 +237,7 @@
- Check the ingress controller version tag is at most three versions behind the last release
- */}}
- {{- define "isControllerTagValid" -}}
--{{- if not (semverCompare ">=0.27.0-0" .Values.controller.image.tag) -}}
-+{{- if not (semverCompare ">=0.27.0-0" (trimPrefix "nginx-" .Values.controller.image.tag)) -}}
- {{- fail "Controller container image tag should be 0.27.0 or higher" -}}
- {{- end -}}
- {{- end -}}
-@@ -268,3 +268,15 @@
+@@ -259,3 +259,15 @@
      - name: modules
        mountPath: /modules_mount
  {{- end -}}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/controller-daemonset.yaml
 +++ charts/templates/controller-daemonset.yaml
-@@ -76,9 +76,7 @@
+@@ -75,9 +75,7 @@
      {{- end }}
        containers:
          - name: {{ .Values.controller.containerName }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/controller-deployment.yaml
 +++ charts/templates/controller-deployment.yaml
-@@ -79,9 +79,7 @@
+@@ -78,9 +78,7 @@
      {{- end }}
        containers:
          - name: {{ .Values.controller.containerName }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -10,11 +10,11 @@
      ## for backwards compatibility consider setting the full image url via the repository value below
      ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
      ## repository:
--    tag: "v1.10.1"
--    digest: sha256:e24f39d3eed6bcc239a56f20098878845f62baa34b9f2be2fd2c38ce9fb0f29e
--    digestChroot: sha256:c155954116b397163c88afcb3252462771bd7867017e8a17623e83601bab7ac7
+-    tag: "v1.10.4"
+-    digest: sha256:505b9048c02dde3d6c8667bf0b52aba7b36adf7b03da34c47d5fa312d2d4c6fc
+-    digestChroot: sha256:bf71acf6e71830a4470e2183e3bc93c4f006b954f8a05fb434242ef0f8a24858
 -    pullPolicy: IfNotPresent
-+    tag: "v1.10.1-hardened2"
++    tag: "v1.10.4-hardened1"
      runAsNonRoot: true
      # www-data -> uid 101
      runAsUser: 101
@@ -90,9 +90,9 @@
          ## for backwards compatibility consider setting the full image url via the repository value below
          ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
          ## repository:
--        tag: v1.4.1
--        digest: sha256:36d05b4077fb8e3d13663702fa337f124675ba8667cbd949c03a8e8ea6fa4366
-+        tag: v20230312-helm-chart-4.5.2-28-g66a760794
+-        tag: v1.4.3
+-        digest: sha256:a320a50cc91bd15fd2d6fa6de58bd98c1bd64b9a6f926ce23a600d87043455a3
++        tag: v1.4.1
          pullPolicy: IfNotPresent
        # -- Provide a priority class name to the webhook patching job
        ##

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.10.1/ingress-nginx-4.10.1.tgz
-packageVersion: 04
+url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.10.4/ingress-nginx-4.10.4.tgz
+packageVersion: 00
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Patch of `isControlerTagValid` is not longer required, as the check got removed in https://github.com/kubernetes/ingress-nginx/pull/11710