### PR TITLE
Update Flannel image on Canal and added blackhole route flag

### DIFF
--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -8,7 +8,7 @@ flannel:
   # kube-flannel image
   image:
     repository: rancher/hardened-flannel
-    tag: v0.27.0-build20250611
+    tag: v0.27.1-build20250710
   # The interface used by canal for host <-> host communication.
   # If left blank, then the interface is chosen using the node's
   # default route.
@@ -20,6 +20,7 @@ flannel:
     - "--ip-masq"
     - "--kube-subnet-mgr"
     - "--iptables-forward-rules=false"
+    - "--ip-blackhole-route"
   # Backend for kube-flannel. Backend should not be changed
   # at runtime.
   backend: "vxlan"

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 01
+packageVersion: 02


### PR DESCRIPTION
Update Flannel image on Canal and added blackhole route flag to enable blackhole route to avoid the wrongly forward of the pods packets