### PR TITLE
Update Flannel to v0.26.2

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
@@ -9,4 +9,4 @@
  sources:
 -- https://github.com/flannel-io/flannel
 +- https://github.com/rancher/rke2-charts
- version: v0.26.1
+ version: v0.26.2

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -15,12 +15,12 @@
    # kube-flannel image
    image:
 -    repository: docker.io/flannel/flannel
--    tag: v0.26.1
+-    tag: v0.26.2
 +    repository: rancher/hardened-flannel
-+    tag: v0.26.1-build20241211
++    tag: v0.26.2-build20241212
    image_cni:
 -    repository: docker.io/flannel/flannel-cni-plugin
--    tag: v1.5.1-flannel2
+-    tag: v1.6.0-flannel1
 +    repository: rancher/hardened-cni-plugins
 +    tag: v1.6.0-build20241022
    # flannel command arguments

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/flannel-io/flannel/releases/download/v0.26.1/flannel.tgz
-packageVersion: 01
+url: https://github.com/flannel-io/flannel/releases/download/v0.26.2/flannel.tgz
+packageVersion: 00


### PR DESCRIPTION
Update Flannel to `v0.26.2` to fix automated update.