### PR TITLE
rke2-canal: fix package version

### DIFF
--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 02


### PR DESCRIPTION
updatecli erroneously reverted the package number to 00 in its latest PR