### PR TITLE
Fixed typo in dns-node-cache version

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -172,10 +172,10 @@
 +  use_cilium_lrp: false
 +  image:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.24.0-build2024121"
++    tag: "1.24.0-build20241211"
 +  initimage:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.24.0-build2024121"
++    tag: "1.24.0-build20241211"
 +  nodeSelector:
 +    kubernetes.io/os: linux
 +

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.36.1/coredns-1.36.1.tgz
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Missed a `1` in the date.