### PR TITLE
Fix/snapshot controller backwards compatibility

### DIFF
--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
@@ -92,3 +92,11 @@ spec:
     served: true
     storage: true
     subresources: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: to not break compatibility when upgrading from previous versions
+          of the CRD
+        type: object
+    served: false
+    storage: false

--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
@@ -95,8 +95,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: to not break compatibility when upgrading from previous versions
-          of the CRD
+        description: v1alpha1 is deprecated and no longer served.
         type: object
     served: false
     storage: false

--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -325,8 +325,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: to not break compatibility when upgrading from previous versions
-          of the CRD
+        description: v1alpha1 is deprecated and no longer served.
         type: object
     served: false
     storage: false

--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -322,3 +322,11 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: to not break compatibility when upgrading from previous versions
+          of the CRD
+        type: object
+    served: false
+    storage: false

--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
@@ -240,8 +240,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: to not break compatibility when upgrading from previous versions
-          of the CRD
+        description: v1alpha1 is deprecated and no longer served.
         type: object
     served: false
     storage: false

--- a/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+++ b/packages/rke2-snapshot-controller/generated-changes/overlay/crds/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
@@ -237,3 +237,11 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: to not break compatibility when upgrading from previous versions
+          of the CRD
+        type: object
+    served: false
+    storage: false

--- a/packages/rke2-snapshot-controller/package.yaml
+++ b/packages/rke2-snapshot-controller/package.yaml
@@ -1,7 +1,7 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-controller
 commit: caf8780858bdd5afe1d80fe2f559ca138f29740e  # snapshot-controller-4.0.0
-packageVersion: 02
+packageVersion: 03
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
This prevents breaking v1alpha1 groupsnpshot resources during rke2 upgrades by re-introducing v1alpha1 to the crds definitions 

Before this fix, rke2 would fail when upgrading from versions 1.31.2 to 1.31.4 to version 1.32.1+:
`
Error: UPGRADE FAILED: cannot patch "volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io" is invalid: status.storedVersions[0]: Invalid value: "v1alpha1": must appear in spec.versions && cannot patch "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io" is invalid: status.storedVersions[0]: Invalid value: "v1alpha1": must appear in spec.versions && cannot patch "volumegroupsnapshots.groupsnapshot.storage.k8s.io" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "volumegroupsnapshots.groupsnapshot.storage.k8s.io" is invalid: status.storedVersions[0]: Invalid value: "v1alpha1": must appear in spec.versions
`