### PR TITLE
Move cilium chart apparmor annotation migration out to 1.31

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-agent/daemonset.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-agent/daemonset.yaml.patch
@@ -12,6 +12,26 @@
  {{- if and .Values.agent (not .Values.preflight.enabled) }}
  
  {{- /*  Default values with backwards compatibility */ -}}
+@@ -54,7 +62,7 @@
+         cilium.io/cilium-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-configmap.yaml") . | sha256sum | quote }}
+         {{- end }}
+         {{- if not .Values.securityContext.privileged }}
+-        {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
++        {{- if semverCompare "<1.31.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+         # Set app AppArmor's profile to "unconfined". The value of this annotation
+         # can be modified as long users know which profiles they have available
+         # in AppArmor.
+@@ -85,8 +93,8 @@
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+       {{- /* K8s version lower than 1.30.0 don't support the "appArmorProfile" field, */}}
+-      {{- /* thus we have to remove it. */}}
+-      {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
++      {{- /* thus we have to remove it until 1.31.0 when both old and new cluster members will support it. */}}
++      {{- if semverCompare "<1.31.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+         {{- $_ := unset .Values.podSecurityContext "appArmorProfile" }}
+       {{- end }}
+       {{- with .Values.podSecurityContext }}
 @@ -95,7 +103,7 @@
        {{- end }}
        containers:

--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-envoy/daemonset.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-envoy/daemonset.yaml.patch
@@ -1,5 +1,25 @@
 --- charts-original/templates/cilium-envoy/daemonset.yaml
 +++ charts/templates/cilium-envoy/daemonset.yaml
+@@ -31,7 +31,7 @@
+         cilium.io/cilium-envoy-configmap-checksum: {{ include (print $.Template.BasePath "/cilium-envoy/configmap.yaml") . | sha256sum | quote }}
+         {{- end }}
+         {{- if not .Values.envoy.securityContext.privileged }}
+-        {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
++        {{- if semverCompare "<1.31.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+         # Set app AppArmor's profile to "unconfined". The value of this annotation
+         # can be modified as long users know which profiles they have available
+         # in AppArmor.
+@@ -55,8 +55,8 @@
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+       {{- /* K8s version lower than 1.30.0 don't support the "appArmorProfile" field, */}}
+-      {{- /* thus we have to remove it. */}}
+-      {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
++      {{- /* thus we have to remove it until 1.31.0 when both old and new cluster members will support it. */}}
++      {{- if semverCompare "<1.31.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+         {{- $_ := unset .Values.envoy.podSecurityContext "appArmorProfile" }}
+       {{- end }}
+       {{- with .Values.envoy.podSecurityContext }}
 @@ -65,7 +65,7 @@
        {{- end }}
        containers:

--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-nodeinit/daemonset.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-nodeinit/daemonset.yaml.patch
@@ -1,5 +1,25 @@
 --- charts-original/templates/cilium-nodeinit/daemonset.yaml
 +++ charts/templates/cilium-nodeinit/daemonset.yaml
+@@ -28,7 +28,7 @@
+         {{- toYaml . | nindent 8 }}
+         {{- end }}
+         {{- if not .Values.securityContext.privileged }}
+-        {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
++        {{- if semverCompare "<1.31.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+         # Set app AppArmor's profile to "unconfined". The value of this annotation
+         # can be modified as long users know which profiles they have available
+         # in AppArmor.
+@@ -48,8 +48,8 @@
+         {{- toYaml . | nindent 8 }}
+       {{- end }}
+       {{- /* K8s version lower than 1.30.0 don't support the "appArmorProfile" field, */}}
+-      {{- /* thus we have to remove it. */}}
+-      {{- if semverCompare "<1.30.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
++      {{- /* thus we have to remove it until 1.31.0 when both old and new cluster members will support it. */}}
++      {{- if semverCompare "<1.31.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor) }}
+         {{- $_ := unset .Values.nodeinit.podSecurityContext "appArmorProfile" }}
+       {{- end }}
+       {{- with .Values.nodeinit.podSecurityContext }}
 @@ -58,7 +58,7 @@
        {{- end }}
        containers:

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.16.5.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
* For https://github.com/rancher/rke2/issues/7480