### PR TITLE
Fixed Flannel chart to disable NFTable by default

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -24,7 +24,7 @@
 +    repository: rancher/hardened-cni-plugins
 +    tag: v1.5.1-build20240805
    # flannel command arguments
-   enableNFTables: false,
+   enableNFTables: false
    args:
 @@ -26,14 +17,14 @@
    # Documentation at https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.25.5/flannel.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
Update the chart subversion to get the fixed chart to disable NFTables by default on Flannel.
https://github.com/rancher/rke2/issues/6601