### PR TITLE
Pass CNI confDir and binDir through to whereabouts pod env

### DIFF
--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 01
+packageVersion: 02

--- a/packages/rke2-whereabouts/charts/templates/daemonset.yaml
+++ b/packages/rke2-whereabouts/charts/templates/daemonset.yaml
@@ -55,13 +55,17 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: CNI_CONF_DIR
+            value: /host{{ .Values.cniConf.confDir }}
+          - name: CNI_BIN_DIR
+            value: /host{{ .Values.cniConf.binDir }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           - name: cnibin
-            mountPath: /host/opt/cni/bin
+            mountPath: /host{{ .Values.cniConf.binDir }}
           - name: cni-net-dir
-            mountPath: /host/etc/cni/net.d
+            mountPath: /host{{ .Values.cniConf.confDir }}
           - name: cron-scheduler-configmap
             mountPath: /cron-schedule
       volumes:


### PR DESCRIPTION
This ensures that the correct kubeconfig path is written into whereabouts.conf. Ref:
* https://github.com/k8snetworkplumbingwg/whereabouts/blob/6684139632524370e24fe3baf4270611991f8ffd/script/install-cni.sh#L13-L23
* https://github.com/k8snetworkplumbingwg/whereabouts/blob/6684139632524370e24fe3baf4270611991f8ffd/script/install-cni.sh#L102-L108

Without this change, the kubeconfig path in the config file is always set to `/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig` even if this path is actually mounted from elsewhere on the host, which leads to problems when the whereabouts plugin reads the config file and doesn't find the kubeconfig at the expected location. 

See https://github.com/k3s-io/k3s/issues/10869#issuecomment-2423558809 for an example of how this can be worked around. Note that `configuration_path` always needs to be overridden in the NetworkAttachmentDefinition for K3s, as there is no way to globally set the config dir for the whole plugin chain; most things assume /etc/cni/net.d or /etc/kubernetes/cni/net.d.