### PR TITLE
Added backend as configuration value on Calico

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/crs/custom-resources.yaml.patch
@@ -11,9 +11,9 @@
 +{{ if empty .Values.installation.calicoNetwork.ipPools }}
 +{{ $calicoNetwork := get .Values.installation "calicoNetwork" }}
 +{{ if not (empty .Values.global.clusterCIDRv4) }}
-+{{ $myIP4Dict := dict "natOutgoing" "Enabled" "encapsulation" "VXLAN" "cidr" .Values.global.clusterCIDRv4 }}
++{{ $myIP4Dict := dict "natOutgoing" .Values.installation.natOutgoing "encapsulation" .Values.installation.backend "cidr" .Values.global.clusterCIDRv4 }}
 +{{ if not (empty .Values.global.clusterCIDRv6) }}
-+{{ $myIP6Dict := dict "natOutgoing" "Enabled" "encapsulation" "VXLAN" "cidr" .Values.global.clusterCIDRv6 }}
++{{ $myIP6Dict := dict "natOutgoing" .Values.installation.natOutgoing "encapsulation" .Values.installation.backend "cidr" .Values.global.clusterCIDRv6 }}
 +{{ $ipPoolList := list $myIP4Dict }}
 +{{ $finalIpPoolList := append $ipPoolList $myIP6Dict }}
 +{{ $_ := set $calicoNetwork "ipPools" $finalIpPoolList }}
@@ -22,7 +22,7 @@
 +{{ $_ := set $calicoNetwork "ipPools" $finalIpPoolList }}
 +{{ end }}
 +{{ else if not (empty .Values.global.clusterCIDRv6) }}
-+{{ $myIP6Dict := dict "natOutgoing" "Enabled" "encapsulation" "VXLAN" "cidr" .Values.global.clusterCIDRv6 }}
++{{ $myIP6Dict := dict "natOutgoing" .Values.installation.natOutgoing "encapsulation" .Values.installation.backend "cidr" .Values.global.clusterCIDRv6 }}
 +{{ $finalIpPoolList := list $myIP6Dict }}
 +{{ $_ := set $calicoNetwork "ipPools" $finalIpPoolList }}
 +{{ end }}

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -6,8 +6,21 @@
+@@ -6,8 +6,23 @@
  imagePullSecrets: {}
  
  installation:
@@ -14,6 +14,8 @@
    enabled: true
 +  kubeletVolumePluginPath: "None"
    kubernetesProvider: ""
++  natOutgoing: "Enabled"
++  backend: "VXLAN"
 +  calicoNetwork:
 +    bgp: Disabled
 +  imagePath: "rancher"
@@ -22,7 +24,7 @@
    # imagePullSecrets are configured on all images deployed by the tigera-operator.
    # secrets specified here must exist in the tigera-operator namespace; they won't be created by the operator or helm.
    # imagePullSecrets are a slice of LocalObjectReferences, which is the same format they appear as on deployments.
-@@ -16,7 +29,7 @@
+@@ -16,7 +31,7 @@
    imagePullSecrets: []
  
  apiServer:
@@ -31,7 +33,7 @@
  
  defaultFelixConfiguration:
    enabled: false
-@@ -63,14 +76,33 @@
+@@ -63,14 +78,33 @@
  
  # Image and registry configuration for the tigera/operator pod.
  tigeraOperator:

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.29.2/tigera-operator-v3.29.2.tgz
-packageVersion: 00
+packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Moved `encapsulation` and `natOutgoing` config on calico as values on Calico chart.