### PR TITLE
rke2-ingress-nginx: Remove incorrectly included `with` bracket for global images

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-createSecret.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-createSecret.yaml.patch
@@ -1,11 +1,13 @@
 --- charts-original/templates/admission-webhooks/job-patch/job-createSecret.yaml
 +++ charts/templates/admission-webhooks/job-patch/job-createSecret.yaml
-@@ -43,7 +43,7 @@
+@@ -42,9 +42,7 @@
+     {{- end }}
        containers:
          - name: create
-           {{- with (merge .Values.controller.admissionWebhooks.patch.image .Values.global.image) }}
+-          {{- with (merge .Values.controller.admissionWebhooks.patch.image .Values.global.image) }}
 -          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
+-          {{- end }}
 +          image: "{{ template "system_default_registry" . }}{{ template "repository_or_registry_and_image" .Values.controller.admissionWebhooks.patch.image }}"
-           {{- end }}
            imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
            args:
+             - create

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-patchWebhook.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/admission-webhooks/job-patch/job-patchWebhook.yaml.patch
@@ -1,11 +1,13 @@
 --- charts-original/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
 +++ charts/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
-@@ -43,7 +43,7 @@
+@@ -42,9 +42,7 @@
+     {{- end }}
        containers:
          - name: patch
-           {{- with (merge .Values.controller.admissionWebhooks.patch.image .Values.global.image) }}
+-          {{- with (merge .Values.controller.admissionWebhooks.patch.image .Values.global.image) }}
 -          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
+-          {{- end }}
 +          image: "{{ template "system_default_registry" . }}{{ template "repository_or_registry_and_image" .Values.controller.admissionWebhooks.patch.image }}"
-           {{- end }}
            imagePullPolicy: {{ .Values.controller.admissionWebhooks.patch.image.pullPolicy }}
            args:
+             - patch

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch
@@ -1,11 +1,13 @@
 --- charts-original/templates/controller-daemonset.yaml
 +++ charts/templates/controller-daemonset.yaml
-@@ -76,7 +76,7 @@
+@@ -75,9 +75,7 @@
+     {{- end }}
        containers:
          - name: {{ .Values.controller.containerName }}
-           {{- with (merge .Values.controller.image .Values.global.image) }}
+-          {{- with (merge .Values.controller.image .Values.global.image) }}
 -          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ include "ingress-nginx.image" . }}{{ end }}:{{ .tag }}{{ include "ingress-nginx.imageDigest" . }}
+-          {{- end }}
 +          image: "{{ template "system_default_registry" . }}{{ template "repository_or_registry_and_image" .Values.controller.image }}"
-           {{- end }}
            imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
          {{- if .Values.controller.lifecycle }}
+           lifecycle: {{ toYaml .Values.controller.lifecycle | nindent 12 }}

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-deployment.yaml.patch
@@ -1,11 +1,13 @@
 --- charts-original/templates/controller-deployment.yaml
 +++ charts/templates/controller-deployment.yaml
-@@ -82,7 +82,7 @@
+@@ -81,9 +81,7 @@
+     {{- end }}
        containers:
          - name: {{ .Values.controller.containerName }}
-           {{- with (merge .Values.controller.image .Values.global.image) }}
+-          {{- with (merge .Values.controller.image .Values.global.image) }}
 -          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ include "ingress-nginx.image" . }}{{ end }}:{{ .tag }}{{ include "ingress-nginx.imageDigest" . }}
+-          {{- end }}
 +          image: "{{ template "system_default_registry" . }}{{ template "repository_or_registry_and_image" .Values.controller.image }}"
-           {{- end }}
            imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
          {{- if .Values.controller.lifecycle }}
+           lifecycle: {{ toYaml .Values.controller.lifecycle | nindent 12 }}


### PR DESCRIPTION
Prior patches were already getting rid of the `with` line. https://github.com/rancher/rke2-charts/blob/24733707b3b033b1a266f9bb7286fb266cfa12e3/packages/rke2-ingress-nginx/generated-changes/patch/templates/controller-daemonset.yaml.patch

It was accidentally brought back in with v1.12.0 chart