### PR TITLE
Fix spacing of traefik helper patch

### DIFF
--- a/packages/rke2-traefik/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/_helpers.tpl.patch
@@ -9,16 +9,15 @@
  {{- end -}}
  {{- end -}}
  
-@@ -327,3 +327,12 @@
+@@ -327,3 +327,11 @@
  {{- $memlimitBytes := include "traefik.convertMemToBytes" .memory | mulf $percentage -}}
  {{- printf "%dMiB" (divf $memlimitBytes 0x1p20 | floor | int64) -}}
  {{- end }}
 +
-++
-++{{- define "system_default_registry" -}}
-++{{- if .Values.global.systemDefaultRegistry -}}
-++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
-++{{- else -}}
-++{{- "" -}}
-++{{- end -}}
-++{{- end -}}
++{{- define "system_default_registry" -}}
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,4 +1,4 @@
 url: https://traefik.github.io/charts/traefik/traefik-37.1.0.tgz
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
Fixed error that was causing `++` being added to image name