### PR TITLE
Bump ingress-nginx to hardened6

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -14,7 +14,7 @@
 -    digest: sha256:c84d11b1f7bd14ebbf49918a7f0dc01b31c0c6e757e0129520ea93453096315c
 -    digestChroot: sha256:030a43bdd5f0212a7e135cc4da76b15a6706ef65a6824eb4cc401f87a81c2987
 -    pullPolicy: IfNotPresent
-+    tag: "v1.10.5-hardened4"
++    tag: "v1.10.5-hardened6"
      runAsNonRoot: true
      # www-data -> uid 101
      runAsUser: 101

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.10.5/ingress-nginx-4.10.5.tgz
-packageVersion: 02
+packageVersion: 03
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Update to base image to address CVEs in hardened4
```
rancher/nginx-ingress-controller:v1.10.5-hardened4 (suse linux enterprise server 15.6)
Total: 18 (UNKNOWN: 0, LOW: 2, MEDIUM: 11, HIGH: 5, CRITICAL: 0)


rancher/nginx-ingress-controller:v1.10.5-hardened6 (suse linux enterprise server 15.6)
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```