### PR TITLE
Remove extra space that breaks kubectl YAML block formatting

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
@@ -5,7 +5,7 @@
      {
        {{- range .plugins }}
 -        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
-+        {{ .name }} {{ if .parameters }} {{if eq .name "kubernetes" }} {{ coalesce $.Values.global.clusterDomain "cluster.local" }} {{ end }} {{.parameters}}{{ end }}{{ if .configBlock }} {
++        {{ .name }}{{ if .parameters }} {{if eq .name "kubernetes" }} {{ coalesce $.Values.global.clusterDomain "cluster.local" }} {{ end }} {{.parameters}}{{ end }}{{ if .configBlock }} {
  {{ .configBlock | indent 12 }}
          }{{ end }}
        {{- end }}

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.29.0/coredns-1.29.0.tgz
-packageVersion: 06
+packageVersion: 07


### PR DESCRIPTION
With the current ConfigMap template version, the data block format rendered by kubectl is broken after an RKE2 deployment:

```
> kubectl get cm rke2-coredns-rke2-coredns -n kube-system -o yaml
apiVersion: v1
data:
  Corefile: ".:53 {\n    errors \n    health  {\n        lameduck 5s\n    }\n    ready
    \n    kubernetes   cluster.local  cluster.local in-addr.arpa ip6.arpa {\n        pods
    insecure\n        fallthrough in-addr.arpa ip6.arpa\n        ttl 30\n    }\n    prometheus
    \  0.0.0.0:9153\n    forward   . /etc/resolv.conf\n    cache   30\n    loop \n
    \   reload \n    loadbalance \n}"
kind: ConfigMap
...
```

It seems that an extra space added during the last commit breaks the rendering.
Removing this extra space restores the correct block format.

```
> kubectl get cm rke2-coredns-rke2-coredns -n kube-system -o yaml
apiVersion: v1
data:
  Corefile: |-
    .:53 {
        errors
        health {
            lameduck 5s
        }
        ready
        kubernetes  cluster.local cluster.local in-addr.arpa ip6.arpa {
            pods insecure
            fallthrough in-addr.arpa ip6.arpa
            ttl 30
        }
        prometheus 0.0.0.0:9153
        forward . /etc/resolv.conf
        cache 30
        loop
        reload
        loadbalance
    }
kind: ConfigMap
...
```