### PR TITLE
Bump ingress-nginx to v1.12.2-hardened1

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/Chart.yaml.patch
@@ -8,4 +8,4 @@
 +name: rke2-ingress-nginx
  sources:
  - https://github.com/kubernetes/ingress-nginx
- version: 4.12.1
+ version: 4.12.2

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -19,11 +19,11 @@
      ## for backwards compatibility consider setting the full image url via the repository value below
      ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
      ## repository:
--    tag: "v1.12.1"
--    digest: sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b
--    digestChroot: sha256:90155c86548e0bb95b3abf1971cd687d8f5d43f340cfca0ad3484e2b8351096e
+-    tag: "v1.12.2"
+-    digest: sha256:03497ee984628e95eca9b2279e3f3a3c1685dd48635479e627d219f00c8eefa9
+-    digestChroot: sha256:a697e2bfa419768315250d079ccbbca45f6099c60057769702b912d20897a574
 -    pullPolicy: IfNotPresent
-+    tag: "v1.12.1-hardened6"
++    tag: "v1.12.2-hardened1"
      runAsNonRoot: true
      # -- This value must not be changed using the official image.
      # uid=101(www-data) gid=82(www-data) groups=82(www-data)
@@ -98,8 +98,8 @@
          ## for backwards compatibility consider setting the full image url via the repository value below
          ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
          ## repository:
-         tag: v1.5.2
--        digest: sha256:e8825994b7a2c7497375a9b945f386506ca6a3eda80b89b74ef2db743f66a5ea
+         tag: v1.5.3
+-        digest: sha256:2cf4ebfa82a37c357455458f6dfc334aea1392d508270b2517795a9933a02524
          pullPolicy: IfNotPresent
        # -- Provide a priority class name to the webhook patching job
        ##

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.12.1/ingress-nginx-4.12.1.tgz
-packageVersion: 03
+url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.12.2/ingress-nginx-4.12.2.tgz
+packageVersion: 00
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
New month, new ingress-nginx bump
```
rancher/nginx-ingress-controller:v1.12.2-hardened1 (suse linux enterprise server 15.6)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```