### PR TITLE
Update hardened-cni-plugins to `v1.5.1-build20241009`

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
@@ -200,7 +200,7 @@
 +portmapPlugin:
 +  image:
 +    repository: "rancher/hardened-cni-plugins"
-+    tag: "v1.5.1-build20240910"
++    tag: "v1.5.1-build20241009"
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.16.2.tgz
-packageVersion: 00
+packageVersion: 01

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -22,7 +22,7 @@
 -    repository: docker.io/flannel/flannel-cni-plugin
 -    tag: v1.5.1-flannel2
 +    repository: rancher/hardened-cni-plugins
-+    tag: v1.5.1-build20240910
++    tag: v1.5.1-build20241009
    # flannel command arguments
    enableNFTables: false
    args:

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.25.7/flannel.tgz
-packageVersion: 00
+packageVersion: 01

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -122,7 +122,7 @@ tolerations:
 cniplugins:
   image:
     repository: rancher/hardened-cni-plugins
-    tag: v1.5.1-build20240910
+    tag: v1.5.1-build20241009
 
   # skipcnis is a comma separated list of cni binaries to skip from
   # installing.

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 00
+packageVersion: 01

--- a/updatecli/scripts/cilium-values.yaml.patch.template
+++ b/updatecli/scripts/cilium-values.yaml.patch.template
@@ -200,7 +200,7 @@
 +portmapPlugin:
 +  image:
 +    repository: "rancher/hardened-cni-plugins"
-+    tag: "v1.5.1-build20240910"
++    tag: "v1.5.1-build20241009"
 +
 +global:
 +  systemDefaultRegistry: ""


### PR DESCRIPTION
updates the cni-plugins for cilium, flannel and multus