### PR TITLE
rke2-canal: make probes and resources more configurable

### DIFF
--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -83,6 +83,9 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+          {{- if .Values.calico_init.resources }}
+          resources: {{- toYaml .Values.calico_init.resources | nindent 12 }}
+          {{- end }}
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
@@ -93,6 +96,10 @@ spec:
             mountPath: /host/driver
           securityContext:
             privileged: true
+          {{- if .Values.flexvol.resources }}
+          resources: {{- toYaml .Values.flexvol.resources | nindent 12 }}
+          {{- end }}
+
       containers:
         # Runs canal container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -192,22 +199,8 @@ spec:
                 command:
                 - /usr/bin/calico-node
                 - -shutdown
-          livenessProbe:
-            exec:
-              command:
-              - /usr/bin/calico-node
-              - -felix-live
-            periodSeconds: 10
-            initialDelaySeconds: 10
-            failureThreshold: 6
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9099
-              host: localhost
-            periodSeconds: 10
-            timeoutSeconds: 10
+          livenessProbe: {{- toYaml .Values.calico.livenessProbe | nindent 12 }}
+          readinessProbe: {{- toYaml .Values.calico.readinessProbe | nindent 12 }}
           volumeMounts:
             # For maintaining CNI plugin API credentials.
             - mountPath: /host/etc/cni/net.d

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -130,6 +130,40 @@ calico:
       # limits:
       #   cpu: 250m
       #   memory: 256Mi
+  livenessProbe:
+    exec:
+      command:
+      - /usr/bin/calico-node
+      - -felix-live
+    periodSeconds: 10
+    initialDelaySeconds: 10
+    failureThreshold: 6
+    timeoutSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /readiness
+      port: 9099
+      host: localhost
+    periodSeconds: 10
+    timeoutSeconds: 10
+# configuration for the calico-init initContainer
+calico_init:
+  resources: ~
+    # requests:
+    #   memory: 256Mi
+    #   cpu: 100m
+    # limits:
+    #   memory: 256Mi
+    #   cpu: 100m
+# configuration for the flexvol-driver initContainer
+flexvol:
+  resources: ~
+    # requests:
+    #   memory: 64Mi
+    #   cpu: 100m
+    # limits:
+    #   memory: 64Mi
+    #   cpu: 100m
 global:
   systemDefaultRegistry: ""
   clusterCIDRv4: ""

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
We add the possibility to configure the readiness and liveness probe of the calico-node pod of canal as well as the possibility to configure the resources of the init containers. 
Ref: SURE-9773