### PR TITLE
Update coredns and metrics-server to fix GO-2024-3106

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -8,7 +8,7 @@
 +  repository: rancher/hardened-coredns
    # Overrides the image tag whose default is the chart appVersion.
 -  tag: ""
-+  tag: "v1.11.1-build20240305"
++  tag: "v1.11.1-build20240910"
    pullPolicy: IfNotPresent
    ## Optionally specify an array of imagePullSecrets.
    ## Secrets must be manually created in the namespace.
@@ -116,7 +116,7 @@
 -    repository: registry.k8s.io/cpa/cluster-proportional-autoscaler
 -    tag: "1.8.5"
 +    repository: rancher/hardened-cluster-autoscaler
-+    tag: "v1.8.10-build20240124"
++    tag: "v1.8.10-build20240910"
      pullPolicy: IfNotPresent
      ## Optionally specify an array of imagePullSecrets.
      ## Secrets must be manually created in the namespace.
@@ -181,10 +181,10 @@
 +  use_cilium_lrp: false
 +  image:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.22.28-build20240125"
++    tag: "1.23.1-build20240910"
 +  initimage:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.22.28-build20240125"
++    tag: "1.23.1-build20240910"
 +  nodeSelector:
 +    kubernetes.io/os: linux
 +

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.29.0/coredns-1.29.0.tgz
-packageVersion: 04
+packageVersion: 05

--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -8,7 +8,7 @@
 +  repository: rancher/hardened-k8s-metrics-server
    # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
 -  tag: ""
-+  tag: v0.7.1-build20240401
++  tag: v0.7.1-build20240910
    pullPolicy: IfNotPresent
  
  imagePullSecrets: []
@@ -27,7 +27,7 @@
 -    repository: registry.k8s.io/autoscaling/addon-resizer
 -    tag: 1.8.20
 +    repository: rancher/hardened-addon-resizer
-+    tag: 1.8.20-build20240410
++    tag: 1.8.20-build20240910
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.0/metrics-server-3.12.0.tgz
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
also bump dns-nodecache to 1.23.1 to fix 
- https://github.com/advisories/GHSA-xw78-pcr6-wrg8
-  https://github.com/advisories/GHSA-hq6q-c2x6-hmch
