### PR TITLE
fix(wherabouts): fix crd not being installed in helm

### DIFF
--- a/packages/rke2-whereabouts/charts/templates/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-whereabouts/charts/templates/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.manifests.customResourceDefinition }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -69,3 +69,4 @@ spec:
         type: object
     served: true
     storage: true
+{{- end -}}

--- a/packages/rke2-whereabouts/charts/templates/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-whereabouts/charts/templates/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.manifests.customResourceDefinition }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -55,3 +55,4 @@ spec:
         type: object
     served: true
     storage: true
+{{- end -}}

--- a/packages/rke2-whereabouts/charts/values.yaml
+++ b/packages/rke2-whereabouts/charts/values.yaml
@@ -46,6 +46,9 @@ tolerations:
 
 affinity: {}
 
+manifests:
+  customResourceDefinition: true
+
 cniConf:
   confDir: /etc/cni/net.d
   binDir: /opt/cni/bin


### PR DESCRIPTION
Fix whereabouts chart where it doesn't install CRD.