### PR TITLE
rke2-coredns: inject clusterDomain only if missing

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/templates/configmap.yaml.patch
@@ -1,11 +1,28 @@
 --- charts-original/templates/configmap.yaml
 +++ charts/templates/configmap.yaml
-@@ -24,7 +24,7 @@
+@@ -23,13 +23,22 @@
+     {{- range $idx, $zone := .zones }}{{ if $idx }} {{ else }}{{ end }}{{ default "" $zone.scheme }}{{ default "." $zone.zone }}{{ else }}.{{ end -}}
      {{- if .port }}:{{ .port }} {{ end -}}
      {
++      {{- $domain := coalesce $.Values.global.clusterDomain "cluster.local" -}}
        {{- range .plugins }}
 -        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
-+        {{ .name }}{{ if .parameters }} {{if eq .name "kubernetes" }} {{ coalesce $.Values.global.clusterDomain "cluster.local" }} {{ end }} {{.parameters}}{{ end }}{{ if .configBlock }} {
++      {{ .name }}
++      {{- if and (eq .name "kubernetes") (not (contains $domain (toString .parameters))) -}}
++      {{- " " -}}{{- $domain -}}
++      {{- end -}}
++      {{- if .parameters -}}
++      {{- " " -}}{{- .parameters -}}
++      {{- end }}
++      {{- if .configBlock }} {
  {{ .configBlock | indent 12 }}
-         }{{ end }}
+-        }{{ end }}
++      }
++      {{- end }}
        {{- end }}
+     }
+-    {{ end }}
++    {{- end }}
+   {{- range .Values.zoneFiles }}
+   {{ .filename }}: {{ toYaml .contents | indent 4 }}
+   {{- end }}

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.43.3/coredns-1.43.3.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
### Summary:
Fix duplication of **`cluster.local`** in the Corefile when rendering parameters for the kubernetes plugin.

Before:
```
Corefile: |-
  .:53 {
      errors
      health {
          lameduck 10s
      }
      ready
      kubernetes  cluster.local  cluster.local in-addr.arpa ip6.arpa {
          pods insecure
          fallthrough in-addr.arpa ip6.arpa
          ttl 30
      }

```


After:
```
Corefile: |-
  .:53 {
    errors
    health {
        lameduck 10s
    }
    ready
    kubernetes cluster.local in-addr.arpa ip6.arpa {
        pods insecure
        fallthrough in-addr.arpa ip6.arpa
        ttl 30
    }

```