### PR TITLE
Bump harvester-cloud-provider chart to v0.2.11 with app image tag v0.2.5

### DIFF
--- a/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
+++ b/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
@@ -1,3 +1,3 @@
 workingDir: ""
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.9/harvester-cloud-provider-0.2.9.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.11/harvester-cloud-provider-0.2.11.tgz
 subdirectory: dependency_charts/kube-vip

--- a/packages/harvester-cloud-provider/generated-changes/patch/Chart.yaml.patch
+++ b/packages/harvester-cloud-provider/generated-changes/patch/Chart.yaml.patch
@@ -1,21 +1,11 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -7,13 +7,14 @@
+@@ -7,7 +7,7 @@
    catalog.cattle.io/rancher-version: '>= 2.7.0-0'
    catalog.cattle.io/release-name: harvester-cloud-provider
    catalog.cattle.io/ui-component: harvester-cloud-provider
 -  catalog.cattle.io/upstream-version: 0.2.0
-+  catalog.cattle.io/upstream-version: 0.2.10
++  catalog.cattle.io/upstream-version: 0.2.11
  apiVersion: v2
- appVersion: v0.2.4
+ appVersion: v0.2.5
  dependencies:
--- condition: kube-vip.enabled
--  name: kube-vip
--  repository: file://./charts/kube-vip
-+- name: kube-vip
-+  condition: kube-vip.enabled
-+  version: 0.6.4
-+  repository: file://dependency_charts/kube-vip
- description: A Helm chart for Harvester Cloud Provider
- keywords:
- - infrastructure

--- a/packages/harvester-cloud-provider/package.yaml
+++ b/packages/harvester-cloud-provider/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.10/harvester-cloud-provider-0.2.10.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.11/harvester-cloud-provider-0.2.11.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
Bump harvester-cloud-provider chart to v0.2.11 with app image tag v0.2.5

also:
https://github.com/rancher/rke2/pull/8923

Harvester issues and PRs:

https://github.com/harvester/harvester/issues/5670
https://github.com/harvester/harvester/issues/8072
harvester chart: https://github.com/harvester/charts/pull/413