### PR TITLE
Do not explicitly configure Calico MTU

### DIFF
--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -107,7 +107,7 @@ calico:
   # Set Felix endpoint to host default action to ACCEPT.
   felixDefaultEndpointToHostAction: ACCEPT
   # Configure the MTU to use.
-  vethuMTU: 1450
+  vethuMTU: 0
   # Typha is disabled.
   typhaServiceName: none
   # Kubelet flex-volume-plugin-dir


### PR DESCRIPTION
This change removes explicit configuration of Calico MTU to let Calico auto-detect host MTU and use it for workload interfaces.

For context, Calico auto-detects host network interface MTU and uses it to configure the MTU for workload interfaces [1][2]. When a non-zero MTU value is explicitly passed to Calico, it overrides the auto-detected MTU value. If the passed MTU value is greater than the host interface value, it could lead to fragmentation and packet loss.

[1] https://docs.tigera.io/calico/latest/networking/configuring/mtu#mtu-and-calico-defaults
[2] https://github.com/projectcalico/calico/blob/bda71ce13268ee63be485b0689ddeb5ff48f209f/manifests/canal.yaml#L59-L62