### PR TITLE
Added automatic update for cni plugins image on cilium chart

### DIFF
--- a/updatecli/scripts/update-cilium.sh
+++ b/updatecli/scripts/update-cilium.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 set -eu
+if [ -n "$CNI_PLUGINS_VERSION" ]; then
+	current_cni_plugins_version=$(sed -nr 's/\+    tag: \"(v'[0-9]+.[0-9]+.[0-9]+-build[0-9]+')\"/\1/p' packages/rke2-cilium/generated-changes/patch/values.yaml.patch)
+	if [ "$current_cni_plugins_version" != "$CNI_PLUGINS_VERSION" ]; then
+		sed -ie "s/$current_cni_plugins_version/$CNI_PLUGINS_VERSION/g" packages/rke2-cilium/generated-changes/patch/values.yaml.patch
+		sed -ie "s/$current_cni_plugins_version/$CNI_PLUGINS_VERSION/g" updatecli/scripts/cilium-values.yaml.patch.template
+		package_version=$(yq '.packageVersion' packages/rke2-cilium/package.yaml)
+		new_version=$(printf "%02d" $(($package_version + 1)))
+		yq -i ".packageVersion = $new_version" packages/rke2-cilium/package.yaml
+	fi
+fi
 if [ -n "$CILIUM_VERSION" ]; then
 	current_cilium_version=$(sed -nr 's/^\ version: ('[0-9]+.[0-9]+.[0-9]+')/\1/p' packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch)
 	if [ "v$current_cilium_version" != "$CILIUM_VERSION" ]; then

--- a/updatecli/updatecli.d/updatecilium.yaml
+++ b/updatecli/updatecli.d/updatecilium.yaml
@@ -16,6 +16,23 @@ sources:
         latest: true
       versionfilter:
         kind: latest
+  cni_plugins:
+    name: Get CNI plugins version
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-cni-plugins
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        latest: true
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
 
 targets:
   ciliumImage:
@@ -28,6 +45,8 @@ targets:
       environments:
         - name: CILIUM_VERSION
           value: '{{ source "cilium" }}'
+        - name: CNI_PLUGINS_VERSION
+          value: '{{ source "cni_plugins" }}'
         - name: PATH
 
 
@@ -45,7 +64,7 @@ scms:
       
 actions:
   default:
-    title: 'Update Cilium version to {{ source "cilium" }}'
+    title: 'Update Cilium version to {{ source "cilium" }} and CNI plugins image to {{ source "cni_plugins" }}'
     kind: github/pullrequest
     spec:
       automerge: false


### PR DESCRIPTION
This PR add the check for new version of the cni plugins image with updatecli and creates the PR with the updated version on the cilium chart.