### PR TITLE
Update metrics-server chart to 3.12.2

### DIFF
--- a/packages/rke2-metrics-server/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/Chart.yaml.patch
@@ -1,15 +1,6 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -5,7 +5,7 @@
-     - kind: changed
-       description: "Updated the _addon-resizer_ OCI image to [v1.8.20](https://github.com/kubernetes/autoscaler/releases/tag/addon-resizer-1.8.20)."
- apiVersion: v2
--appVersion: 0.7.0
-+appVersion: 0.7.1
- description: Metrics Server is a scalable, efficient source of container resource
-   metrics for Kubernetes built-in autoscaling pipelines.
- home: https://github.com/kubernetes-sigs/metrics-server
-@@ -21,7 +21,7 @@
+@@ -25,7 +25,7 @@
    url: https://github.com/krmichel
  - name: endrec
    url: https://github.com/endrec

--- a/packages/rke2-metrics-server/generated-changes/patch/templates/deployment.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/templates/deployment.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/deployment.yaml
 +++ charts/templates/deployment.yaml
-@@ -59,7 +59,7 @@
+@@ -61,7 +61,7 @@
            securityContext:
              {{- toYaml . | nindent 12 }}
            {{- end }}
@@ -9,7 +9,7 @@
            imagePullPolicy: {{ .Values.image.pullPolicy }}
            args:
              - {{ printf "--secure-port=%d" (int .Values.containerPort) }}
-@@ -100,7 +100,7 @@
+@@ -102,7 +102,7 @@
            securityContext:
              {{- toYaml . | nindent 12 }}
            {{- end }}

--- a/packages/rke2-metrics-server/generated-changes/patch/templates/service.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/templates/service.yaml.patch
@@ -1,9 +1,9 @@
 --- charts-original/templates/service.yaml
 +++ charts/templates/service.yaml
-@@ -19,5 +19,6 @@
-       port: {{ .Values.service.port }}
+@@ -20,5 +20,6 @@
        protocol: TCP
        targetPort: https
+       appProtocol: https
 +  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
    selector:
      {{- include "metrics-server.selectorLabels" . | nindent 4 }}

--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -27,7 +27,7 @@
 -    repository: registry.k8s.io/autoscaling/addon-resizer
 -    tag: 1.8.20
 +    repository: rancher/hardened-addon-resizer
-+    tag: 1.8.20-build20241001
++    tag: 1.8.22-build20250110
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true

--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -8,11 +8,11 @@
 +  repository: rancher/hardened-k8s-metrics-server
    # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
 -  tag: ""
-+  tag: v0.7.1-build20241008
++  tag: v0.7.2-build20250110
    pullPolicy: IfNotPresent
  
  imagePullSecrets: []
-@@ -121,6 +121,7 @@
+@@ -122,6 +122,7 @@
    port: 443
    annotations: {}
    labels: {}
@@ -20,18 +20,18 @@
    #  Add these labels to have metrics-server show up in `kubectl cluster-info`
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
-@@ -128,8 +129,8 @@
+@@ -129,8 +130,8 @@
  addonResizer:
    enabled: false
    image:
 -    repository: registry.k8s.io/autoscaling/addon-resizer
--    tag: 1.8.20
+-    tag: 1.8.21
 +    repository: rancher/hardened-addon-resizer
 +    tag: 1.8.22-build20250110
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true
-@@ -180,7 +181,8 @@
+@@ -181,7 +182,8 @@
  
  extraVolumes: []
  
@@ -41,7 +41,7 @@
  
  tolerations: []
  
-@@ -197,3 +199,6 @@
+@@ -198,3 +200,6 @@
  
  tmpVolume:
    emptyDir: {}

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.0/metrics-server-3.12.0.tgz
-packageVersion: 05
+url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.2/metrics-server-3.12.2.tgz
+packageVersion: 00

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.0/metrics-server-3.12.0.tgz
-packageVersion: 04
+packageVersion: 05


### PR DESCRIPTION
Update to the latest metrics-server chart.

Also bump to the latest images:
* hardened-k8s-metrics-server:v0.7.2-build20250110
* hardened-addon-resizer:1.8.22-build20250110