### PR TITLE
rke2-flannel: fixup `hardened-cni-plugin` image name

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -24,7 +24,7 @@
 -  # skipCNIConfigInstallation skips the installation of the flannel CNI config. This is useful when the CNI config is
 -  # provided externally.
 -  skipCNIConfigInstallation: false
-+    repository: rancher/cni-plugins
++    repository: rancher/hardened-cni-plugins
 +    tag: v1.6.2-build20250124
    # flannel command arguments
    enableNFTables: false

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.26.4/flannel.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
Fix accidentally renamed cni-plugin image:
`rancher/cni-plugins` -> `rancher/hardened-cni-plugins`

Fixup: https://github.com/rancher/rke2-charts/pull/619
See also: https://github.com/rancher/rke2/actions/runs/13171375450/job/36762238705
