### PR TITLE
updatecli: create an issue in rancher/rke2 when an updatecli run fails.

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main-source'
+    # if you want to testupdatecli on another branch, you also need to modify updatecli/values.yaml
+    if: ${{github.ref == 'refs/heads/main-source' && github.repository == 'rancher/rke2-charts'}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +28,16 @@ jobs:
 
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
+
+      - name: Get token
+        id: get_token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+            app-id: ${{ secrets.CREATE_ISSUE_APP_ID }}
+            private-key: ${{ secrets.CREATE_ISSUE_PRIVATE_KEY }}
+            owner: rancher
+            repositories: |
+              rke2
 
       - name: Delete leftover UpdateCLI branches
         run: |
@@ -53,3 +64,6 @@ jobs:
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_WORKFLOW_URL: "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}
+

--- a/updatecli/scripts/create-issue.sh
+++ b/updatecli/scripts/create-issue.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+TARGET_REPOSITORY="rancher/rke2"
+BODY="Url of the failed run: ${UPDATECLI_GITHUB_WORKFLOW_URL}"
+
+create-issue() {
+    title=$1
+
+    #check if issue already exists
+    issues=$(gh issue list -R ${TARGET_REPOSITORY} \
+                --search "is:open ${title}" \
+                --app rke2-issues-updatecli --json number --jq ".[].number" | wc -l)
+
+    if [[ $issues = 0 ]]; then
+        echo "Creating issue for: $title"
+        gh issue create -R ${TARGET_REPOSITORY} \
+            --title "${title}" \
+            --body "${BODY}"
+    else
+        echo "Issue already exists for: ${title}"
+    fi
+}
+
+export -f create-issue

--- a/updatecli/scripts/update-calico.sh
+++ b/updatecli/scripts/update-calico.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 set -eu
+
+source $(dirname $0)/create-issue.sh
+
+report-error() {
+    exit_code=$?
+    trap - EXIT INT
+
+    if [[ $exit_code != 0 ]]; then
+        create-issue "Updatecli failed for calico ${CALICO_VERSION}" 
+    fi
+
+    exit ${exit_code}
+}
+trap report-error EXIT INT
+
 if [ -n "$CALICO_VERSION" ]; then
 	current_calico_version=$(yq '.version' packages/rke2-calico/templates/crd-template/Chart.yaml)
 	if [ "$current_calico_version" != "$CALICO_VERSION" ]; then

--- a/updatecli/scripts/update-canal.sh
+++ b/updatecli/scripts/update-canal.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 set -eu
+
+source $(dirname $0)/create-issue.sh
+
+report-error() {
+    exit_code=$?
+    trap - EXIT INT
+
+    if [[ $exit_code != 0 ]]; then
+        create-issue "Updatecli failed for canal with calico ${CALICO_VERSION} and flannel ${FLANNEL_VERSION}" 
+    fi
+
+    exit ${exit_code}
+}
+trap report-error EXIT INT
+
 if [ -n "$FLANNEL_VERSION" ]; then
 	current_flannel_version=$(yq '.flannel.image.tag' packages/rke2-canal/charts/values.yaml)
 	if [ "$current_flannel_version" != "$FLANNEL_VERSION" ]; then

--- a/updatecli/scripts/update-cilium.sh
+++ b/updatecli/scripts/update-cilium.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 set -eu
+
+source $(dirname $0)/create-issue.sh
+
+report-error() {
+    exit_code=$?
+    trap - EXIT INT
+
+    if [[ $exit_code != 0 ]]; then
+        create-issue "Updatecli failed for cilium ${CILIUM_VERSION}" 
+    fi
+
+    exit ${exit_code}
+}
+trap report-error EXIT INT
+
 if [ -n "$CILIUM_VERSION" ]; then
 	current_cilium_version=$(sed -nr 's/^\ version: ('[0-9]+.[0-9]+.[0-9]+')/\1/p' packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch)
 	if [ "v$current_cilium_version" != "$CILIUM_VERSION" ]; then

--- a/updatecli/scripts/update-flannel.sh
+++ b/updatecli/scripts/update-flannel.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 set -eu
+
+source $(dirname $0)/create-issue.sh
+
+report-error() {
+    exit_code=$?
+    trap - EXIT INT
+
+    if [[ $exit_code != 0 ]]; then
+        create-issue "Updatecli failed for flannel ${FLANNEL_VERSION}" 
+    fi
+
+    exit ${exit_code}
+}
+trap report-error EXIT INT
+
 if [ -n "$FLANNEL_VERSION" ]; then
 	app_version=$(echo "$FLANNEL_VERSION" | grep -Eo 'v[0-9]+.[0-9]+.[0-9]+')
 	current_flannel_version=$(sed -nr 's/^\+    tag: ('v[0-9]+.[0-9]+.[0-9]+')/\1/p' packages/rke2-flannel/generated-changes/patch/values.yaml.patch  | head -1)

--- a/updatecli/scripts/update-multus.sh
+++ b/updatecli/scripts/update-multus.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
-set -eu
+set -eux
+
+source $(dirname $0)/create-issue.sh
+
+report-error() {
+    exit_code=$?
+    trap - EXIT INT
+
+    if [[ $exit_code != 0 ]]; then
+        create-issue "Updatecli failed for multus ${MULTUS_VERSION}" 
+    fi
+
+    exit ${exit_code}
+}
+trap report-error EXIT INT
+
 if [ -n "$MULTUS_VERSION" ]; then
 	app_version=$(echo "$MULTUS_VERSION" | grep -Eo '^v*[0-9]+.[0-9]+.[0-9]+' | tr -d 'v')
 	current_multus_version=$(yq '.image.tag' packages/rke2-multus/charts/values.yaml)

--- a/updatecli/updatecli.d/updatecalico.yaml
+++ b/updatecli/updatecli.d/updatecalico.yaml
@@ -29,6 +29,8 @@ targets:
         - name: CALICO_VERSION
           value: '{{ source "calico" }}'
         - name: PATH
+        - name: UPDATECLI_GITHUB_WORKFLOW_URL
+        - name: GH_TOKEN
 
 
 scms:

--- a/updatecli/updatecli.d/updatecanal.yaml
+++ b/updatecli/updatecli.d/updatecanal.yaml
@@ -51,6 +51,8 @@ targets:
         - name: CALICO_VERSION
           value: '{{ source "calico" }}'
         - name: PATH
+        - name: UPDATECLI_GITHUB_WORKFLOW_URL
+        - name: GH_TOKEN
 
 scms:
   default:

--- a/updatecli/updatecli.d/updatecilium.yaml
+++ b/updatecli/updatecli.d/updatecilium.yaml
@@ -29,6 +29,8 @@ targets:
         - name: CILIUM_VERSION
           value: '{{ source "cilium" }}'
         - name: PATH
+        - name: UPDATECLI_GITHUB_WORKFLOW_URL
+        - name: GH_TOKEN
 
 
 scms:

--- a/updatecli/updatecli.d/updateflannel.yaml
+++ b/updatecli/updatecli.d/updateflannel.yaml
@@ -32,6 +32,8 @@ targets:
         - name: FLANNEL_VERSION
           value: '{{ source "flannel" }}'
         - name: PATH
+        - name: UPDATECLI_GITHUB_WORKFLOW_URL
+        - name: GH_TOKEN
 
 
 scms:

--- a/updatecli/updatecli.d/updatemultus.yaml
+++ b/updatecli/updatecli.d/updatemultus.yaml
@@ -29,6 +29,8 @@ targets:
         - name: MULTUS_VERSION
           value: '{{ source "multus" }}'
         - name: PATH
+        - name: UPDATECLI_GITHUB_WORKFLOW_URL
+        - name: GH_TOKEN
 
 
 scms:


### PR DESCRIPTION
The script uses a Github App to authenticate to the rke2 repo.
It also checks whether the issue already exists before creating it.

Note: the authentication process is similar to the one used here: https://github.com/rancher/renovate-config/blob/main/.github/workflows/renovate.yml#L69-L80

The PR is a draft because the GH App is not created at the moment.