### PR TITLE
Add Autodetect config for IPv6 and removed on IPv4 if CIDR not configured

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/crs/custom-resources.yaml
 +++ charts/templates/crs/custom-resources.yaml
-@@ -2,7 +2,34 @@
+@@ -2,7 +2,43 @@
  {{ $installSpec := omit .Values.installation "enabled" }}
  {{ $_ := set $installSpec "imagePullSecrets" (include "tigera-operator.imagePullSecrets" . | fromYamlArray) }}
  {{ $_ := set $installSpec "kubeletVolumePluginPath" .Values.kubeletVolumePluginPath }}
@@ -27,9 +27,18 @@
 +{{ $_ := set $calicoNetwork "ipPools" $finalIpPoolList }}
 +{{ end }}
 +{{ if empty .Values.installation.calicoNetwork.nodeAddressAutodetectionV4 }}
++{{ if not (empty .Values.global.clusterCIDRv4) }}
 +{{ $calicoNetwork := get .Values.installation "calicoNetwork" }}
 +{{ $autodetect := dict "firstFound" true }}
 +{{ $_ := set $calicoNetwork "nodeAddressAutodetectionV4" $autodetect }}
++{{ end }}
++{{ end }}
++{{ if empty .Values.installation.calicoNetwork.nodeAddressAutodetectionV6 }}
++{{ if not (empty .Values.global.clusterCIDRv6) }}
++{{ $calicoNetwork := get .Values.installation "calicoNetwork" }}
++{{ $autodetect := dict "firstFound" true }}
++{{ $_ := set $calicoNetwork "nodeAddressAutodetectionV6" $autodetect }}
++{{ end }}
 +{{ end }}
 +{{ end }}
 + 

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.29.1/tigera-operator-v3.29.1.tgz
-packageVersion: 00
+packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
This PR fixed Autodetection method for IPv4 and IPv6 in case of IPv6 only node where the `nodeAddressAutodetectionV4` value was configured when no IPv4 CIDR was used.
Issue:
- https://github.com/rancher/rke2/issues/7454