### PR TITLE
Set Multus ConfigMap name so that it matches DaemonSet

### DIFF
--- a/packages/rke2-multus/charts/templates/daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/daemonSet.yaml
@@ -117,7 +117,7 @@ spec:
           mountPath: /host/opt/cni/bin
         {{- if .Values.manifests.configMap }}
         - name: multus-cfg
-          mountPath: /tmp/multus-conf/00-multus.conf.template
+          mountPath: /tmp/multus-conf/00-multus.conf
           subPath: "cni-conf.json"
         {{- end }}
       volumes:
@@ -130,6 +130,6 @@ spec:
         {{- if .Values.manifests.configMap }}
         - name: multus-cfg
           configMap:
-            name: {{ .Release.Name }}-{{ .Chart.Name }}-{{ .Chart.Version }}-config
+            name: {{ .Release.Name }}-{{ .Chart.Version }}-config
         {{- end }}
 {{- end }}

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
When trying to configure multus using the configmap by setting `manifests.configMap` to `true` i noticed that the name of the generated ConfigMap doesn't match the name used in the [DaemonSet](https://github.com/rancher/rke2-charts/blob/91bb126433b48ec453fbb0d154ff89c16513add8/packages/rke2-multus/charts/templates/daemonSet.yaml#L133).

I'm deploying in K3S using the built-in helm controller.

I'm using the following config:

```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChart
metadata:
  name: multus
  namespace: kube-system
spec:
  repo: https://rke2-charts.rancher.io
  chart: rke2-multus
  bootstrap: true
  version: 4.1.1
  targetNamespace: kube-system
  valuesContent: |-
    config:
      cni_conf:
        multusConfFile: /tmp/multus-conf/00-multus.conf.template
        cniVersion: 0.3.1
        name: multus-cni-network
        type: multus
        confDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
        binDir: /var/lib/rancher/k3s/data/current/bin/
        kubeconfig: /var/lib/rancher/k3s/agent/etc/cni/net.d/multus.d/multus.kubeconfig
        delegates:
          - type: cilium-cni
            name: cilium
            cniVersion: 0.3.1
            delegate:
              isDefaultGateway: true
    manifests:
      dhcpDaemonSet: true
      configMap: true
```