### PR TITLE
Revert calico to `v3.29.1`

### DIFF
--- a/packages/rke2-canal/charts/Chart.yaml
+++ b/packages/rke2-canal/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: rke2-canal
 description: Install Canal Network Plugin.
-version: v3.29.1-build20250206
+version: v3.29.1-build20250220
 appVersion: v3.29.1
 home: https://www.projectcalico.org/
 keywords:

--- a/packages/rke2-canal/charts/Chart.yaml
+++ b/packages/rke2-canal/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: rke2-canal
 description: Install Canal Network Plugin.
-version: v3.29.2-build20250218
-appVersion: v3.29.2
+version: v3.29.1-build20250206
+appVersion: v3.29.1
 home: https://www.projectcalico.org/
 keywords:
   - canal

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -8,7 +8,7 @@ flannel:
   # kube-flannel image
   image:
     repository: rancher/hardened-flannel
-    tag: v0.26.4-build20250206
+    tag: v0.26.4-build20250218
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.
@@ -60,19 +60,19 @@ calico:
   # CNI installation image.
   cniImage:
     repository: rancher/hardened-calico
-    tag: v3.29.1-build20250206
+    tag: v3.29.1-build20250220
   # Canal node image.
   nodeImage:
     repository: rancher/hardened-calico
-    tag: v3.29.1-build20250206
+    tag: v3.29.1-build20250220
   # Flexvol Image.
   flexvolImage:
     repository: rancher/hardened-calico
-    tag: v3.29.1-build20250206
+    tag: v3.29.1-build20250220
   # kubecontroller image
   kubeControllerImage:
     repository: rancher/hardened-calico
-    tag: v3.29.1-build20250206
+    tag: v3.29.1-build20250220
   # Datastore type for canal. It can be either kuberentes or etcd.
   datastoreType: kubernetes
   # Wait for datastore to initialize.

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -8,7 +8,7 @@ flannel:
   # kube-flannel image
   image:
     repository: rancher/hardened-flannel
-    tag: v0.26.4-build20250218
+    tag: v0.26.4-build20250206
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.
@@ -60,19 +60,19 @@ calico:
   # CNI installation image.
   cniImage:
     repository: rancher/hardened-calico
-    tag: v3.29.2-build20250218
+    tag: v3.29.1-build20250206
   # Canal node image.
   nodeImage:
     repository: rancher/hardened-calico
-    tag: v3.29.2-build20250218
+    tag: v3.29.1-build20250206
   # Flexvol Image.
   flexvolImage:
     repository: rancher/hardened-calico
-    tag: v3.29.2-build20250218
+    tag: v3.29.1-build20250206
   # kubecontroller image
   kubeControllerImage:
     repository: rancher/hardened-calico
-    tag: v3.29.2-build20250218
+    tag: v3.29.1-build20250206
   # Datastore type for canal. It can be either kuberentes or etcd.
   datastoreType: kubernetes
   # Wait for datastore to initialize.


### PR DESCRIPTION
Revert to calico `v3.29.1` on the canal chart

This reverts commit:
- https://github.com/rancher/rke2-charts/commit/e45fbbddb161b9d85bebc597d895ae3b0ca79937
- https://github.com/rancher/rke2-charts/commit/626f8fb5e57003eb14ac7f0c7d630dd57105d509

Bumps to latest flannel and calico images:
- rancher/hardened-flannel:v0.26.4-build20250218
- rancher/hardened-calico:v3.29.1-build20250220