### PR TITLE
Bump multus, whereabouts, cniplugins and flannel images

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -17,12 +17,12 @@
 -    repository: docker.io/flannel/flannel
 -    tag: v0.25.6
 +    repository: rancher/hardened-flannel
-+    tag: v0.25.6-build20240828
++    tag: v0.25.6-build20240910
    image_cni:
 -    repository: docker.io/flannel/flannel-cni-plugin
 -    tag: v1.5.1-flannel2
 +    repository: rancher/hardened-cni-plugins
-+    tag: v1.5.1-build20240830
++    tag: v1.5.1-build20240910
    # flannel command arguments
    enableNFTables: false
    args:

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.25.6/flannel.tgz
-packageVersion: 00
+packageVersion: 01

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -20,7 +20,7 @@
 
 image:
   repository: rancher/hardened-multus-cni
-  tag: v4.1.0-build20240830
+  tag: v4.1.0-build20240910
   pullPolicy: IfNotPresent
 
 #imagePullSecrets: []
@@ -122,7 +122,7 @@ tolerations:
 cniplugins:
   image:
     repository: rancher/hardened-cni-plugins
-    tag: v1.5.1-build20240830
+    tag: v1.5.1-build20240910
 
   # skipcnis is a comma separated list of cni binaries to skip from
   # installing.

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 00
+packageVersion: 01

--- a/packages/rke2-whereabouts/charts/values.yaml
+++ b/packages/rke2-whereabouts/charts/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: rancher/hardened-whereabouts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.8.0-build20240830
+  tag: v0.8.0-build20240910
 
 updateStrategy: RollingUpdate
 imagePullSecrets: []


### PR DESCRIPTION
Bump multus, whereabouts, cniplugins and flannel images with the fix for CVE GO-2024-3106