### PR TITLE
Disabling Flannel forward rules on Canal by default

### DIFF
--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -15,10 +15,11 @@ flannel:
   iface: ""
   # A regulare expression used to match the interface
   regexIface: ""
-  # kube-flannel command arguments
+  # kube-flannel command arguments with forward rules disabled because with Calico the packets for pod IPs that doesn't exist are forwarded to the default GW
   args:
     - "--ip-masq"
     - "--kube-subnet-mgr"
+    - "--iptables-forward-rules=false"
   # Backend for kube-flannel. Backend should not be changed
   # at runtime.
   backend: "vxlan"

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
This PR disables the forwarding rules in Flannel that era conflicting with Calico that could forward the pods traffic to the default gateway.
https://github.com/flannel-io/flannel/issues/2245