### PR TITLE
fix: rke2-multus: cni image version

### DIFF
--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -122,7 +122,7 @@ tolerations:
 cniplugins:
   image:
     repository: rancher/hardened-cni-plugins
-    tag: v1.6.2-build20250108
+    tag: v1.6.2-build20250124
 
   # skipcnis is a comma separated list of cni binaries to skip from
   # installing.

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Fixes issue introduced in #605

Version `v1.6.2-build20250108` doesn't exists on docker.io