### PR TITLE
Bump vsphere cpi and csi to support k8s v1.34

### DIFF
--- a/packages/rancher-vsphere-cpi/package.yaml
+++ b/packages/rancher-vsphere-cpi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-cpi
-commit: 64ab6840ebc33cf98892f3cc077275af454c0e04
+commit: 5487dcb440d27f4ccd2f17b0c54a837e7437a886
 packageVersion: 00

--- a/packages/rancher-vsphere-csi/package.yaml
+++ b/packages/rancher-vsphere-csi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-csi
-commit: 64ab6840ebc33cf98892f3cc077275af454c0e04
+commit: 5487dcb440d27f4ccd2f17b0c54a837e7437a886
 packageVersion: 00


### PR DESCRIPTION
Moves to https://github.com/rancher/vsphere-charts/commit/5487dcb440d27f4ccd2f17b0c54a837e7437a886

Signed-off-by: Derek Nola <derek.nola@suse.com>