### PR TITLE
Move ingress-nginx global values under new default structure

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
@@ -29,5 +29,5 @@
 +{{- end -}}
 +
 +{{- define "repository_or_registry_and_image" -}}
-+{{- if .repository -}}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{- end -}}:{{ .tag }}{{- if (.digest) -}} @{{.digest}} {{- end -}}
++{{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
 +{{- end -}}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,16 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -26,14 +26,11 @@
+@@ -6,6 +6,9 @@
+   image:
+     # -- Registry host to pull images from.
+     registry: registry.k8s.io
++  systemDefaultRegistry: ""
++  systemDefaultIngressClass: ""
++
+ ## Overrides for generated resource names
+ # See templates/_helpers.tpl
+ # nameOverride:
+@@ -26,14 +29,11 @@
      ## Keep false as default for now!
      chroot: false
      # registry: registry.k8s.io
@@ -17,7 +27,7 @@
      runAsNonRoot: true
      # -- This value must not be changed using the official image.
      # uid=101(www-data) gid=82(www-data) groups=82(www-data)
-@@ -46,7 +43,7 @@
+@@ -46,7 +46,7 @@
        type: RuntimeDefault
      readOnlyRootFilesystem: false
    # -- Configures the controller container name
@@ -26,7 +36,7 @@
    # -- Configures the ports that the nginx-controller listens on
    containerPort:
      http: 80
-@@ -77,7 +74,7 @@
+@@ -77,7 +77,7 @@
    # -- Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
    # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
    # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
@@ -35,7 +45,7 @@
    # -- Bare-metal considerations via the host network https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network
    # Ingress status was blank because there is no Service exposing the Ingress-Nginx Controller in a configuration using the host network, the default --publish-service flag used in standard cloud setups does not apply
    reportNodeInternalIp: false
-@@ -107,7 +104,7 @@
+@@ -107,7 +107,7 @@
    ## Disabled by default
    hostPort:
      # -- Enable 'hostPort' or not
@@ -44,7 +54,7 @@
      ports:
        # -- 'hostPort' http port
        http: 80
-@@ -174,7 +171,7 @@
+@@ -174,7 +174,7 @@
    # node or nodes where an ingress controller pod is running.
    publishService:
      # -- Enable 'publishService' or not
@@ -53,7 +63,7 @@
      # -- Allows overriding of the publish service to bind to
      # Must be <namespace>/<service_name>
      pathOverride: ""
-@@ -221,7 +218,7 @@
+@@ -221,7 +221,7 @@
    #         name: secret-resource
  
    # -- Use a `DaemonSet` or `Deployment`
@@ -62,7 +72,7 @@
    # -- Annotations to be added to the controller Deployment or DaemonSet
    ##
    annotations: {}
-@@ -482,7 +479,7 @@
+@@ -482,7 +482,7 @@
      configMapKey: ""
    service:
      # -- Enable controller services or not. This does not influence the creation of either the admission webhook or the metrics service.
@@ -71,7 +81,7 @@
      external:
        # -- Enable the external controller service or not. Useful for internal-only deployments.
        enabled: true
-@@ -752,6 +749,7 @@
+@@ -752,6 +752,7 @@
        loadBalancerSourceRanges: []
        servicePort: 443
        type: ClusterIP
@@ -79,7 +89,7 @@
      createSecretJob:
        name: create
        # -- Security context for secret creation containers
-@@ -792,12 +790,11 @@
+@@ -792,12 +793,11 @@
        enabled: true
        image:
          # registry: registry.k8s.io
@@ -93,7 +103,7 @@
          pullPolicy: IfNotPresent
        # -- Provide a priority class name to the webhook patching job
        ##
-@@ -951,11 +948,11 @@
+@@ -951,11 +951,11 @@
    name: defaultbackend
    image:
      # registry: registry.k8s.io
@@ -107,11 +117,3 @@
      pullPolicy: IfNotPresent
      runAsNonRoot: true
      # nobody user -> uid 65534
-@@ -1191,3 +1188,7 @@
- # This can be generated with: `openssl dhparam 4096 2> /dev/null | base64`
- ## Ref: https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/ssl-dh-param
- dhParam: ""
-+
-+global:
-+  systemDefaultRegistry: ""
-+  systemDefaultIngressClass: ""

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.12.0/ingress-nginx-4.12.0.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Fixes the latest release v1.12.0 of ingress-nginx chart. A new global structure is now in upstream, so we no longer should define our own.