### PR TITLE
Fixed cilium updatecli script to add output in case of cni plugin update

### DIFF
--- a/updatecli/scripts/update-cilium.sh
+++ b/updatecli/scripts/update-cilium.sh
@@ -3,6 +3,7 @@ set -eu
 if [ -n "$CNI_PLUGINS_VERSION" ]; then
 	current_cni_plugins_version=$(sed -nr 's/\+    tag: \"(v'[0-9]+.[0-9]+.[0-9]+-build[0-9]+')\"/\1/p' packages/rke2-cilium/generated-changes/patch/values.yaml.patch)
 	if [ "$current_cni_plugins_version" != "$CNI_PLUGINS_VERSION" ]; then
+		echo "Updating CNI plugin version to $CNI_PLUGINS_VERSION"
 		sed -ie "s/$current_cni_plugins_version/$CNI_PLUGINS_VERSION/g" packages/rke2-cilium/generated-changes/patch/values.yaml.patch
 		sed -ie "s/$current_cni_plugins_version/$CNI_PLUGINS_VERSION/g" updatecli/scripts/cilium-values.yaml.patch.template
 		package_version=$(yq '.packageVersion' packages/rke2-cilium/package.yaml)


### PR DESCRIPTION
Added an `echo` in case of update the CNI plugins image version on the script to force updatecli to create the PR with the update.