### PR TITLE
Update to flannel `v0.26.5`

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
@@ -9,4 +9,4 @@
  sources:
 -- https://github.com/flannel-io/flannel
 +- https://github.com/rancher/rke2-charts
- version: v0.26.4
+ version: v0.26.5

--- a/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/templates/config.yaml.patch
@@ -1,7 +1,7 @@
 --- charts-original/templates/config.yaml
 +++ charts/templates/config.yaml
-@@ -29,13 +29,13 @@
-     }
+@@ -10,13 +10,13 @@
+   cni-conf.json: {{ .Values.flannel.cniConf | toJson }}
    net-conf.json: |
      {
 -{{- if .Values.podCidr }}

--- a/packages/rke2-flannel/generated-changes/patch/templates/daemonset.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/templates/daemonset.yaml.patch
@@ -87,8 +87,8 @@
            path: /run/flannel
        - name: cni-plugin
          hostPath:
-           path: /opt/cni/bin
+           path: {{ .Values.flannel.cniBinDir }}
 +          type: DirectoryOrCreate
        - name: cni
          hostPath:
-           path: /etc/cni/net.d
+           path: {{ .Values.flannel.cniConfDir }}

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -50,7 +50,20 @@
    # Enable VXLAN Group Based Policy (Default false)
    # GBP: false
    # Enable direct routes (default is false)
-@@ -83,16 +71,18 @@
+@@ -76,6 +64,12 @@
+           "capabilities": {
+             "portMappings": true
+           }
++        },
++        {
++          "type":"bandwidth",
++          "capabilities": {
++            "bandwidth": true
++          }
+         }
+       ]
+     }
+@@ -83,16 +77,18 @@
    # General daemonset configs
    #
    tolerations:

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -1,24 +1,12 @@
+@@ -1,28 +1,16 @@
  ---
 -global:
 -  imagePullSecrets:
@@ -15,21 +15,25 @@
    # kube-flannel image
    image:
 -    repository: ghcr.io/flannel-io/flannel
--    tag: v0.26.4
+-    tag: v0.26.5
 +    repository: rancher/hardened-flannel
-+    tag: v0.26.4-build20250306
++    tag: v0.26.5-build20250306
    image_cni:
 -    repository: ghcr.io/flannel-io/flannel-cni-plugin
 -    tag: v1.6.2-flannel1
++    repository: rancher/hardened-cni-plugins
++    tag: v1.6.2-build20250306
+   # cniBinDir is the directory to which the flannel CNI binary is installed.
+   cniBinDir: "/opt/cni/bin"
+   # cniConfDir is the directory where the CNI configuration is located.
+   cniConfDir: "/etc/cni/net.d"
 -  # skipCNIConfigInstallation skips the installation of the flannel CNI config. This is useful when the CNI config is
 -  # provided externally.
 -  skipCNIConfigInstallation: false
-+    repository: rancher/hardened-cni-plugins
-+    tag: v1.6.2-build20250124
    # flannel command arguments
    enableNFTables: false
    args:
-@@ -29,14 +17,14 @@
+@@ -33,14 +21,14 @@
    # Documentation at https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md
    backend: "vxlan"
    # Port used by the backend 0 means default value (VXLAN: 8472, Wireguard: 51821, UDP: 8285)
@@ -46,7 +50,7 @@
    # Enable VXLAN Group Based Policy (Default false)
    # GBP: false
    # Enable direct routes (default is false)
-@@ -58,16 +46,18 @@
+@@ -83,16 +71,18 @@
    # General daemonset configs
    #
    tolerations:

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/flannel-io/flannel/releases/download/v0.26.4/flannel.tgz
-packageVersion: 04
+url: https://github.com/flannel-io/flannel/releases/download/v0.26.5/flannel.tgz
+packageVersion: 00


### PR DESCRIPTION
Manually resolve chart conflicts for update to flannel `v0.26.5`

Also adds the `bandwidth` plugin to the cniConf