### PR TITLE
Update calico to 3.29.1 and fixed automated script

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
@@ -10,6 +10,6 @@
  - https://github.com/projectcalico/calico/tree/master/charts/tigera-operator
  - https://github.com/tigera/operator
  - https://github.com/projectcalico/calico
- version: v3.29.0
+ version: v3.29.1
 +annotations:
 +  catalog.cattle.io/namespace: tigera-operator

--- a/packages/rke2-calico/generated-changes/patch/templates/tigera-operator/00-uninstall.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/tigera-operator/00-uninstall.yaml.patch
@@ -7,9 +7,9 @@
 -  namespace: {{.Release.Namespace}}
 +  namespace: tigera-operator
    labels:
-     k8s-app: tigera-operator-uninstall
      helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-@@ -35,5 +35,5 @@
+     {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
+@@ -34,5 +34,5 @@
        serviceAccountName: tigera-operator
        containers:
        - name: cleanup-job

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -37,13 +37,13 @@
  tigeraOperator:
 -  image: tigera/operator
 +  image: rancher/mirrored-calico-operator
-   version: v1.36.0
+   version: v1.36.2
 -  registry: quay.io
 +  registry: docker.io
  calicoctl:
 -  image: docker.io/calico/ctl
 +  image: rancher/mirrored-calico-ctl
-   tag: v3.29.0
+   tag: v3.29.1
  
 -kubeletVolumePluginPath: /var/lib/kubelet
 +kubeletVolumePluginPath: "None"

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/projectcalico/calico/releases/download/v3.29.0/tigera-operator-v3.29.0.tgz
+url: https://github.com/projectcalico/calico/releases/download/v3.29.1/tigera-operator-v3.29.1.tgz
 packageVersion: 00
 additionalCharts:
   - workingDir: charts-crd

--- a/packages/rke2-calico/templates/crd-template/Chart.yaml
+++ b/packages/rke2-calico/templates/crd-template/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: v3.29.0
+version: v3.29.1
 description: Installs the CRDs for rke2-calico
 name: rke2-calico-crd
 type: application

--- a/updatecli/scripts/update-calico.sh
+++ b/updatecli/scripts/update-calico.sh
@@ -16,6 +16,8 @@ if [ -n "$CALICO_VERSION" ]; then
 		yq -i ".url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz\" |
 			.packageVersion = 00" packages/rke2-calico/package.yaml
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make prepare
+		find packages/rke2-calico/charts -name '*.orig' -delete
+		find packages/rke2-calico/charts-crd -name '*.orig' -delete
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make patch
 		make clean
 	fi

--- a/updatecli/scripts/update-flannel.sh
+++ b/updatecli/scripts/update-flannel.sh
@@ -19,6 +19,7 @@ if [ -n "$FLANNEL_VERSION" ]; then
 			yq -i ".packageVersion = $new_version" packages/rke2-flannel/package.yaml
 		fi
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-flannel' make prepare
+		find packages/rke2-flannel/charts -name '*.orig' -delete
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-flannel' make patch
 		make clean
 	fi


### PR DESCRIPTION
Updated calico chart to v3.29.1 and added the deletion of .orig files.

Replaces: https://github.com/rancher/rke2-charts/pull/567

Depends on:

- [x] https://github.com/rancher/image-mirror/pull/776
- [x] https://github.com/rancher/image-mirror/pull/774