### PR TITLE
Update Kubernetes Metrics Server chart to 3.12.201

### DIFF
--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -8,7 +8,7 @@
 +  repository: rancher/hardened-k8s-metrics-server
    # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
 -  tag: ""
-+  tag: v0.7.2-build20250110
++  tag: v0.7.2-build20250507
    pullPolicy: IfNotPresent
  
  imagePullSecrets: []
@@ -27,7 +27,7 @@
 -    repository: registry.k8s.io/autoscaling/addon-resizer
 -    tag: 1.8.21
 +    repository: rancher/hardened-addon-resizer
-+    tag: 1.8.22-build20250110
++    tag: 1.8.23-build20250507
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.2/metrics-server-3.12.2.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
Update to the latest chart images:
- rancher/hardened-k8s-metrics-server:v0.7.2-build20250507
- rancher/hardened-addon-resizer:1.8.23-build20250507