### PR TITLE
coredns: nodelocal should query the UDP service port

### DIFF
--- a/packages/rke2-coredns/generated-changes/overlay/templates/daemonset-nodelocal.yaml
+++ b/packages/rke2-coredns/generated-changes/overlay/templates/daemonset-nodelocal.yaml
@@ -37,7 +37,7 @@ spec:
       initContainers:
       - name: wait-coredns
         image: {{ template "system_default_registry" . }}{{ .Values.nodelocal.initimage.repository }}:{{ .Values.nodelocal.initimage.tag }}
-        command: ['sh', '-c', "until nc -zv {{ template "clusterDNSServerIP" . }} 53; do echo waiting for dns service; sleep 2; done"]
+        command: ['sh', '-c', "until nc -zv -u {{ template "clusterDNSServerIP" . }} 53; do echo waiting for dns service; sleep 2; done"]
 {{- end }}
       containers:
       - name: node-cache

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.42.3/coredns-1.42.3.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
The nodelocal `wait-coredns` container should query the coredns service port using UDP (instead of TCP)

See also: https://github.com/coredns/helm/commit/d579bfc7359dba42e9baa2f9b2dd3fc377b51f43
Issue: https://github.com/rancher/rke2/issues/8230