### PR TITLE
Updates for hardened image provenance

### DIFF
--- a/packages/rke2-canal/charts/Chart.yaml
+++ b/packages/rke2-canal/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rke2-canal
 description: Install Canal Network Plugin.
-version: v3.28.2-build20241003
+version: v3.28.2-build20241016
 appVersion: v3.28.2
 home: https://www.projectcalico.org/
 keywords:

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -8,7 +8,7 @@ flannel:
   # kube-flannel image
   image:
     repository: rancher/hardened-flannel
-    tag: v0.25.7-build20241007
+    tag: v0.25.7-build20241008
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.
@@ -60,19 +60,19 @@ calico:
   # CNI installation image.
   cniImage:
     repository: rancher/hardened-calico
-    tag: v3.28.2-build20241003
+    tag: v3.28.2-build20241016
   # Canal node image.
   nodeImage:
     repository: rancher/hardened-calico
-    tag: v3.28.2-build20241003
+    tag: v3.28.2-build20241016
   # Flexvol Image.
   flexvolImage:
     repository: rancher/hardened-calico
-    tag: v3.28.2-build20241003
+    tag: v3.28.2-build20241016
   # kubecontroller image
   kubeControllerImage:
     repository: rancher/hardened-calico
-    tag: v3.28.2-build20241003
+    tag: v3.28.2-build20241016
   # Datastore type for canal. It can be either kuberentes or etcd.
   datastoreType: kubernetes
   # Wait for datastore to initialize.

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 01

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -107,7 +107,7 @@
 -    repository: registry.k8s.io/cpa/cluster-proportional-autoscaler
 -    tag: "1.8.5"
 +    repository: rancher/hardened-cluster-autoscaler
-+    tag: "v1.8.11-build20240910"
++    tag: "v1.8.11-build20241014"
      pullPolicy: IfNotPresent
      ## Optionally specify an array of imagePullSecrets.
      ## Secrets must be manually created in the namespace.
@@ -172,10 +172,10 @@
 +  use_cilium_lrp: false
 +  image:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.23.1-build20240910"
++    tag: "1.23.1-build20241008"
 +  initimage:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.23.1-build20240910"
++    tag: "1.23.1-build20241008"
 +  nodeSelector:
 +    kubernetes.io/os: linux
 +

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.33.0/coredns-1.33.0.tgz
-packageVersion: 01
+packageVersion: 02

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -17,7 +17,7 @@
 -    repository: docker.io/flannel/flannel
 -    tag: v0.25.7
 +    repository: rancher/hardened-flannel
-+    tag: v0.25.7-build20241007
++    tag: v0.25.7-build20241008
    image_cni:
 -    repository: docker.io/flannel/flannel-cni-plugin
 -    tag: v1.5.1-flannel2

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.25.7/flannel.tgz
-packageVersion: 02
+packageVersion: 03

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -14,7 +14,7 @@
 -    digest: sha256:c84d11b1f7bd14ebbf49918a7f0dc01b31c0c6e757e0129520ea93453096315c
 -    digestChroot: sha256:030a43bdd5f0212a7e135cc4da76b15a6706ef65a6824eb4cc401f87a81c2987
 -    pullPolicy: IfNotPresent
-+    tag: "v1.10.5-hardened1"
++    tag: "v1.10.5-hardened3"
      runAsNonRoot: true
      # www-data -> uid 101
      runAsUser: 101

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.10.5/ingress-nginx-4.10.5.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00

--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -8,7 +8,7 @@
 +  repository: rancher/hardened-k8s-metrics-server
    # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
 -  tag: ""
-+  tag: v0.7.1-build20240910
++  tag: v0.7.1-build20241008
    pullPolicy: IfNotPresent
  
  imagePullSecrets: []
@@ -27,7 +27,7 @@
 -    repository: registry.k8s.io/autoscaling/addon-resizer
 -    tag: 1.8.20
 +    repository: rancher/hardened-addon-resizer
-+    tag: 1.8.20-build20240910
++    tag: 1.8.20-build20241001
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.0/metrics-server-3.12.0.tgz
-packageVersion: 03
+packageVersion: 04

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -20,7 +20,7 @@
 
 image:
   repository: rancher/hardened-multus-cni
-  tag: v4.1.2-build20241009
+  tag: v4.1.2-build20241011
   pullPolicy: IfNotPresent
 
 #imagePullSecrets: []

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 03
+packageVersion: 04

--- a/packages/rke2-whereabouts/charts/values.yaml
+++ b/packages/rke2-whereabouts/charts/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: rancher/hardened-whereabouts
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.8.0-build20240910
+  tag: v0.8.0-build20241011
 
 updateStrategy: RollingUpdate
 imagePullSecrets: []

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,5 +1,5 @@
 url: local
 workingDir: charts
-packageVersion: 00
+packageVersion: 01
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
There are more recently tagged hardened images for some charts that supports slsa level 3. This PR updates those image tags and increments the chart package version.