### PR TITLE
Fix Multus chart subversion

### DIFF
--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 04
+packageVersion: 05


### PR DESCRIPTION
Fixed multus chart subversion because updated by whereabouts before the multus update.