### PR TITLE
Bump cpi/csi to support Kubernetes v1.33

### DIFF
--- a/packages/rancher-vsphere-cpi/package.yaml
+++ b/packages/rancher-vsphere-cpi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-cpi
-commit: 52aae722ffeab0d3efe68595e1878c36a9a61e79
+commit: 64ab6840ebc33cf98892f3cc077275af454c0e04
 packageVersion: 00

--- a/packages/rancher-vsphere-csi/package.yaml
+++ b/packages/rancher-vsphere-csi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-csi
-commit: 948b4940d270761e67bcef5965988dda7418100d
+commit: 64ab6840ebc33cf98892f3cc077275af454c0e04
 packageVersion: 00


### PR DESCRIPTION
Update CPI/CSI to https://github.com/rancher/vsphere-charts/commit/64ab6840ebc33cf98892f3cc077275af454c0e04