### PR TITLE
Fix broken ciliumlocalredirectpolicy

### DIFF
--- a/packages/rke2-coredns/generated-changes/overlay/templates/lrp-nodelocal.yaml
+++ b/packages/rke2-coredns/generated-changes/overlay/templates/lrp-nodelocal.yaml
@@ -8,15 +8,22 @@ spec:
     serviceMatcher:
       serviceName: {{ default (include "coredns.fullname" .) .Values.service.name }}
       namespace: {{ .Release.Namespace }}
+      toPorts:
+        - name: dns-tcp
+          port: "53"
+          protocol: TCP
+        - name: dns
+          port: "53"
+          protocol: UDP 
   redirectBackend:
     localEndpointSelector:
       matchLabels:
         k8s-app: node-local-dns
     toPorts:
-      - port: "53"
-        name: udp-53
+      - name: dns
+        port: "53"
         protocol: UDP
-      - port: "53"
-        name: tcp-53
+      - name: dns-tcp
+        port: "53"
         protocol: TCP
 {{- end }}


### PR DESCRIPTION
The Cilium local redirect policy is broken. The solution posted here https://github.com/cilium/cilium/issues/13040#issuecomment-2039227198 solves the problem. This PR implements the solution.


---
## Before:
```
⌛ [default] Waiting for pod cilium-test-1/client-b65598b6f-4fj5q to reach default/kubernetes service...
🐛 [default] Error looking up kubernetes.default from pod cilium-test-1/client-b65598b6f-4fj5q: error with exec request (pod=cilium-test-1/client-b65598b6f-4fj5q, container=): command terminated with exit code 1: "": ;; communications error to 240.0.0.10#53: timed out
;; communications error to 240.0.0.10#53: timed out
;; communications error to 240.0.0.10#53: timed out
;; no servers could be reached



🐛 [default] Error looking up kubernetes.default from pod cilium-test-1/client-b65598b6f-4fj5q: error with exec request (pod=cilium-test-1/client-b65598b6f-4fj5q, container=): context deadline exceeded: "": ;; communications error to 240.0.0.10#53: timed out

timeout reached waiting for lookup for kubernetes.default from pod cilium-test-1/client-b65598b6f-4fj5q to succeed (last error: error with exec request (pod=cilium-test-1/client-b65598b6f-4fj5q, container=): context deadline exceeded: "")
```


## After:
```
✅ [cilium-test-1] All 61 tests (658 actions) successful, 44 tests skipped, 0 scenarios skipped.
```
