### PR TITLE
Bump Harvester CSI driver v0.1.22

### DIFF
--- a/packages/harvester-csi-driver/package.yaml
+++ b/packages/harvester-csi-driver/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-csi-driver-0.1.21/harvester-csi-driver-0.1.21.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-csi-driver-0.1.22/harvester-csi-driver-0.1.22.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
Bump Harvester CSI driver v0.1.22
Related issue: https://github.com/harvester/harvester/issues/7308

Hi @brandond,
We would like to bump Harvester CSI driver v0.1.22 to update the `kube-version` annotation.
Please help review it. Thanks!

Thanks!