### PR TITLE
Level rke2-flannel CNI plugin config with k3s

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
@@ -1,6 +1,25 @@
 --- charts-original/templates/config.yaml
 +++ charts/templates/config.yaml
-@@ -29,13 +29,13 @@
+@@ -16,6 +16,7 @@
+           "type": "flannel",
+           "delegate": {
+             "hairpinMode": true,
++            "forceAddress": true,
+             "isDefaultGateway": true
+           }
+         },
+@@ -24,18 +25,24 @@
+           "capabilities": {
+             "portMappings": true
+           }
++        },
++        {
++          "type": "bandwidth",
++          "capabilities": {
++            "bandwidth": true
++          }
+         }
+       ]
      }
    net-conf.json: |
      {

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.26.0/flannel.tgz
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
This change follows how k3s configures flannel mostly, including adding the `bandwidth` plugin, except for leaving the cni version the same.

Most importantly and the main reason for this change, this adds `"forceAddress": true` to handle when the `cni0` interface, `/run/flannel/subnet.env`, and node's `podCIDR` don't match, without requiring an rke2 service restart/manual `cni0` intervention.

Reference: https://github.com/k3s-io/k3s/blob/master/pkg/agent/flannel/setup_linux.go

Issue: 
* https://github.com/rancher/rke2/issues/7244