### PR TITLE
Add gatewayAPI crds chart

### DIFF
--- a/packages/rke2-gateway-api-crd/README.md
+++ b/packages/rke2-gateway-api-crd/README.md
@@ -1,0 +1,98 @@
+# rke2-gateway-api-crd
+
+This package ships Gateway API CRDs as a dedicated Helm chart.
+
+## Layout
+
+- Stable CRD source files live in [charts/crdfiles](charts/crdfiles)
+- Experimental-only CRD source files live in [charts/experimentalcrds](charts/experimentalcrds)
+- Stable CRDs are rendered by [charts/templates/stablecrds.yaml](charts/templates/stablecrds.yaml)
+- Experimental CRDs are conditionally rendered by [charts/templates/experimentalcrds.yaml](charts/templates/experimentalcrds.yaml)
+- The safe-upgrade guardrail lives in [charts/templates/safe-upgrades.yaml](charts/templates/safe-upgrades.yaml)
+
+## Why this chart is structured this way
+
+### Why not render the upstream YAML bundles directly?
+
+The upstream Gateway API release files are:
+
+- `standard-install.yaml`
+- `experimental-install.yaml`
+
+We do not keep those full files as directly-rendered chart inputs for two reasons:
+
+1. `experimental-install.yaml` includes both stable and experimental resources.
+   - We only want the experimental-only CRDs to be gated by `gatewayAPIExperimental`.
+   - Because of that, we split out just the experimental-only CRDs.
+
+2. Rendering the full upstream bundles directly makes the Helm release metadata much larger.
+   - In practice, this pushed the Helm release Secret close to or beyond the Kubernetes 1 MiB Secret limit.
+   - Splitting the CRDs into individual vendored files keeps the chart manageable and avoids carrying unnecessary duplicated content.
+
+## Why not use the Helm `crds/` directory?
+
+We intentionally do **not** keep these CRDs under the chart `crds/` directory.
+
+Helm treats `crds/` specially:
+
+- CRDs are installed before normal templates
+- They are not managed like normal templated resources
+- They are generally not deleted on uninstall
+- Removed CRDs tend to remain in the cluster
+- CRD lifecycle changes are harder to manage across upgrades
+
+That behavior is not a good fit for Gateway API CRDs because:
+
+- new CRDs may appear in later Gateway API releases
+- existing CRDs can change schema
+- some CRDs can move from experimental to stable
+- old CRDs may need to be removed cleanly
+
+By rendering them through normal templates instead, Helm manages them as ordinary release resources.
+
+## Update workflow for a new Gateway API release
+
+When updating this package to a new upstream Gateway API version:
+
+1. Download the new standard bundle from upstream, for example:
+   - `https://github.com/kubernetes-sigs/gateway-api/releases/download/<VERSION>/standard-install.yaml`
+2. Replace the stable CRD files in [charts/crdfiles](charts/crdfiles)
+   - Keep only the stable CRDs there
+3. Download the new experimental bundle from upstream, for example:
+   - `https://github.com/kubernetes-sigs/gateway-api/releases/download/<VERSION>/experimental-install.yaml`
+4. Update [charts/experimentalcrds](charts/experimentalcrds)
+   - Keep only the experimental-only CRDs there
+   - Do not duplicate stable CRDs in this directory
+5. Update [charts/templates/safe-upgrades.yaml](charts/templates/safe-upgrades.yaml)
+   - Refresh the `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` from the upstream standard bundle if they changed
+   - Update bundle-version annotations as needed
+6. Update chart metadata if needed:
+   - [charts/Chart.yaml](charts/Chart.yaml)
+   - [package.yaml](package.yaml)
+7. Validate renders:
+   - `helm template test packages/rke2-gateway-api-crd/charts`
+   - `helm template test packages/rke2-gateway-api-crd/charts --set gatewayAPIExperimental=true`
+8. Package/test the chart as needed.
+
+## Notes on experimental CRDs
+
+`gatewayAPIExperimental` defaults to `false` in [charts/values.yaml](charts/values.yaml).
+
+When set to `true`, the chart renders the files in [charts/experimentalcrds](charts/experimentalcrds) in addition to the stable CRDs.
+
+## Notes on the safe-upgrades policy
+
+The resources in [charts/templates/safe-upgrades.yaml](charts/templates/safe-upgrades.yaml) are sourced from the upstream Gateway API standard bundle.
+
+Within this chart's intended workflow, we already separate stable and experimental CRDs, so this chart itself should not normally try to install experimental CRDs on top of standard CRDs.
+
+The policy is still useful as a cluster-level guardrail, mainly for cases where Gateway API CRDs are installed or modified by something else, for example:
+
+- another Helm chart or component trying to install Gateway API CRDs
+- an older manifest being applied manually
+- a pre-existing cluster state that already contains different Gateway API CRDs
+
+It exists to prevent unsafe CRD transitions, especially:
+
+- installing experimental CRDs on top of standard CRDs
+- installing CRDs older than the supported minimum

--- a/packages/rke2-gateway-api-crd/charts/Chart.yaml
+++ b/packages/rke2-gateway-api-crd/charts/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rke2-gateway-api-crd
+description: RKE2 Helm chart for Gateway API CRDs
+version: 1.5.1
+appVersion: v1.5.1
+type: application

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -1,0 +1,1886 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'BackendTLSPolicy provides a way to configure how a Gateway
+
+          connects to a Backend via TLS.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              options:
+                additionalProperties:
+                  description: 'AnnotationValue is the value of an annotation in Gateway
+                    API. This is used
+
+                    for validation of maps such as TLS options. This roughly matches
+                    Kubernetes
+
+                    annotation validation, although the length validation in that
+                    case is based
+
+                    on the entire size of the annotations struct.'
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: 'Options are a list of key/value pairs to enable extended
+                  TLS
+
+                  configuration for each implementation. For example, configuring
+                  the
+
+                  minimum TLS version or supported cipher suites.
+
+
+                  A set of common keys MAY be defined by the API in the future. To
+                  avoid
+
+                  any ambiguity, implementation-specific definitions MUST use
+
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+
+                  Un-prefixed names are reserved for key names defined by Gateway
+                  API.
+
+
+                  Support: Implementation-specific'
+                maxProperties: 16
+                type: object
+              targetRefs:
+                description: "TargetRefs identifies an API object to apply the policy\
+                  \ to.\nNote that this config applies to the entire referenced resource\n\
+                  by default, but this default may change in the future to provide\n\
+                  a more granular application of the policy.\n\nTargetRefs must be\
+                  \ _distinct_. This means either that:\n\n* They select different\
+                  \ targets. If this is the case, then targetRef\n  entries are distinct.\
+                  \ In terms of fields, this means that the\n  multi-part key defined\
+                  \ by `group`, `kind`, and `name` must\n  be unique across all targetRef\
+                  \ entries in the BackendTLSPolicy.\n* They select different sectionNames\
+                  \ in the same target.\n\nWhen more than one BackendTLSPolicy selects\
+                  \ the same target and\nsectionName, implementations MUST determine\
+                  \ precedence using the\nfollowing criteria, continuing on ties:\n\
+                  \n* The older policy by creation timestamp takes precedence. For\n\
+                  \  example, a policy with a creation timestamp of \"2021-07-15\n\
+                  \  01:02:03\" MUST be given precedence over a policy with a\n  creation\
+                  \ timestamp of \"2021-07-15 01:02:04\".\n* The policy appearing\
+                  \ first in alphabetical order by {namespace}/{name}.\n  For example,\
+                  \ a policy named `foo/bar` is given precedence over a\n  policy\
+                  \ named `foo/baz`.\n\nFor any BackendTLSPolicy that does not take\
+                  \ precedence, the\nimplementation MUST ensure the `Accepted` Condition\
+                  \ is set to\n`status: False`, with Reason `Conflicted`.\n\nImplementations\
+                  \ SHOULD NOT support more than one targetRef at this\ntime. Although\
+                  \ the API technically allows for this, the current guidance\nfor\
+                  \ conflict resolution and status handling is lacking. Until that\
+                  \ can be\nclarified in a future release, the safest approach is\
+                  \ to support a single\ntargetRef.\n\nSupport Levels:\n\n* Extended:\
+                  \ Kubernetes Service referenced by HTTPRoute backendRefs.\n\n* Implementation-Specific:\
+                  \ Services not connected via HTTPRoute, and any\n  other kind of\
+                  \ backend. Implementations MAY use BackendTLSPolicy for:\n  - Services\
+                  \ not referenced by any Route (e.g., infrastructure services)\n\
+                  \  - Gateway feature backends (e.g., ExternalAuth, rate-limiting\
+                  \ services)\n  - Service mesh workload-to-service communication\n\
+                  \  - Other resource types beyond Service\n\nImplementations SHOULD\
+                  \ aim to ensure that BackendTLSPolicy behavior is consistent,\n\
+                  even outside of the extended HTTPRoute -(backendRef) -> Service\
+                  \ path.\nThey SHOULD clearly document how BackendTLSPolicy is interpreted\
+                  \ in these\nscenarios, including:\n  - Which resources beyond Service\
+                  \ are supported\n  - How the policy is discovered and applied\n\
+                  \  - Any implementation-specific semantics or restrictions\n\nNote\
+                  \ that this config applies to the entire referenced resource\nby\
+                  \ default, but this default may change in the future to provide\n\
+                  a more granular application of the policy."
+                items:
+                  description: 'LocalPolicyTargetReferenceWithSectionName identifies
+                    an API object to apply a
+
+                    direct policy to. This should be used as part of Policy resources
+                    that can
+
+                    target single resources. For more information on how this policy
+                    attachment
+
+                    mode works, and a sample Policy resource, refer to the policy
+                    attachment
+
+                    documentation for Gateway API.
+
+
+                    Note: This should only be used for direct policy attachment when
+                    references
+
+                    to SectionName are actually needed. In all other cases,
+
+                    LocalPolicyTargetReference should be used.'
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. When
+
+                        unspecified, this targetRef targets the entire resource. In
+                        the following
+
+                        resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name
+
+                        * HTTPRoute: HTTPRouteRule name
+
+                        * Service: Port name
+
+
+                        If a SectionName is specified, but does not exist on the targeted
+                        object,
+
+                        the Policy must fail to attach, and the policy implementation
+                        should record
+
+                        a `ResolvedRefs` or similar Condition in the Policy''s status.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when targetRefs includes
+                    2 or more references to the same target
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name ? ((!has(p1.sectionName) || p1.sectionName
+                    == '''') == (!has(p2.sectionName) || p2.sectionName == ''''))
+                    : true))'
+                - message: sectionName must be unique when targetRefs includes 2 or
+                    more references to the same target
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.sectionName) ||
+                    p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: "CACertificateRefs contains one or more references\
+                      \ to Kubernetes objects that\ncontain a PEM-encoded TLS CA certificate\
+                      \ bundle, which is used to\nvalidate a TLS handshake between\
+                      \ the Gateway and backend Pod.\n\nIf CACertificateRefs is empty\
+                      \ or unspecified, then WellKnownCACertificates must be\nspecified.\
+                      \ Only one of CACertificateRefs or WellKnownCACertificates may\
+                      \ be specified,\nnot both. If CACertificateRefs is empty or\
+                      \ unspecified, the configuration for\nWellKnownCACertificates\
+                      \ MUST be honored instead if supported by the implementation.\n\
+                      \nA CACertificateRef is invalid if:\n\n* It refers to a resource\
+                      \ that cannot be resolved (e.g., the referenced resource\n \
+                      \ does not exist) or is misconfigured (e.g., a ConfigMap does\
+                      \ not contain a key\n  named `ca.crt`). In this case, the Reason\
+                      \ must be set to `InvalidCACertificateRef`\n  and the Message\
+                      \ of the Condition must indicate which reference is invalid\
+                      \ and why.\n\n* It refers to an unknown or unsupported kind\
+                      \ of resource. In this case, the Reason\n  must be set to `InvalidKind`\
+                      \ and the Message of the Condition must explain which\n  kind\
+                      \ of resource is unknown or unsupported.\n\n* It refers to a\
+                      \ resource in another namespace. This may change in future\n\
+                      \  spec updates.\n\nImplementations MAY choose to perform further\
+                      \ validation of the certificate\ncontent (e.g., checking expiry\
+                      \ or enforcing specific formats). In such cases,\nan implementation-specific\
+                      \ Reason and Message must be set for the invalid reference.\n\
+                      \nIn all cases, the implementation MUST ensure the `ResolvedRefs`\
+                      \ Condition on\nthe BackendTLSPolicy is set to `status: False`,\
+                      \ with a Reason and Message\nthat indicate the cause of the\
+                      \ error. Connections using an invalid\nCACertificateRef MUST\
+                      \ fail, and the client MUST receive an HTTP 5xx error\nresponse.\
+                      \ If ALL CACertificateRefs are invalid, the implementation MUST\
+                      \ also\nensure the `Accepted` Condition on the BackendTLSPolicy\
+                      \ is set to\n`status: False`, with a Reason `NoValidCACertificate`.\n\
+                      \nA single CACertificateRef to a Kubernetes ConfigMap kind has\
+                      \ \"Core\" support.\nImplementations MAY choose to support attaching\
+                      \ multiple certificates to\na backend, but this behavior is\
+                      \ implementation-specific.\n\nSupport: Core - An optional single\
+                      \ reference to a Kubernetes ConfigMap,\nwith the CA certificate\
+                      \ in a key named `ca.crt`.\n\nSupport: Implementation-specific\
+                      \ - More than one reference, other kinds\nof resources, or a\
+                      \ single reference that includes multiple certificates."
+                    items:
+                      description: 'LocalObjectReference identifies an API object
+                        within the namespace of the
+
+                        referrer.
+
+                        The API object must be valid in the cluster; the Group and
+                        Kind must
+
+                        be registered in the cluster for this reference to be valid.
+
+
+                        References to objects with invalid Group and Kind are not
+                        valid, and must
+
+                        be rejected by the implementation, with appropriate Conditions
+                        set
+
+                        on the containing object.'
+                      properties:
+                        group:
+                          description: 'Group is the group of the referent. For example,
+                            "gateway.networking.k8s.io".
+
+                            When unspecified or empty string, core API group is inferred.'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  hostname:
+                    description: "Hostname is used for two purposes in the connection\
+                      \ between Gateways and\nbackends:\n\n1. Hostname MUST be used\
+                      \ as the SNI to connect to the backend (RFC 6066).\n2. Hostname\
+                      \ MUST be used for authentication and MUST match the certificate\n\
+                      \   served by the matching backend, unless SubjectAltNames is\
+                      \ specified.\n3. If SubjectAltNames are specified, Hostname\
+                      \ can be used for certificate selection\n   but MUST NOT be\
+                      \ used for authentication. If you want to use the value\n  \
+                      \ of the Hostname field for authentication, you MUST add it\
+                      \ to the SubjectAltNames list.\n\nSupport: Core"
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  subjectAltNames:
+                    description: 'SubjectAltNames contains one or more Subject Alternative
+                      Names.
+
+                      When specified the certificate served from the backend MUST
+
+                      have at least one Subject Alternate Name matching one of the
+                      specified SubjectAltNames.
+
+
+                      Support: Extended'
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: 'Hostname contains Subject Alternative Name
+                            specified in DNS name format.
+
+                            Required when Type is set to Hostname, ignored otherwise.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: 'Type determines the format of the Subject
+                            Alternative Name. Always required.
+
+
+                            Support: Core'
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: 'URI contains Subject Alternative Name specified
+                            in a full URI format.
+
+                            It MUST include both a scheme (e.g., "http" or "ftp")
+                            and a scheme-specific-part.
+
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+
+                            Required when Type is set to URI, ignored otherwise.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  wellKnownCACertificates:
+                    description: 'WellKnownCACertificates specifies whether a well-known
+                      set of CA certificates
+
+                      may be used in the TLS handshake between the gateway and backend
+                      pod.
+
+
+                      If WellKnownCACertificates is unspecified or empty (""), then
+                      CACertificateRefs
+
+                      must be specified with at least one entry for a valid configuration.
+                      Only one of
+
+                      CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both.
+
+                      If an implementation does not support the WellKnownCACertificates
+                      field, or
+
+                      the supplied value is not recognized, the implementation MUST
+                      ensure the
+
+                      `Accepted` Condition on the BackendTLSPolicy is set to `status:
+                      False`, with
+
+                      a Reason `Invalid`.
+
+
+                      Valid values include:
+
+                      * "System" - indicates that well-known system CA certificates
+                      should be used.
+
+
+                      Implementations MAY define their own sets of CA certificates.
+                      Such definitions
+
+                      MUST use an implementation-specific, prefixed name, such as
+
+                      `mycompany.com/my-custom-ca-certificates`.
+
+
+                      Support: Implementation-specific'
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: 'Ancestors is a list of ancestor resources (usually Gateways)
+                  that are
+
+                  associated with the policy, and the status of the policy with respect
+                  to
+
+                  each ancestor. When this policy attaches to a parent, the controller
+                  that
+
+                  manages the parent and the ancestors MUST add an entry to this list
+                  when
+
+                  the controller first sees the policy and SHOULD update the entry
+                  as
+
+                  appropriate when the relevant ancestor is modified.
+
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+
+                  an important part of Policy design is designing the right object
+                  level at
+
+                  which to namespace this status.
+
+
+                  Note also that implementations MUST ONLY populate ancestor status
+                  for
+
+                  the Ancestor resources they are responsible for. Implementations
+                  MUST
+
+                  use the ControllerName field to uniquely identify the entries in
+                  this list
+
+                  that they are responsible for.
+
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+
+                  and ControllerName fields combined.
+
+
+                  A maximum of 16 ancestors will be represented in this list. An empty
+                  list
+
+                  means the Policy is not relevant for any ancestors.
+
+
+                  If this slice is full, implementations MUST NOT add further entries.
+
+                  Instead they MUST consider the policy unimplementable and signal
+                  that
+
+                  on any related resources such as the ancestor that would be referenced
+
+                  here. For example, if this list was full on BackendTLSPolicy, no
+
+                  additional Gateways would be able to reference the Service targeted
+                  by
+
+                  the BackendTLSPolicy.'
+                items:
+                  description: 'PolicyAncestorStatus describes the status of a route
+                    with respect to an
+
+                    associated Ancestor.
+
+
+                    Ancestors refer to objects that are either the Target of a policy
+                    or above it
+
+                    in terms of object hierarchy. For example, if a policy targets
+                    a Service, the
+
+                    Policy''s Ancestors are, in order, the Service, the HTTPRoute,
+                    the Gateway, and
+
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway
+                    will be the most
+
+                    useful object to place Policy status on, so we recommend that
+                    implementations
+
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the
+                    designers
+
+                    have a _very_ good reason otherwise.
+
+
+                    In the context of policy attachment, the Ancestor is used to distinguish
+                    which
+
+                    resource results in a distinct application of this policy. For
+                    example, if a policy
+
+                    targets a Service, it may have a distinct result per attached
+                    Gateway.
+
+
+                    Policies targeting the same resource may have different effects
+                    depending on the
+
+                    ancestors of those resources. For example, different Gateways
+                    targeting the same
+
+                    Service may have different capabilities, especially if they have
+                    different underlying
+
+                    implementations.
+
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service
+                    that is
+
+                    used as a backend in a HTTPRoute that is itself attached to a
+                    Gateway.
+
+                    In this case, the relevant object for status is the Gateway, and
+                    that is the
+
+                    ancestor object referred to in this status.
+
+
+                    Note that a parent is also an ancestor, so for objects where the
+                    parent is the
+
+                    relevant object for status, this struct SHOULD still be used.
+
+
+                    This struct is intended to be used in a slice that''s effectively
+                    a map,
+
+                    with a composite key made up of the AncestorRef and the ControllerName.'
+                  properties:
+                    ancestorRef:
+                      description: 'AncestorRef corresponds with a ParentRef in the
+                        spec that this
+
+                        PolicyAncestorStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - conditions
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: The v1alpha3 version of BackendTLSPolicy has been deprecated
+      and will be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: 'BackendTLSPolicy provides a way to configure how a Gateway
+
+          connects to a Backend via TLS.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              options:
+                additionalProperties:
+                  description: 'AnnotationValue is the value of an annotation in Gateway
+                    API. This is used
+
+                    for validation of maps such as TLS options. This roughly matches
+                    Kubernetes
+
+                    annotation validation, although the length validation in that
+                    case is based
+
+                    on the entire size of the annotations struct.'
+                  maxLength: 4096
+                  minLength: 0
+                  type: string
+                description: 'Options are a list of key/value pairs to enable extended
+                  TLS
+
+                  configuration for each implementation. For example, configuring
+                  the
+
+                  minimum TLS version or supported cipher suites.
+
+
+                  A set of common keys MAY be defined by the API in the future. To
+                  avoid
+
+                  any ambiguity, implementation-specific definitions MUST use
+
+                  domain-prefixed names, such as `example.com/my-custom-option`.
+
+                  Un-prefixed names are reserved for key names defined by Gateway
+                  API.
+
+
+                  Support: Implementation-specific'
+                maxProperties: 16
+                type: object
+              targetRefs:
+                description: "TargetRefs identifies an API object to apply the policy\
+                  \ to.\nNote that this config applies to the entire referenced resource\n\
+                  by default, but this default may change in the future to provide\n\
+                  a more granular application of the policy.\n\nTargetRefs must be\
+                  \ _distinct_. This means either that:\n\n* They select different\
+                  \ targets. If this is the case, then targetRef\n  entries are distinct.\
+                  \ In terms of fields, this means that the\n  multi-part key defined\
+                  \ by `group`, `kind`, and `name` must\n  be unique across all targetRef\
+                  \ entries in the BackendTLSPolicy.\n* They select different sectionNames\
+                  \ in the same target.\n\nWhen more than one BackendTLSPolicy selects\
+                  \ the same target and\nsectionName, implementations MUST determine\
+                  \ precedence using the\nfollowing criteria, continuing on ties:\n\
+                  \n* The older policy by creation timestamp takes precedence. For\n\
+                  \  example, a policy with a creation timestamp of \"2021-07-15\n\
+                  \  01:02:03\" MUST be given precedence over a policy with a\n  creation\
+                  \ timestamp of \"2021-07-15 01:02:04\".\n* The policy appearing\
+                  \ first in alphabetical order by {namespace}/{name}.\n  For example,\
+                  \ a policy named `foo/bar` is given precedence over a\n  policy\
+                  \ named `foo/baz`.\n\nFor any BackendTLSPolicy that does not take\
+                  \ precedence, the\nimplementation MUST ensure the `Accepted` Condition\
+                  \ is set to\n`status: False`, with Reason `Conflicted`.\n\nImplementations\
+                  \ SHOULD NOT support more than one targetRef at this\ntime. Although\
+                  \ the API technically allows for this, the current guidance\nfor\
+                  \ conflict resolution and status handling is lacking. Until that\
+                  \ can be\nclarified in a future release, the safest approach is\
+                  \ to support a single\ntargetRef.\n\nSupport Levels:\n\n* Extended:\
+                  \ Kubernetes Service referenced by HTTPRoute backendRefs.\n\n* Implementation-Specific:\
+                  \ Services not connected via HTTPRoute, and any\n  other kind of\
+                  \ backend. Implementations MAY use BackendTLSPolicy for:\n  - Services\
+                  \ not referenced by any Route (e.g., infrastructure services)\n\
+                  \  - Gateway feature backends (e.g., ExternalAuth, rate-limiting\
+                  \ services)\n  - Service mesh workload-to-service communication\n\
+                  \  - Other resource types beyond Service\n\nImplementations SHOULD\
+                  \ aim to ensure that BackendTLSPolicy behavior is consistent,\n\
+                  even outside of the extended HTTPRoute -(backendRef) -> Service\
+                  \ path.\nThey SHOULD clearly document how BackendTLSPolicy is interpreted\
+                  \ in these\nscenarios, including:\n  - Which resources beyond Service\
+                  \ are supported\n  - How the policy is discovered and applied\n\
+                  \  - Any implementation-specific semantics or restrictions\n\nNote\
+                  \ that this config applies to the entire referenced resource\nby\
+                  \ default, but this default may change in the future to provide\n\
+                  a more granular application of the policy."
+                items:
+                  description: 'LocalPolicyTargetReferenceWithSectionName identifies
+                    an API object to apply a
+
+                    direct policy to. This should be used as part of Policy resources
+                    that can
+
+                    target single resources. For more information on how this policy
+                    attachment
+
+                    mode works, and a sample Policy resource, refer to the policy
+                    attachment
+
+                    documentation for Gateway API.
+
+
+                    Note: This should only be used for direct policy attachment when
+                    references
+
+                    to SectionName are actually needed. In all other cases,
+
+                    LocalPolicyTargetReference should be used.'
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. When
+
+                        unspecified, this targetRef targets the entire resource. In
+                        the following
+
+                        resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name
+
+                        * HTTPRoute: HTTPRouteRule name
+
+                        * Service: Port name
+
+
+                        If a SectionName is specified, but does not exist on the targeted
+                        object,
+
+                        the Policy must fail to attach, and the policy implementation
+                        should record
+
+                        a `ResolvedRefs` or similar Condition in the Policy''s status.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when targetRefs includes
+                    2 or more references to the same target
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name ? ((!has(p1.sectionName) || p1.sectionName
+                    == '''') == (!has(p2.sectionName) || p2.sectionName == ''''))
+                    : true))'
+                - message: sectionName must be unique when targetRefs includes 2 or
+                    more references to the same target
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.sectionName) ||
+                    p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: "CACertificateRefs contains one or more references\
+                      \ to Kubernetes objects that\ncontain a PEM-encoded TLS CA certificate\
+                      \ bundle, which is used to\nvalidate a TLS handshake between\
+                      \ the Gateway and backend Pod.\n\nIf CACertificateRefs is empty\
+                      \ or unspecified, then WellKnownCACertificates must be\nspecified.\
+                      \ Only one of CACertificateRefs or WellKnownCACertificates may\
+                      \ be specified,\nnot both. If CACertificateRefs is empty or\
+                      \ unspecified, the configuration for\nWellKnownCACertificates\
+                      \ MUST be honored instead if supported by the implementation.\n\
+                      \nA CACertificateRef is invalid if:\n\n* It refers to a resource\
+                      \ that cannot be resolved (e.g., the referenced resource\n \
+                      \ does not exist) or is misconfigured (e.g., a ConfigMap does\
+                      \ not contain a key\n  named `ca.crt`). In this case, the Reason\
+                      \ must be set to `InvalidCACertificateRef`\n  and the Message\
+                      \ of the Condition must indicate which reference is invalid\
+                      \ and why.\n\n* It refers to an unknown or unsupported kind\
+                      \ of resource. In this case, the Reason\n  must be set to `InvalidKind`\
+                      \ and the Message of the Condition must explain which\n  kind\
+                      \ of resource is unknown or unsupported.\n\n* It refers to a\
+                      \ resource in another namespace. This may change in future\n\
+                      \  spec updates.\n\nImplementations MAY choose to perform further\
+                      \ validation of the certificate\ncontent (e.g., checking expiry\
+                      \ or enforcing specific formats). In such cases,\nan implementation-specific\
+                      \ Reason and Message must be set for the invalid reference.\n\
+                      \nIn all cases, the implementation MUST ensure the `ResolvedRefs`\
+                      \ Condition on\nthe BackendTLSPolicy is set to `status: False`,\
+                      \ with a Reason and Message\nthat indicate the cause of the\
+                      \ error. Connections using an invalid\nCACertificateRef MUST\
+                      \ fail, and the client MUST receive an HTTP 5xx error\nresponse.\
+                      \ If ALL CACertificateRefs are invalid, the implementation MUST\
+                      \ also\nensure the `Accepted` Condition on the BackendTLSPolicy\
+                      \ is set to\n`status: False`, with a Reason `NoValidCACertificate`.\n\
+                      \nA single CACertificateRef to a Kubernetes ConfigMap kind has\
+                      \ \"Core\" support.\nImplementations MAY choose to support attaching\
+                      \ multiple certificates to\na backend, but this behavior is\
+                      \ implementation-specific.\n\nSupport: Core - An optional single\
+                      \ reference to a Kubernetes ConfigMap,\nwith the CA certificate\
+                      \ in a key named `ca.crt`.\n\nSupport: Implementation-specific\
+                      \ - More than one reference, other kinds\nof resources, or a\
+                      \ single reference that includes multiple certificates."
+                    items:
+                      description: 'LocalObjectReference identifies an API object
+                        within the namespace of the
+
+                        referrer.
+
+                        The API object must be valid in the cluster; the Group and
+                        Kind must
+
+                        be registered in the cluster for this reference to be valid.
+
+
+                        References to objects with invalid Group and Kind are not
+                        valid, and must
+
+                        be rejected by the implementation, with appropriate Conditions
+                        set
+
+                        on the containing object.'
+                      properties:
+                        group:
+                          description: 'Group is the group of the referent. For example,
+                            "gateway.networking.k8s.io".
+
+                            When unspecified or empty string, core API group is inferred.'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  hostname:
+                    description: "Hostname is used for two purposes in the connection\
+                      \ between Gateways and\nbackends:\n\n1. Hostname MUST be used\
+                      \ as the SNI to connect to the backend (RFC 6066).\n2. Hostname\
+                      \ MUST be used for authentication and MUST match the certificate\n\
+                      \   served by the matching backend, unless SubjectAltNames is\
+                      \ specified.\n3. If SubjectAltNames are specified, Hostname\
+                      \ can be used for certificate selection\n   but MUST NOT be\
+                      \ used for authentication. If you want to use the value\n  \
+                      \ of the Hostname field for authentication, you MUST add it\
+                      \ to the SubjectAltNames list.\n\nSupport: Core"
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  subjectAltNames:
+                    description: 'SubjectAltNames contains one or more Subject Alternative
+                      Names.
+
+                      When specified the certificate served from the backend MUST
+
+                      have at least one Subject Alternate Name matching one of the
+                      specified SubjectAltNames.
+
+
+                      Support: Extended'
+                    items:
+                      description: SubjectAltName represents Subject Alternative Name.
+                      properties:
+                        hostname:
+                          description: 'Hostname contains Subject Alternative Name
+                            specified in DNS name format.
+
+                            Required when Type is set to Hostname, ignored otherwise.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type:
+                          description: 'Type determines the format of the Subject
+                            Alternative Name. Always required.
+
+
+                            Support: Core'
+                          enum:
+                          - Hostname
+                          - URI
+                          type: string
+                        uri:
+                          description: 'URI contains Subject Alternative Name specified
+                            in a full URI format.
+
+                            It MUST include both a scheme (e.g., "http" or "ftp")
+                            and a scheme-specific-part.
+
+                            Common values include SPIFFE IDs like "spiffe://mycluster.example.com/ns/myns/sa/svc1sa".
+
+                            Required when Type is set to URI, ignored otherwise.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^(([^:/?#]+):)(//([^/?#]*))([^?#]*)(\?([^#]*))?(#(.*))?
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: SubjectAltName element must contain Hostname, if
+                          Type is set to Hostname
+                        rule: '!(self.type == "Hostname" && (!has(self.hostname) ||
+                          self.hostname == ""))'
+                      - message: SubjectAltName element must not contain Hostname,
+                          if Type is not set to Hostname
+                        rule: '!(self.type != "Hostname" && has(self.hostname) &&
+                          self.hostname != "")'
+                      - message: SubjectAltName element must contain URI, if Type
+                          is set to URI
+                        rule: '!(self.type == "URI" && (!has(self.uri) || self.uri
+                          == ""))'
+                      - message: SubjectAltName element must not contain URI, if Type
+                          is not set to URI
+                        rule: '!(self.type != "URI" && has(self.uri) && self.uri !=
+                          "")'
+                    maxItems: 5
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  wellKnownCACertificates:
+                    description: 'WellKnownCACertificates specifies whether a well-known
+                      set of CA certificates
+
+                      may be used in the TLS handshake between the gateway and backend
+                      pod.
+
+
+                      If WellKnownCACertificates is unspecified or empty (""), then
+                      CACertificateRefs
+
+                      must be specified with at least one entry for a valid configuration.
+                      Only one of
+
+                      CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both.
+
+                      If an implementation does not support the WellKnownCACertificates
+                      field, or
+
+                      the supplied value is not recognized, the implementation MUST
+                      ensure the
+
+                      `Accepted` Condition on the BackendTLSPolicy is set to `status:
+                      False`, with
+
+                      a Reason `Invalid`.
+
+
+                      Valid values include:
+
+                      * "System" - indicates that well-known system CA certificates
+                      should be used.
+
+
+                      Implementations MAY define their own sets of CA certificates.
+                      Such definitions
+
+                      MUST use an implementation-specific, prefixed name, such as
+
+                      `mycompany.com/my-custom-ca-certificates`.
+
+
+                      Support: Implementation-specific'
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(System|([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]))$
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: 'Ancestors is a list of ancestor resources (usually Gateways)
+                  that are
+
+                  associated with the policy, and the status of the policy with respect
+                  to
+
+                  each ancestor. When this policy attaches to a parent, the controller
+                  that
+
+                  manages the parent and the ancestors MUST add an entry to this list
+                  when
+
+                  the controller first sees the policy and SHOULD update the entry
+                  as
+
+                  appropriate when the relevant ancestor is modified.
+
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+
+                  an important part of Policy design is designing the right object
+                  level at
+
+                  which to namespace this status.
+
+
+                  Note also that implementations MUST ONLY populate ancestor status
+                  for
+
+                  the Ancestor resources they are responsible for. Implementations
+                  MUST
+
+                  use the ControllerName field to uniquely identify the entries in
+                  this list
+
+                  that they are responsible for.
+
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+
+                  and ControllerName fields combined.
+
+
+                  A maximum of 16 ancestors will be represented in this list. An empty
+                  list
+
+                  means the Policy is not relevant for any ancestors.
+
+
+                  If this slice is full, implementations MUST NOT add further entries.
+
+                  Instead they MUST consider the policy unimplementable and signal
+                  that
+
+                  on any related resources such as the ancestor that would be referenced
+
+                  here. For example, if this list was full on BackendTLSPolicy, no
+
+                  additional Gateways would be able to reference the Service targeted
+                  by
+
+                  the BackendTLSPolicy.'
+                items:
+                  description: 'PolicyAncestorStatus describes the status of a route
+                    with respect to an
+
+                    associated Ancestor.
+
+
+                    Ancestors refer to objects that are either the Target of a policy
+                    or above it
+
+                    in terms of object hierarchy. For example, if a policy targets
+                    a Service, the
+
+                    Policy''s Ancestors are, in order, the Service, the HTTPRoute,
+                    the Gateway, and
+
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway
+                    will be the most
+
+                    useful object to place Policy status on, so we recommend that
+                    implementations
+
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the
+                    designers
+
+                    have a _very_ good reason otherwise.
+
+
+                    In the context of policy attachment, the Ancestor is used to distinguish
+                    which
+
+                    resource results in a distinct application of this policy. For
+                    example, if a policy
+
+                    targets a Service, it may have a distinct result per attached
+                    Gateway.
+
+
+                    Policies targeting the same resource may have different effects
+                    depending on the
+
+                    ancestors of those resources. For example, different Gateways
+                    targeting the same
+
+                    Service may have different capabilities, especially if they have
+                    different underlying
+
+                    implementations.
+
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service
+                    that is
+
+                    used as a backend in a HTTPRoute that is itself attached to a
+                    Gateway.
+
+                    In this case, the relevant object for status is the Gateway, and
+                    that is the
+
+                    ancestor object referred to in this status.
+
+
+                    Note that a parent is also an ancestor, so for objects where the
+                    parent is the
+
+                    relevant object for status, this struct SHOULD still be used.
+
+
+                    This struct is intended to be used in a slice that''s effectively
+                    a map,
+
+                    with a composite key made up of the AncestorRef and the ControllerName.'
+                  properties:
+                    ancestorRef:
+                      description: 'AncestorRef corresponds with a ParentRef in the
+                        spec that this
+
+                        PolicyAncestorStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - conditions
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -1,0 +1,663 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: gatewayclasses.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GatewayClass
+    listKind: GatewayClassList
+    plural: gatewayclasses
+    shortNames:
+    - gc
+    singular: gatewayclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'GatewayClass describes a class of Gateways available to the
+          user for creating
+
+          Gateway resources.
+
+
+          It is recommended that this resource be used as a template for Gateways.
+          This
+
+          means that a Gateway is based on the state of the GatewayClass at the time
+          it
+
+          was created and changes to the GatewayClass or associated parameters are
+          not
+
+          propagated down to existing Gateways. This recommendation is intended to
+
+          limit the blast radius of changes to GatewayClass or associated parameters.
+
+          If implementations choose to propagate GatewayClass changes to existing
+
+          Gateways, that MUST be clearly documented by the implementation.
+
+
+          Whenever one or more Gateways are using a GatewayClass, implementations
+          SHOULD
+
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on
+          the
+
+          associated GatewayClass. This ensures that a GatewayClass associated with
+          a
+
+          Gateway is not deleted while in use.
+
+
+          GatewayClass is a Cluster level resource.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: 'ControllerName is the name of the controller that is
+                  managing Gateways of
+
+                  this class. The value of this field MUST be a domain prefixed path.
+
+
+                  Example: "example.net/gateway-controller".
+
+
+                  This field is not mutable and cannot be empty.
+
+
+                  Support: Core'
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: 'ParametersRef is a reference to a resource that contains
+                  the configuration
+
+                  parameters corresponding to the GatewayClass. This is optional if
+                  the
+
+                  controller does not require any additional configuration.
+
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e.
+                  ConfigMap,
+
+                  or an implementation-specific custom resource. The resource can
+                  be
+
+                  cluster-scoped or namespace-scoped.
+
+
+                  If the referent cannot be found, refers to an unsupported kind,
+                  or when
+
+                  the data within that resource is malformed, the GatewayClass SHOULD
+                  be
+
+                  rejected with the "Accepted" status condition set to "False" and
+                  an
+
+                  "InvalidParameters" reason.
+
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`.
+                  When both are specified,
+
+                  the merging behavior is implementation specific.
+
+                  It is generally recommended that GatewayClass provides defaults
+                  that can be overridden by a Gateway.
+
+
+                  Support: Implementation-specific'
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: 'Namespace is the namespace of the referent.
+
+                      This field is required when referring to a Namespace-scoped
+                      resource and
+
+                      MUST be unset when referring to a Cluster-scoped resource.'
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: 'Status defines the current state of GatewayClass.
+
+
+              Implementations MUST populate status on all GatewayClass resources which
+
+              specify their controller name.'
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: 'Conditions is the current status from the controller
+                  for
+
+                  this GatewayClass.
+
+
+                  Controllers should prefer to publish conditions using values
+
+                  of GatewayClassConditionType for the type of each Condition.'
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              supportedFeatures:
+                description: 'SupportedFeatures is the set of features the GatewayClass
+                  support.
+
+                  It MUST be sorted in ascending alphabetical order by the Name key.'
+                items:
+                  properties:
+                    name:
+                      description: 'FeatureName is used to describe distinct features
+                        that are covered by
+
+                        conformance tests.'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: 'GatewayClass describes a class of Gateways available to the
+          user for creating
+
+          Gateway resources.
+
+
+          It is recommended that this resource be used as a template for Gateways.
+          This
+
+          means that a Gateway is based on the state of the GatewayClass at the time
+          it
+
+          was created and changes to the GatewayClass or associated parameters are
+          not
+
+          propagated down to existing Gateways. This recommendation is intended to
+
+          limit the blast radius of changes to GatewayClass or associated parameters.
+
+          If implementations choose to propagate GatewayClass changes to existing
+
+          Gateways, that MUST be clearly documented by the implementation.
+
+
+          Whenever one or more Gateways are using a GatewayClass, implementations
+          SHOULD
+
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on
+          the
+
+          associated GatewayClass. This ensures that a GatewayClass associated with
+          a
+
+          Gateway is not deleted while in use.
+
+
+          GatewayClass is a Cluster level resource.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: 'ControllerName is the name of the controller that is
+                  managing Gateways of
+
+                  this class. The value of this field MUST be a domain prefixed path.
+
+
+                  Example: "example.net/gateway-controller".
+
+
+                  This field is not mutable and cannot be empty.
+
+
+                  Support: Core'
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: 'ParametersRef is a reference to a resource that contains
+                  the configuration
+
+                  parameters corresponding to the GatewayClass. This is optional if
+                  the
+
+                  controller does not require any additional configuration.
+
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e.
+                  ConfigMap,
+
+                  or an implementation-specific custom resource. The resource can
+                  be
+
+                  cluster-scoped or namespace-scoped.
+
+
+                  If the referent cannot be found, refers to an unsupported kind,
+                  or when
+
+                  the data within that resource is malformed, the GatewayClass SHOULD
+                  be
+
+                  rejected with the "Accepted" status condition set to "False" and
+                  an
+
+                  "InvalidParameters" reason.
+
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`.
+                  When both are specified,
+
+                  the merging behavior is implementation specific.
+
+                  It is generally recommended that GatewayClass provides defaults
+                  that can be overridden by a Gateway.
+
+
+                  Support: Implementation-specific'
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: 'Namespace is the namespace of the referent.
+
+                      This field is required when referring to a Namespace-scoped
+                      resource and
+
+                      MUST be unset when referring to a Cluster-scoped resource.'
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: 'Status defines the current state of GatewayClass.
+
+
+              Implementations MUST populate status on all GatewayClass resources which
+
+              specify their controller name.'
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: 'Conditions is the current status from the controller
+                  for
+
+                  this GatewayClass.
+
+
+                  Controllers should prefer to publish conditions using values
+
+                  of GatewayClassConditionType for the type of each Condition.'
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              supportedFeatures:
+                description: 'SupportedFeatures is the set of features the GatewayClass
+                  support.
+
+                  It MUST be sorted in ascending alphabetical order by the Name key.'
+                items:
+                  properties:
+                    name:
+                      description: 'FeatureName is used to describe distinct features
+                        that are covered by
+
+                        conformance tests.'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gateways.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gateways.yaml
@@ -1,0 +1,3965 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: gateways.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gtw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'Gateway represents an instance of a service-traffic handling
+          infrastructure
+
+          by binding Listeners to a set of IP addresses.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: 'Addresses requested for this Gateway. This is optional
+                  and behavior can
+
+                  depend on the implementation. If a value is set in the spec and
+                  the
+
+                  requested address is invalid or unavailable, the implementation
+                  MUST
+
+                  indicate this in an associated entry in GatewayStatus.Conditions.
+
+
+                  The Addresses field represents a request for the address(es) on
+                  the
+
+                  "outside of the Gateway", that traffic bound for this Gateway will
+                  use.
+
+                  This could be the IP address or hostname of an external load balancer
+                  or
+
+                  other networking infrastructure, or some other address that traffic
+                  will
+
+                  be sent to.
+
+
+                  If no Addresses are specified, the implementation MAY schedule the
+
+                  Gateway in an implementation-specific manner, assigning an appropriate
+
+                  set of Addresses.
+
+
+                  The implementation MUST bind all Listeners to every GatewayAddress
+                  that
+
+                  it assigns to the Gateway and add a corresponding entry in
+
+                  GatewayStatus.Addresses.
+
+
+                  Support: Extended'
+                items:
+                  description: GatewaySpecAddress describes an address that can be
+                    bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: 'When a value is unspecified, an implementation
+                        SHOULD automatically
+
+                        assign an address matching the requested type if possible.
+
+
+                        If an implementation does not support an empty value, they
+                        MUST set the
+
+                        "Programmed" condition in status to False with a reason of
+                        "AddressNotAssigned".
+
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.'
+                      maxLength: 253
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must be empty or contain only valid characters
+                      (matching ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? (!has(self.value) || self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$""")):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
+              allowedListeners:
+                description: 'AllowedListeners defines which ListenerSets can be attached
+                  to this Gateway.
+
+                  The default value is to allow no ListenerSets.'
+                properties:
+                  namespaces:
+                    default:
+                      from: None
+                    description: 'Namespaces defines which namespaces ListenerSets
+                      can be attached to this Gateway.
+
+                      The default value is to allow no ListenerSets.'
+                    properties:
+                      from:
+                        default: None
+                        description: 'From indicates where ListenerSets can attach
+                          to this Gateway. Possible
+
+                          values are:
+
+
+                          * Same: Only ListenerSets in the same namespace may be attached
+                          to this Gateway.
+
+                          * Selector: ListenerSets in namespaces selected by the selector
+                          may be attached to this Gateway.
+
+                          * All: ListenerSets in all namespaces may be attached to
+                          this Gateway.
+
+                          * None: Only listeners defined in the Gateway''s spec are
+                          allowed
+
+
+                          The default value None'
+                        enum:
+                        - All
+                        - Selector
+                        - Same
+                        - None
+                        type: string
+                      selector:
+                        description: 'Selector must be specified when From is set
+                          to "Selector". In that case,
+
+                          only ListenerSets in Namespaces matching this Selector will
+                          be selected by this
+
+                          Gateway. This field is ignored for other values of "From".'
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: 'A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+
+                                relates the key and values.'
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: 'operator represents a key''s relationship
+                                    to a set of values.
+
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.'
+                                  type: string
+                                values:
+                                  description: 'values is an array of string values.
+                                    If the operator is In or NotIn,
+
+                                    the values array must be non-empty. If the operator
+                                    is Exists or DoesNotExist,
+
+                                    the values array must be empty. This array is
+                                    replaced during a strategic
+
+                                    merge patch.'
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: 'matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels
+
+                              map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the
+
+                              operator is "In", and the values array contains only
+                              "value". The requirements are ANDed.'
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                type: object
+              gatewayClassName:
+                description: 'GatewayClassName used for this Gateway. This is the
+                  name of a
+
+                  GatewayClass resource.'
+                maxLength: 253
+                minLength: 1
+                type: string
+              infrastructure:
+                description: 'Infrastructure defines infrastructure level attributes
+                  about this Gateway instance.
+
+
+                  Support: Extended'
+                properties:
+                  annotations:
+                    additionalProperties:
+                      description: 'AnnotationValue is the value of an annotation
+                        in Gateway API. This is used
+
+                        for validation of maps such as TLS options. This roughly matches
+                        Kubernetes
+
+                        annotation validation, although the length validation in that
+                        case is based
+
+                        on the entire size of the annotations struct.'
+                      maxLength: 4096
+                      minLength: 0
+                      type: string
+                    description: 'Annotations that SHOULD be applied to any resources
+                      created in response to this Gateway.
+
+
+                      For implementations creating other Kubernetes objects, this
+                      should be the `metadata.annotations` field on resources.
+
+                      For other implementations, this refers to any relevant (implementation
+                      specific) "annotations" concepts.
+
+
+                      An implementation may chose to add additional implementation-specific
+                      annotations as they see fit.
+
+
+                      Support: Extended'
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  labels:
+                    additionalProperties:
+                      description: 'LabelValue is the value of a label in the Gateway
+                        API. This is used for validation
+
+                        of maps such as Gateway infrastructure labels. This matches
+                        the Kubernetes
+
+                        label validation rules:
+
+                        * must be 63 characters or less (can be empty),
+
+                        * unless empty, must begin and end with an alphanumeric character
+                        ([a-z0-9A-Z]),
+
+                        * could contain dashes (-), underscores (_), dots (.), and
+                        alphanumerics between.
+
+
+                        Valid values include:
+
+
+                        * MyValue
+
+                        * my.name
+
+                        * 123-my-value'
+                      maxLength: 63
+                      minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: 'Labels that SHOULD be applied to any resources created
+                      in response to this Gateway.
+
+
+                      For implementations creating other Kubernetes objects, this
+                      should be the `metadata.labels` field on resources.
+
+                      For other implementations, this refers to any relevant (implementation
+                      specific) "labels" concepts.
+
+
+                      An implementation may chose to add additional implementation-specific
+                      labels as they see fit.
+
+
+                      If an implementation maps these labels to Pods, or any other
+                      resource that would need to be recreated when labels
+
+                      change, it SHOULD clearly warn about this behavior in documentation.
+
+
+                      Support: Extended'
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  parametersRef:
+                    description: 'ParametersRef is a reference to a resource that
+                      contains the configuration
+
+                      parameters corresponding to the Gateway. This is optional if
+                      the
+
+                      controller does not require any additional configuration.
+
+
+                      This follows the same semantics as GatewayClass''s `parametersRef`,
+                      but on a per-Gateway basis
+
+
+                      The Gateway''s GatewayClass may provide its own `parametersRef`.
+                      When both are specified,
+
+                      the merging behavior is implementation specific.
+
+                      It is generally recommended that GatewayClass provides defaults
+                      that can be overridden by a Gateway.
+
+
+                      If the referent cannot be found, refers to an unsupported kind,
+                      or when
+
+                      the data within that resource is malformed, the Gateway SHOULD
+                      be
+
+                      rejected with the "Accepted" status condition set to "False"
+                      and an
+
+                      "InvalidParameters" reason.
+
+
+                      Support: Implementation-specific'
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                type: object
+              listeners:
+                description: "Listeners associated with this Gateway. Listeners define\n\
+                  logical endpoints that are bound on this Gateway's addresses.\n\
+                  At least one Listener MUST be specified.\n\n## Distinct Listeners\n\
+                  \nEach Listener in a set of Listeners (for example, in a single\
+                  \ Gateway)\nMUST be _distinct_, in that a traffic flow MUST be able\
+                  \ to be assigned to\nexactly one listener. (This section uses \"\
+                  set of Listeners\" rather than\n\"Listeners in a single Gateway\"\
+                  \ because implementations MAY merge configuration\nfrom multiple\
+                  \ Gateways onto a single data plane, and these rules _also_\napply\
+                  \ in that case).\n\nPractically, this means that each listener in\
+                  \ a set MUST have a unique\ncombination of Port, Protocol, and,\
+                  \ if supported by the protocol, Hostname.\n\nSome combinations of\
+                  \ port, protocol, and TLS settings are considered\nCore support\
+                  \ and MUST be supported by implementations based on the objects\n\
+                  they support:\n\nHTTPRoute\n\n1. HTTPRoute, Port: 80, Protocol:\
+                  \ HTTP\n2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate,\
+                  \ TLS keypair provided\n\nTLSRoute\n\n1. TLSRoute, Port: 443, Protocol:\
+                  \ TLS, TLS Mode: Passthrough\n\n\"Distinct\" Listeners have the\
+                  \ following property:\n\n**The implementation can match inbound\
+                  \ requests to a single distinct\nListener**.\n\nWhen multiple Listeners\
+                  \ share values for fields (for\nexample, two Listeners with the\
+                  \ same Port value), the implementation\ncan match requests to only\
+                  \ one of the Listeners using other\nListener fields.\n\nWhen multiple\
+                  \ listeners have the same value for the Protocol field, then\neach\
+                  \ of the Listeners with matching Protocol values MUST have different\n\
+                  values for other fields.\n\nThe set of fields that MUST be different\
+                  \ for a Listener differs per protocol.\nThe following rules define\
+                  \ the rules for what fields MUST be considered for\nListeners to\
+                  \ be distinct with each protocol currently defined in the\nGateway\
+                  \ API spec.\n\nThe set of listeners that all share a protocol value\
+                  \ MUST have _different_\nvalues for _at least one_ of these fields\
+                  \ to be distinct:\n\n* **HTTP, HTTPS, TLS**: Port, Hostname\n* **TCP,\
+                  \ UDP**: Port\n\nOne **very** important rule to call out involves\
+                  \ what happens when an\nimplementation:\n\n* Supports TCP protocol\
+                  \ Listeners, as well as HTTP, HTTPS, or TLS protocol\n  Listeners,\
+                  \ and\n* sees HTTP, HTTPS, or TLS protocols with the same `port`\
+                  \ as one with TCP\n  Protocol.\n\nIn this case all the Listeners\
+                  \ that share a port with the\nTCP Listener are not distinct and\
+                  \ so MUST NOT be accepted.\n\nIf an implementation does not support\
+                  \ TCP Protocol Listeners, then the\nprevious rule does not apply,\
+                  \ and the TCP Listeners SHOULD NOT be\naccepted.\n\nNote that the\
+                  \ `tls` field is not used for determining if a listener is distinct,\
+                  \ because\nListeners that _only_ differ on TLS config will still\
+                  \ conflict in all cases.\n\n### Listeners that are distinct only\
+                  \ by Hostname\n\nWhen the Listeners are distinct based only on Hostname,\
+                  \ inbound request\nhostnames MUST match from the most specific to\
+                  \ least specific Hostname\nvalues to choose the correct Listener\
+                  \ and its associated set of Routes.\n\nExact matches MUST be processed\
+                  \ before wildcard matches, and wildcard\nmatches MUST be processed\
+                  \ before fallback (empty Hostname value)\nmatches. For example,\
+                  \ `\"foo.example.com\"` takes precedence over\n`\"*.example.com\"\
+                  `, and `\"*.example.com\"` takes precedence over `\"\"`.\n\nAdditionally,\
+                  \ if there are multiple wildcard entries, more specific\nwildcard\
+                  \ entries must be processed before less specific wildcard entries.\n\
+                  For example, `\"*.foo.example.com\"` takes precedence over `\"*.example.com\"\
+                  `.\n\nThe precise definition here is that the higher the number\
+                  \ of dots in the\nhostname to the right of the wildcard character,\
+                  \ the higher the precedence.\n\nThe wildcard character will match\
+                  \ any number of characters _and dots_ to\nthe left, however, so\
+                  \ `\"*.example.com\"` will match both\n`\"foo.bar.example.com\"\
+                  ` _and_ `\"bar.example.com\"`.\n\n## Handling indistinct Listeners\n\
+                  \nIf a set of Listeners contains Listeners that are not distinct,\
+                  \ then those\nListeners are _Conflicted_, and the implementation\
+                  \ MUST set the \"Conflicted\"\ncondition in the Listener Status\
+                  \ to \"True\".\n\nThe words \"indistinct\" and \"conflicted\" are\
+                  \ considered equivalent for the\npurpose of this documentation.\n\
+                  \nImplementations MAY choose to accept a Gateway with some Conflicted\n\
+                  Listeners only if they only accept the partial Listener set that\
+                  \ contains\nno Conflicted Listeners.\n\nSpecifically, an implementation\
+                  \ MAY accept a partial Listener set subject to\nthe following rules:\n\
+                  \n* The implementation MUST NOT pick one conflicting Listener as\
+                  \ the winner.\n  ALL indistinct Listeners must not be accepted for\
+                  \ processing.\n* At least one distinct Listener MUST be present,\
+                  \ or else the Gateway effectively\n  contains _no_ Listeners, and\
+                  \ must be rejected from processing as a whole.\n\nThe implementation\
+                  \ MUST set a \"ListenersNotValid\" condition on the\nGateway Status\
+                  \ when the Gateway contains Conflicted Listeners whether or\nnot\
+                  \ they accept the Gateway. That Condition SHOULD clearly\nindicate\
+                  \ in the Message which Listeners are conflicted, and which are\n\
+                  Accepted. Additionally, the Listener status for those listeners\
+                  \ SHOULD\nindicate which Listeners are conflicted and not Accepted.\n\
+                  \n## General Listener behavior\n\nNote that, for all distinct Listeners,\
+                  \ requests SHOULD match at most one Listener.\nFor example, if Listeners\
+                  \ are defined for \"foo.example.com\" and \"*.example.com\", a\n\
+                  request to \"foo.example.com\" SHOULD only be routed using routes\
+                  \ attached\nto the \"foo.example.com\" Listener (and not the \"\
+                  *.example.com\" Listener).\n\nThis concept is known as \"Listener\
+                  \ Isolation\", and it is an Extended feature\nof Gateway API. Implementations\
+                  \ that do not support Listener Isolation MUST\nclearly document\
+                  \ this, and MUST NOT claim support for the\n`GatewayHTTPListenerIsolation`\
+                  \ feature.\n\nImplementations that _do_ support Listener Isolation\
+                  \ SHOULD claim support\nfor the Extended `GatewayHTTPListenerIsolation`\
+                  \ feature and pass the associated\nconformance tests.\n\n## Compatible\
+                  \ Listeners\n\nA Gateway's Listeners are considered _compatible_\
+                  \ if:\n\n1. They are distinct.\n2. The implementation can serve\
+                  \ them in compliance with the Addresses\n   requirement that all\
+                  \ Listeners are available on all assigned\n   addresses.\n\nCompatible\
+                  \ combinations in Extended support are expected to vary across\n\
+                  implementations. A combination that is compatible for one implementation\n\
+                  may not be compatible for another.\n\nFor example, an implementation\
+                  \ that cannot serve both TCP and UDP listeners\non the same address,\
+                  \ or cannot mix HTTPS and generic TLS listens on the same port\n\
+                  would not consider those cases compatible, even though they are\
+                  \ distinct.\n\nImplementations MAY merge separate Gateways onto\
+                  \ a single set of\nAddresses if all Listeners across all Gateways\
+                  \ are compatible.\n\nIn a future release the MinItems=1 requirement\
+                  \ MAY be dropped.\n\nSupport: Core"
+                items:
+                  description: 'Listener embodies the concept of a logical endpoint
+                    where a Gateway accepts
+
+                    network connections.'
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: "AllowedRoutes defines the types of routes that\
+                        \ MAY be attached to a\nListener and the trusted namespaces\
+                        \ where those Route resources MAY be\npresent.\n\nAlthough\
+                        \ a client request may match multiple route rules, only one\
+                        \ rule\nmay ultimately receive the request. Matching precedence\
+                        \ MUST be\ndetermined in order of the following criteria:\n\
+                        \n* The most specific match as defined by the Route type.\n\
+                        * The oldest Route based on creation timestamp. For example,\
+                        \ a Route with\n  a creation timestamp of \"2020-09-08 01:02:03\"\
+                        \ is given precedence over\n  a Route with a creation timestamp\
+                        \ of \"2020-09-08 01:02:04\".\n* If everything else is equivalent,\
+                        \ the Route appearing first in\n  alphabetical order (namespace/name)\
+                        \ should be given precedence. For\n  example, foo/bar is given\
+                        \ precedence over foo/baz.\n\nAll valid rules within a Route\
+                        \ attached to this Listener should be\nimplemented. Invalid\
+                        \ Route rules can be ignored (sometimes that will mean\nthe\
+                        \ full Route). If a Route rule transitions from valid to invalid,\n\
+                        support for that Route rule should be dropped to ensure consistency.\
+                        \ For\nexample, even if a filter specified by a Route rule\
+                        \ is invalid, the rest\nof the rules within that Route should\
+                        \ still be supported.\n\nSupport: Core"
+                      properties:
+                        kinds:
+                          description: 'Kinds specifies the groups and kinds of Routes
+                            that are allowed to bind
+
+                            to this Gateway Listener. When unspecified or empty, the
+                            kinds of Routes
+
+                            selected are determined using the Listener protocol.
+
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that
+                            are compatible
+
+                            with the application protocol specified in the Listener''s
+                            Protocol field.
+
+                            If an implementation does not support or recognize this
+                            resource type, it
+
+                            MUST set the "ResolvedRefs" condition to False for this
+                            Listener with the
+
+                            "InvalidRouteKinds" reason.
+
+
+                            Support: Core'
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        namespaces:
+                          default:
+                            from: Same
+                          description: 'Namespaces indicates namespaces from which
+                            Routes may be attached to this
+
+                            Listener. This is restricted to the namespace of this
+                            Gateway by default.
+
+
+                            Support: Core'
+                          properties:
+                            from:
+                              default: Same
+                              description: "From indicates where Routes will be selected\
+                                \ for this Gateway. Possible\nvalues are:\n\n* All:\
+                                \ Routes in all namespaces may be used by this Gateway.\n\
+                                * Selector: Routes in namespaces selected by the selector\
+                                \ may be used by\n  this Gateway.\n* Same: Only Routes\
+                                \ in the same namespace may be used by this Gateway.\n\
+                                \nSupport: Core"
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: 'Selector must be specified when From is
+                                set to "Selector". In that case,
+
+                                only Routes in Namespaces matching this Selector will
+                                be selected by this
+
+                                Gateway. This field is ignored for other values of
+                                "From".
+
+
+                                Support: Core'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: 'A label selector requirement is
+                                      a selector that contains values, a key, and
+                                      an operator that
+
+                                      relates the key and values.'
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: 'operator represents a key''s
+                                          relationship to a set of values.
+
+                                          Valid operators are In, NotIn, Exists and
+                                          DoesNotExist.'
+                                        type: string
+                                      values:
+                                        description: 'values is an array of string
+                                          values. If the operator is In or NotIn,
+
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist,
+
+                                          the values array must be empty. This array
+                                          is replaced during a strategic
+
+                                          merge patch.'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the
+
+                                    operator is "In", and the values array contains
+                                    only "value". The requirements are ANDed.'
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: "Hostname specifies the virtual hostname to match\
+                        \ for protocol types that\ndefine this concept. When unspecified,\
+                        \ all hostnames are matched. This\nfield is ignored for protocols\
+                        \ that don't require hostname based\nmatching.\n\nImplementations\
+                        \ MUST apply Hostname matching appropriately for each of\n\
+                        the following protocols:\n\n* TLS: The Listener Hostname MUST\
+                        \ match the SNI.\n* HTTP: The Listener Hostname MUST match\
+                        \ the Host header of the request.\n* HTTPS: The Listener Hostname\
+                        \ SHOULD match both the SNI and Host header.\n  Note that\
+                        \ this does not require the SNI and Host header to be the\
+                        \ same.\n  The semantics of this are described in more detail\
+                        \ below.\n\nTo ensure security, Section 11.1 of RFC-6066 emphasizes\
+                        \ that server\nimplementations that rely on SNI hostname matching\
+                        \ MUST also verify\nhostnames within the application protocol.\n\
+                        \nSection 9.1.2 of RFC-7540 provides a mechanism for servers\
+                        \ to reject the\nreuse of a connection by responding with\
+                        \ the HTTP 421 Misdirected Request\nstatus code. This indicates\
+                        \ that the origin server has rejected the\nrequest because\
+                        \ it appears to have been misdirected.\n\nTo detect misdirected\
+                        \ requests, Gateways SHOULD match the authority of\nthe requests\
+                        \ with all the SNI hostname(s) configured across all the\n\
+                        Gateway Listeners on the same port and protocol:\n\n* If another\
+                        \ Listener has an exact match or more specific wildcard entry,\n\
+                        \  the Gateway SHOULD return a 421.\n* If the current Listener\
+                        \ (selected by SNI matching during ClientHello)\n  does not\
+                        \ match the Host:\n    * If another Listener does match the\
+                        \ Host, the Gateway SHOULD return a\n      421.\n    * If\
+                        \ no other Listener matches the Host, the Gateway MUST return\
+                        \ a\n      404.\n\nFor HTTPRoute and TLSRoute resources, there\
+                        \ is an interaction with the\n`spec.hostnames` array. When\
+                        \ both listener and route specify hostnames,\nthere MUST be\
+                        \ an intersection between the values for a Route to be\naccepted.\
+                        \ For more information, refer to the Route specific Hostnames\n\
+                        documentation.\n\nHostnames that are prefixed with a wildcard\
+                        \ label (`*.`) are interpreted\nas a suffix match. That means\
+                        \ that a match for `*.example.com` would match\nboth `test.example.com`,\
+                        \ and `foo.test.example.com`, but not `example.com`.\n\nSupport:\
+                        \ Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: 'Name is the name of the Listener. This name MUST
+                        be unique within a
+
+                        Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: 'Port is the network port. Multiple listeners may
+                        use the
+
+                        same port, subject to the Listener compatibility rules.
+
+
+                        Support: Core'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: 'Protocol specifies the network protocol this listener
+                        expects to receive.
+
+
+                        Support: Core'
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: 'TLS is the TLS configuration for the Listener.
+                        This field is required if
+
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set
+                        this field
+
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+
+                        The association of SNIs to Certificate defined in ListenerTLSConfig
+                        is
+
+                        defined based on the Hostname field for this listener.
+
+
+                        The GatewayClass MUST use the longest matching SNI out of
+                        all
+
+                        available certificates for any TLS handshake.
+
+
+                        Support: Core'
+                      properties:
+                        certificateRefs:
+                          description: 'CertificateRefs contains a series of references
+                            to Kubernetes objects that
+
+                            contains TLS certificates and private keys. These certificates
+                            are used to
+
+                            establish a TLS handshake for requests that match the
+                            hostname of the
+
+                            associated listener.
+
+
+                            A single CertificateRef to a Kubernetes Secret has "Core"
+                            support.
+
+                            Implementations MAY choose to support attaching multiple
+                            certificates to
+
+                            a Listener, but this behavior is implementation-specific.
+
+
+                            References to a resource in different namespace are invalid
+                            UNLESS there
+
+                            is a ReferenceGrant in the target namespace that allows
+                            the certificate
+
+                            to be attached. If a ReferenceGrant does not allow this
+                            reference, the
+
+                            "ResolvedRefs" condition MUST be set to False for this
+                            listener with the
+
+                            "RefNotPermitted" reason.
+
+
+                            This field is required to have at least one element when
+                            the mode is set
+
+                            to "Terminate" (default) and is optional otherwise.
+
+
+                            CertificateRefs can reference to standard Kubernetes resources,
+                            i.e.
+
+                            Secret, or implementation-specific custom resources.
+
+
+                            Support: Core - A single reference to a Kubernetes Secret
+                            of type kubernetes.io/tls
+
+
+                            Support: Implementation-specific (More than one reference
+                            or other resource types)'
+                          items:
+                            description: 'SecretObjectReference identifies an API
+                              object including its namespace,
+
+                              defaulting to Secret.
+
+
+                              The API object must be valid in the cluster; the Group
+                              and Kind must
+
+                              be registered in the cluster for this reference to be
+                              valid.
+
+
+                              References to objects with invalid Group and Kind are
+                              not valid, and must
+
+                              be rejected by the implementation, with appropriate
+                              Conditions set
+
+                              on the containing object.'
+                            properties:
+                              group:
+                                default: ''
+                                description: 'Group is the group of the referent.
+                                  For example, "gateway.networking.k8s.io".
+
+                                  When unspecified or empty string, core API group
+                                  is inferred.'
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: 'Namespace is the namespace of the referenced
+                                  object. When unspecified, the local
+
+                                  namespace is inferred.
+
+
+                                  Note that when a namespace different than the local
+                                  namespace is specified,
+
+                                  a ReferenceGrant object is required in the referent
+                                  namespace to allow that
+
+                                  namespace''s owner to accept the reference. See
+                                  the ReferenceGrant
+
+                                  documentation for details.
+
+
+                                  Support: Core'
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        mode:
+                          default: Terminate
+                          description: "Mode defines the TLS behavior for the TLS\
+                            \ session initiated by the client.\nThere are two possible\
+                            \ modes:\n\n- Terminate: The TLS session between the downstream\
+                            \ client and the\n  Gateway is terminated at the Gateway.\
+                            \ This mode requires certificates\n  to be specified in\
+                            \ some way, such as populating the certificateRefs\n \
+                            \ field.\n- Passthrough: The TLS session is NOT terminated\
+                            \ by the Gateway. This\n  implies that the Gateway can't\
+                            \ decipher the TLS stream except for\n  the ClientHello\
+                            \ message of the TLS protocol. The certificateRefs field\n\
+                            \  is ignored in this mode.\n\nSupport: Core"
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: 'AnnotationValue is the value of an annotation
+                              in Gateway API. This is used
+
+                              for validation of maps such as TLS options. This roughly
+                              matches Kubernetes
+
+                              annotation validation, although the length validation
+                              in that case is based
+
+                              on the entire size of the annotations struct.'
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: 'Options are a list of key/value pairs to enable
+                            extended TLS
+
+                            configuration for each implementation. For example, configuring
+                            the
+
+                            minimum TLS version or supported cipher suites.
+
+
+                            A set of common keys MAY be defined by the API in the
+                            future. To avoid
+
+                            any ambiguity, implementation-specific definitions MUST
+                            use
+
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+
+                            Un-prefixed names are reserved for key names defined by
+                            Gateway API.
+
+
+                            Support: Implementation-specific'
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+              tls:
+                description: 'TLS specifies frontend and backend tls configuration
+                  for entire gateway.
+
+
+                  Support: Extended'
+                properties:
+                  backend:
+                    description: 'Backend describes TLS configuration for gateway
+                      when connecting
+
+                      to backends.
+
+
+                      Note that this contains only details for the Gateway as a TLS
+                      client,
+
+                      and does _not_ imply behavior about how to choose which backend
+                      should
+
+                      get a TLS connection. That is determined by the presence of
+                      a BackendTLSPolicy.
+
+
+                      Support: Core'
+                    properties:
+                      clientCertificateRef:
+                        description: "ClientCertificateRef references an object that\
+                          \ contains a client certificate\nand its associated private\
+                          \ key. It can reference standard Kubernetes resources,\n\
+                          i.e., Secret, or implementation-specific custom resources.\n\
+                          \nA ClientCertificateRef is considered invalid if:\n\n*\
+                          \ It refers to a resource that cannot be resolved (e.g.,\
+                          \ the referenced resource\n  does not exist) or is misconfigured\
+                          \ (e.g., a Secret does not contain the keys\n  named `tls.crt`\
+                          \ and `tls.key`). In this case, the `ResolvedRefs` condition\n\
+                          \  on the Gateway MUST be set to False with the Reason `InvalidClientCertificateRef`\n\
+                          \  and the Message of the Condition MUST indicate why the\
+                          \ reference is invalid.\n\n* It refers to a resource in\
+                          \ another namespace UNLESS there is a ReferenceGrant\n \
+                          \ in the target namespace that allows the certificate to\
+                          \ be attached.\n  If a ReferenceGrant does not allow this\
+                          \ reference, the `ResolvedRefs` condition\n  on the Gateway\
+                          \ MUST be set to False with the Reason `RefNotPermitted`.\n\
+                          \nImplementations MAY choose to perform further validation\
+                          \ of the certificate\ncontent (e.g., checking expiry or\
+                          \ enforcing specific formats). In such cases,\nan implementation-specific\
+                          \ Reason and Message MUST be set.\n\nSupport: Core - Reference\
+                          \ to a Kubernetes TLS Secret (with the type `kubernetes.io/tls`).\n\
+                          Support: Implementation-specific - Other resource kinds\
+                          \ or Secrets with a\ndifferent type (e.g., `Opaque`)."
+                        properties:
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Secret
+                            description: Kind is kind of the referent. For example
+                              "Secret".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the referenced
+                              object. When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  frontend:
+                    description: 'Frontend describes TLS config when client connects
+                      to Gateway.
+
+                      Support: Core'
+                    properties:
+                      default:
+                        description: 'Default specifies the default client certificate
+                          validation configuration
+
+                          for all Listeners handling HTTPS traffic, unless a per-port
+                          configuration
+
+                          is defined.
+
+
+                          support: Core'
+                        properties:
+                          validation:
+                            description: 'Validation holds configuration information
+                              for validating the frontend (client).
+
+                              Setting this field will result in mutual authentication
+                              when connecting to the gateway.
+
+                              In browsers this may result in a dialog appearing
+
+                              that requests a user to specify the client certificate.
+
+                              The maximum depth of a certificate chain accepted in
+                              verification is Implementation specific.
+
+
+                              Support: Core'
+                            properties:
+                              caCertificateRefs:
+                                description: "CACertificateRefs contains one or more\
+                                  \ references to Kubernetes\nobjects that contain\
+                                  \ a PEM-encoded TLS CA certificate bundle, which\n\
+                                  is used as a trust anchor to validate the certificates\
+                                  \ presented by\nthe client.\n\nA CACertificateRef\
+                                  \ is invalid if:\n\n* It refers to a resource that\
+                                  \ cannot be resolved (e.g., the\n  referenced resource\
+                                  \ does not exist) or is misconfigured (e.g., a\n\
+                                  \  ConfigMap does not contain a key named `ca.crt`).\
+                                  \ In this case, the\n  Reason on all matching HTTPS\
+                                  \ listeners must be set to `InvalidCACertificateRef`\n\
+                                  \  and the Message of the Condition must indicate\
+                                  \ which reference is invalid and why.\n\n* It refers\
+                                  \ to an unknown or unsupported kind of resource.\
+                                  \ In this\n  case, the Reason on all matching HTTPS\
+                                  \ listeners must be set to\n  `InvalidCACertificateKind`\
+                                  \ and the Message of the Condition must explain\n\
+                                  \  which kind of resource is unknown or unsupported.\n\
+                                  \n* It refers to a resource in another namespace\
+                                  \ UNLESS there is a\n  ReferenceGrant in the target\
+                                  \ namespace that allows the CA\n  certificate to\
+                                  \ be attached. If a ReferenceGrant does not allow\
+                                  \ this\n  reference, the `ResolvedRefs` on all matching\
+                                  \ HTTPS listeners condition\n  MUST be set with\
+                                  \ the Reason `RefNotPermitted`.\n\nImplementations\
+                                  \ MAY choose to perform further validation of the\n\
+                                  certificate content (e.g., checking expiry or enforcing\
+                                  \ specific formats).\nIn such cases, an implementation-specific\
+                                  \ Reason and Message MUST be set.\n\nIn all cases,\
+                                  \ the implementation MUST ensure that the `ResolvedRefs`\n\
+                                  condition is set to `status: False` on all targeted\
+                                  \ listeners (i.e.,\nlisteners serving HTTPS on a\
+                                  \ matching port). The condition MUST\ninclude a\
+                                  \ Reason and Message that indicate the cause of\
+                                  \ the error. If\nALL CACertificateRefs are invalid,\
+                                  \ the implementation MUST also ensure\nthe `Accepted`\
+                                  \ condition on the listener is set to `status: False`,\
+                                  \ with\nthe Reason `NoValidCACertificate`.\nImplementations\
+                                  \ MAY choose to support attaching multiple CA certificates\n\
+                                  to a listener, but this behavior is implementation-specific.\n\
+                                  \nSupport: Core - A single reference to a Kubernetes\
+                                  \ ConfigMap, with the\nCA certificate in a key named\
+                                  \ `ca.crt`.\n\nSupport: Implementation-specific\
+                                  \ - More than one reference, other kinds\nof resources,\
+                                  \ or a single reference that includes multiple certificates."
+                                items:
+                                  description: 'ObjectReference identifies an API
+                                    object including its namespace.
+
+
+                                    The API object must be valid in the cluster; the
+                                    Group and Kind must
+
+                                    be registered in the cluster for this reference
+                                    to be valid.
+
+
+                                    References to objects with invalid Group and Kind
+                                    are not valid, and must
+
+                                    be rejected by the implementation, with appropriate
+                                    Conditions set
+
+                                    on the containing object.'
+                                  properties:
+                                    group:
+                                      description: 'Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+
+                                        When set to the empty string, core API group
+                                        is inferred.'
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "ConfigMap" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace is the namespace of
+                                        the referenced object. When unspecified, the
+                                        local
+
+                                        namespace is inferred.
+
+
+                                        Note that when a namespace different than
+                                        the local namespace is specified,
+
+                                        a ReferenceGrant object is required in the
+                                        referent namespace to allow that
+
+                                        namespace''s owner to accept the reference.
+                                        See the ReferenceGrant
+
+                                        documentation for details.
+
+
+                                        Support: Core'
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                maxItems: 8
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mode:
+                                default: AllowValidOnly
+                                description: "FrontendValidationMode defines the mode\
+                                  \ for validating the client certificate.\nThere\
+                                  \ are two possible modes:\n\n- AllowValidOnly: In\
+                                  \ this mode, the gateway will accept connections\
+                                  \ only if\n  the client presents a valid certificate.\
+                                  \ This certificate must successfully\n  pass validation\
+                                  \ against the CA certificates specified in `CACertificateRefs`.\n\
+                                  - AllowInsecureFallback: In this mode, the gateway\
+                                  \ will accept connections\n  even if the client\
+                                  \ certificate is not presented or fails verification.\n\
+                                  \n  This approach delegates client authorization\
+                                  \ to the backend and introduce\n  a significant\
+                                  \ security risk. It should be used in testing environments\
+                                  \ or\n  on a temporary basis in non-testing environments.\n\
+                                  \nDefaults to AllowValidOnly.\n\nSupport: Core"
+                                enum:
+                                - AllowValidOnly
+                                - AllowInsecureFallback
+                                type: string
+                            required:
+                            - caCertificateRefs
+                            type: object
+                        type: object
+                      perPort:
+                        description: 'PerPort specifies tls configuration assigned
+                          per port.
+
+                          Per port configuration is optional. Once set this configuration
+                          overrides
+
+                          the default configuration for all Listeners handling HTTPS
+                          traffic
+
+                          that match this port.
+
+                          Each override port requires a unique TLS configuration.
+
+
+                          support: Core'
+                        items:
+                          properties:
+                            port:
+                              description: 'The Port indicates the Port Number to
+                                which the TLS configuration will be
+
+                                applied. This configuration will be applied to all
+                                Listeners handling HTTPS
+
+                                traffic that match this port.
+
+
+                                Support: Core'
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            tls:
+                              description: 'TLS store the configuration that will
+                                be applied to all Listeners handling
+
+                                HTTPS traffic and matching given port.
+
+
+                                Support: Core'
+                              properties:
+                                validation:
+                                  description: 'Validation holds configuration information
+                                    for validating the frontend (client).
+
+                                    Setting this field will result in mutual authentication
+                                    when connecting to the gateway.
+
+                                    In browsers this may result in a dialog appearing
+
+                                    that requests a user to specify the client certificate.
+
+                                    The maximum depth of a certificate chain accepted
+                                    in verification is Implementation specific.
+
+
+                                    Support: Core'
+                                  properties:
+                                    caCertificateRefs:
+                                      description: "CACertificateRefs contains one\
+                                        \ or more references to Kubernetes\nobjects\
+                                        \ that contain a PEM-encoded TLS CA certificate\
+                                        \ bundle, which\nis used as a trust anchor\
+                                        \ to validate the certificates presented by\n\
+                                        the client.\n\nA CACertificateRef is invalid\
+                                        \ if:\n\n* It refers to a resource that cannot\
+                                        \ be resolved (e.g., the\n  referenced resource\
+                                        \ does not exist) or is misconfigured (e.g.,\
+                                        \ a\n  ConfigMap does not contain a key named\
+                                        \ `ca.crt`). In this case, the\n  Reason on\
+                                        \ all matching HTTPS listeners must be set\
+                                        \ to `InvalidCACertificateRef`\n  and the\
+                                        \ Message of the Condition must indicate which\
+                                        \ reference is invalid and why.\n\n* It refers\
+                                        \ to an unknown or unsupported kind of resource.\
+                                        \ In this\n  case, the Reason on all matching\
+                                        \ HTTPS listeners must be set to\n  `InvalidCACertificateKind`\
+                                        \ and the Message of the Condition must explain\n\
+                                        \  which kind of resource is unknown or unsupported.\n\
+                                        \n* It refers to a resource in another namespace\
+                                        \ UNLESS there is a\n  ReferenceGrant in the\
+                                        \ target namespace that allows the CA\n  certificate\
+                                        \ to be attached. If a ReferenceGrant does\
+                                        \ not allow this\n  reference, the `ResolvedRefs`\
+                                        \ on all matching HTTPS listeners condition\n\
+                                        \  MUST be set with the Reason `RefNotPermitted`.\n\
+                                        \nImplementations MAY choose to perform further\
+                                        \ validation of the\ncertificate content (e.g.,\
+                                        \ checking expiry or enforcing specific formats).\n\
+                                        In such cases, an implementation-specific\
+                                        \ Reason and Message MUST be set.\n\nIn all\
+                                        \ cases, the implementation MUST ensure that\
+                                        \ the `ResolvedRefs`\ncondition is set to\
+                                        \ `status: False` on all targeted listeners\
+                                        \ (i.e.,\nlisteners serving HTTPS on a matching\
+                                        \ port). The condition MUST\ninclude a Reason\
+                                        \ and Message that indicate the cause of the\
+                                        \ error. If\nALL CACertificateRefs are invalid,\
+                                        \ the implementation MUST also ensure\nthe\
+                                        \ `Accepted` condition on the listener is\
+                                        \ set to `status: False`, with\nthe Reason\
+                                        \ `NoValidCACertificate`.\nImplementations\
+                                        \ MAY choose to support attaching multiple\
+                                        \ CA certificates\nto a listener, but this\
+                                        \ behavior is implementation-specific.\n\n\
+                                        Support: Core - A single reference to a Kubernetes\
+                                        \ ConfigMap, with the\nCA certificate in a\
+                                        \ key named `ca.crt`.\n\nSupport: Implementation-specific\
+                                        \ - More than one reference, other kinds\n\
+                                        of resources, or a single reference that includes\
+                                        \ multiple certificates."
+                                      items:
+                                        description: 'ObjectReference identifies an
+                                          API object including its namespace.
+
+
+                                          The API object must be valid in the cluster;
+                                          the Group and Kind must
+
+                                          be registered in the cluster for this reference
+                                          to be valid.
+
+
+                                          References to objects with invalid Group
+                                          and Kind are not valid, and must
+
+                                          be rejected by the implementation, with
+                                          appropriate Conditions set
+
+                                          on the containing object.'
+                                        properties:
+                                          group:
+                                            description: 'Group is the group of the
+                                              referent. For example, "gateway.networking.k8s.io".
+
+                                              When set to the empty string, core API
+                                              group is inferred.'
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            description: Kind is kind of the referent.
+                                              For example "ConfigMap" or "Service".
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: 'Namespace is the namespace
+                                              of the referenced object. When unspecified,
+                                              the local
+
+                                              namespace is inferred.
+
+
+                                              Note that when a namespace different
+                                              than the local namespace is specified,
+
+                                              a ReferenceGrant object is required
+                                              in the referent namespace to allow that
+
+                                              namespace''s owner to accept the reference.
+                                              See the ReferenceGrant
+
+                                              documentation for details.
+
+
+                                              Support: Core'
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                        required:
+                                        - group
+                                        - kind
+                                        - name
+                                        type: object
+                                      maxItems: 8
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mode:
+                                      default: AllowValidOnly
+                                      description: "FrontendValidationMode defines\
+                                        \ the mode for validating the client certificate.\n\
+                                        There are two possible modes:\n\n- AllowValidOnly:\
+                                        \ In this mode, the gateway will accept connections\
+                                        \ only if\n  the client presents a valid certificate.\
+                                        \ This certificate must successfully\n  pass\
+                                        \ validation against the CA certificates specified\
+                                        \ in `CACertificateRefs`.\n- AllowInsecureFallback:\
+                                        \ In this mode, the gateway will accept connections\n\
+                                        \  even if the client certificate is not presented\
+                                        \ or fails verification.\n\n  This approach\
+                                        \ delegates client authorization to the backend\
+                                        \ and introduce\n  a significant security\
+                                        \ risk. It should be used in testing environments\
+                                        \ or\n  on a temporary basis in non-testing\
+                                        \ environments.\n\nDefaults to AllowValidOnly.\n\
+                                        \nSupport: Core"
+                                      enum:
+                                      - AllowValidOnly
+                                      - AllowInsecureFallback
+                                      type: string
+                                  required:
+                                  - caCertificateRefs
+                                  type: object
+                              type: object
+                          required:
+                          - port
+                          - tls
+                          type: object
+                        maxItems: 64
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Port for TLS configuration must be unique within
+                            the Gateway
+                          rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                    required:
+                    - default
+                    type: object
+                type: object
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: "Addresses lists the network addresses that have been\
+                  \ bound to the\nGateway.\n\nThis list may differ from the addresses\
+                  \ provided in the spec under some\nconditions:\n\n  * no addresses\
+                  \ are specified, all addresses are dynamically assigned\n  * a combination\
+                  \ of specified and dynamic addresses are assigned\n  * a specified\
+                  \ address was unusable (e.g. already in use)"
+                items:
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: 'Value of the address. The validity of the values
+                        will depend
+
+                        on the type and support by the controller.
+
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              attachedListenerSets:
+                description: 'AttachedListenerSets represents the total number of
+                  ListenerSets that have been
+
+                  successfully attached to this Gateway.
+
+
+                  A ListenerSet is successfully attached to a Gateway when all the
+                  following conditions are met:
+
+                  - The ListenerSet is selected by the Gateway''s AllowedListeners
+                  field
+
+                  - The ListenerSet has a valid ParentRef selecting the Gateway
+
+                  - The ListenerSet''s status has the condition "Accepted: true"
+
+
+                  Uses for this field include troubleshooting AttachedListenerSets
+                  attachment and
+
+                  measuring blast radius/impact of changes to a Gateway.'
+                format: int32
+                type: integer
+              conditions:
+                default:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: 'Conditions describe the current conditions of the Gateway.
+
+
+                  Implementations should prefer to express Gateway conditions
+
+                  using the `GatewayConditionType` and `GatewayConditionReason`
+
+                  constants so that operators and tools can converge on a common
+
+                  vocabulary to describe Gateway state.
+
+
+                  Known condition types are:
+
+
+                  * "Accepted"
+
+                  * "Programmed"
+
+                  * "Ready"'
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: 'AttachedRoutes represents the total number of
+                        Routes that have been
+
+                        successfully attached to this Listener.
+
+
+                        Successful attachment of a Route to a Listener is based solely
+                        on the
+
+                        combination of the AllowedRoutes field on the corresponding
+                        Listener
+
+                        and the Route''s ParentRefs field. A Route is successfully
+                        attached to
+
+                        a Listener when it is selected by the Listener''s AllowedRoutes
+                        field
+
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+
+                        resource or a specific Listener as a parent resource (more
+                        detail on
+
+                        attachment semantics can be found in the documentation on
+                        the various
+
+                        Route kinds ParentRefs fields). Listener or Route status does
+                        not impact
+
+                        successful attachment, i.e. the AttachedRoutes field count
+                        MUST be set
+
+                        for Listeners, even if the Accepted condition of an individual
+                        Listener is set
+
+                        to "False". The AttachedRoutes number represents the number
+                        of Routes with
+
+                        the Accepted condition set to "True" that have been attached
+                        to this Listener.
+
+                        Routes with any other value for the Accepted condition MUST
+                        NOT be included
+
+                        in this count.
+
+
+                        Uses for this field include troubleshooting Route attachment
+                        and
+
+                        measuring blast radius/impact of changes to a Listener.'
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: 'SupportedKinds is the list indicating the Kinds
+                        supported by this
+
+                        listener. This MUST represent the kinds supported by an implementation
+                        for
+
+                        that Listener configuration.
+
+
+                        If kinds are specified in Spec that are not supported, they
+                        MUST NOT
+
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+
+                        condition to "False" with the "InvalidRouteKinds" reason.
+                        If both valid
+
+                        and invalid Route kinds are specified, the implementation
+                        MUST
+
+                        reference the valid Route kinds that have been specified.'
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: 'Gateway represents an instance of a service-traffic handling
+          infrastructure
+
+          by binding Listeners to a set of IP addresses.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: 'Addresses requested for this Gateway. This is optional
+                  and behavior can
+
+                  depend on the implementation. If a value is set in the spec and
+                  the
+
+                  requested address is invalid or unavailable, the implementation
+                  MUST
+
+                  indicate this in an associated entry in GatewayStatus.Conditions.
+
+
+                  The Addresses field represents a request for the address(es) on
+                  the
+
+                  "outside of the Gateway", that traffic bound for this Gateway will
+                  use.
+
+                  This could be the IP address or hostname of an external load balancer
+                  or
+
+                  other networking infrastructure, or some other address that traffic
+                  will
+
+                  be sent to.
+
+
+                  If no Addresses are specified, the implementation MAY schedule the
+
+                  Gateway in an implementation-specific manner, assigning an appropriate
+
+                  set of Addresses.
+
+
+                  The implementation MUST bind all Listeners to every GatewayAddress
+                  that
+
+                  it assigns to the Gateway and add a corresponding entry in
+
+                  GatewayStatus.Addresses.
+
+
+                  Support: Extended'
+                items:
+                  description: GatewaySpecAddress describes an address that can be
+                    bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: 'When a value is unspecified, an implementation
+                        SHOULD automatically
+
+                        assign an address matching the requested type if possible.
+
+
+                        If an implementation does not support an empty value, they
+                        MUST set the
+
+                        "Programmed" condition in status to False with a reason of
+                        "AddressNotAssigned".
+
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.'
+                      maxLength: 253
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must be empty or contain only valid characters
+                      (matching ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? (!has(self.value) || self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$""")):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: IPAddress values must be unique
+                  rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
+                - message: Hostname values must be unique
+                  rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ?
+                    self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value
+                    == a1.value) : true )'
+              allowedListeners:
+                description: 'AllowedListeners defines which ListenerSets can be attached
+                  to this Gateway.
+
+                  The default value is to allow no ListenerSets.'
+                properties:
+                  namespaces:
+                    default:
+                      from: None
+                    description: 'Namespaces defines which namespaces ListenerSets
+                      can be attached to this Gateway.
+
+                      The default value is to allow no ListenerSets.'
+                    properties:
+                      from:
+                        default: None
+                        description: 'From indicates where ListenerSets can attach
+                          to this Gateway. Possible
+
+                          values are:
+
+
+                          * Same: Only ListenerSets in the same namespace may be attached
+                          to this Gateway.
+
+                          * Selector: ListenerSets in namespaces selected by the selector
+                          may be attached to this Gateway.
+
+                          * All: ListenerSets in all namespaces may be attached to
+                          this Gateway.
+
+                          * None: Only listeners defined in the Gateway''s spec are
+                          allowed
+
+
+                          The default value None'
+                        enum:
+                        - All
+                        - Selector
+                        - Same
+                        - None
+                        type: string
+                      selector:
+                        description: 'Selector must be specified when From is set
+                          to "Selector". In that case,
+
+                          only ListenerSets in Namespaces matching this Selector will
+                          be selected by this
+
+                          Gateway. This field is ignored for other values of "From".'
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: 'A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+
+                                relates the key and values.'
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: 'operator represents a key''s relationship
+                                    to a set of values.
+
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.'
+                                  type: string
+                                values:
+                                  description: 'values is an array of string values.
+                                    If the operator is In or NotIn,
+
+                                    the values array must be non-empty. If the operator
+                                    is Exists or DoesNotExist,
+
+                                    the values array must be empty. This array is
+                                    replaced during a strategic
+
+                                    merge patch.'
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: 'matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels
+
+                              map is equivalent to an element of matchExpressions,
+                              whose key field is "key", the
+
+                              operator is "In", and the values array contains only
+                              "value". The requirements are ANDed.'
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                type: object
+              gatewayClassName:
+                description: 'GatewayClassName used for this Gateway. This is the
+                  name of a
+
+                  GatewayClass resource.'
+                maxLength: 253
+                minLength: 1
+                type: string
+              infrastructure:
+                description: 'Infrastructure defines infrastructure level attributes
+                  about this Gateway instance.
+
+
+                  Support: Extended'
+                properties:
+                  annotations:
+                    additionalProperties:
+                      description: 'AnnotationValue is the value of an annotation
+                        in Gateway API. This is used
+
+                        for validation of maps such as TLS options. This roughly matches
+                        Kubernetes
+
+                        annotation validation, although the length validation in that
+                        case is based
+
+                        on the entire size of the annotations struct.'
+                      maxLength: 4096
+                      minLength: 0
+                      type: string
+                    description: 'Annotations that SHOULD be applied to any resources
+                      created in response to this Gateway.
+
+
+                      For implementations creating other Kubernetes objects, this
+                      should be the `metadata.annotations` field on resources.
+
+                      For other implementations, this refers to any relevant (implementation
+                      specific) "annotations" concepts.
+
+
+                      An implementation may chose to add additional implementation-specific
+                      annotations as they see fit.
+
+
+                      Support: Extended'
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Annotation keys must be in the form of an optional
+                        DNS subdomain prefix followed by a required name segment of
+                        up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the annotation key's prefix must be a
+                        DNS subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  labels:
+                    additionalProperties:
+                      description: 'LabelValue is the value of a label in the Gateway
+                        API. This is used for validation
+
+                        of maps such as Gateway infrastructure labels. This matches
+                        the Kubernetes
+
+                        label validation rules:
+
+                        * must be 63 characters or less (can be empty),
+
+                        * unless empty, must begin and end with an alphanumeric character
+                        ([a-z0-9A-Z]),
+
+                        * could contain dashes (-), underscores (_), dots (.), and
+                        alphanumerics between.
+
+
+                        Valid values include:
+
+
+                        * MyValue
+
+                        * my.name
+
+                        * 123-my-value'
+                      maxLength: 63
+                      minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: 'Labels that SHOULD be applied to any resources created
+                      in response to this Gateway.
+
+
+                      For implementations creating other Kubernetes objects, this
+                      should be the `metadata.labels` field on resources.
+
+                      For other implementations, this refers to any relevant (implementation
+                      specific) "labels" concepts.
+
+
+                      An implementation may chose to add additional implementation-specific
+                      labels as they see fit.
+
+
+                      If an implementation maps these labels to Pods, or any other
+                      resource that would need to be recreated when labels
+
+                      change, it SHOULD clearly warn about this behavior in documentation.
+
+
+                      Support: Extended'
+                    maxProperties: 8
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Label keys must be in the form of an optional DNS subdomain
+                        prefix followed by a required name segment of up to 63 characters.
+                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
+                    - message: If specified, the label key's prefix must be a DNS
+                        subdomain not longer than 253 characters in total.
+                      rule: self.all(key, key.split("/")[0].size() < 253)
+                  parametersRef:
+                    description: 'ParametersRef is a reference to a resource that
+                      contains the configuration
+
+                      parameters corresponding to the Gateway. This is optional if
+                      the
+
+                      controller does not require any additional configuration.
+
+
+                      This follows the same semantics as GatewayClass''s `parametersRef`,
+                      but on a per-Gateway basis
+
+
+                      The Gateway''s GatewayClass may provide its own `parametersRef`.
+                      When both are specified,
+
+                      the merging behavior is implementation specific.
+
+                      It is generally recommended that GatewayClass provides defaults
+                      that can be overridden by a Gateway.
+
+
+                      If the referent cannot be found, refers to an unsupported kind,
+                      or when
+
+                      the data within that resource is malformed, the Gateway SHOULD
+                      be
+
+                      rejected with the "Accepted" status condition set to "False"
+                      and an
+
+                      "InvalidParameters" reason.
+
+
+                      Support: Implementation-specific'
+                    properties:
+                      group:
+                        description: Group is the group of the referent.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                type: object
+              listeners:
+                description: "Listeners associated with this Gateway. Listeners define\n\
+                  logical endpoints that are bound on this Gateway's addresses.\n\
+                  At least one Listener MUST be specified.\n\n## Distinct Listeners\n\
+                  \nEach Listener in a set of Listeners (for example, in a single\
+                  \ Gateway)\nMUST be _distinct_, in that a traffic flow MUST be able\
+                  \ to be assigned to\nexactly one listener. (This section uses \"\
+                  set of Listeners\" rather than\n\"Listeners in a single Gateway\"\
+                  \ because implementations MAY merge configuration\nfrom multiple\
+                  \ Gateways onto a single data plane, and these rules _also_\napply\
+                  \ in that case).\n\nPractically, this means that each listener in\
+                  \ a set MUST have a unique\ncombination of Port, Protocol, and,\
+                  \ if supported by the protocol, Hostname.\n\nSome combinations of\
+                  \ port, protocol, and TLS settings are considered\nCore support\
+                  \ and MUST be supported by implementations based on the objects\n\
+                  they support:\n\nHTTPRoute\n\n1. HTTPRoute, Port: 80, Protocol:\
+                  \ HTTP\n2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate,\
+                  \ TLS keypair provided\n\nTLSRoute\n\n1. TLSRoute, Port: 443, Protocol:\
+                  \ TLS, TLS Mode: Passthrough\n\n\"Distinct\" Listeners have the\
+                  \ following property:\n\n**The implementation can match inbound\
+                  \ requests to a single distinct\nListener**.\n\nWhen multiple Listeners\
+                  \ share values for fields (for\nexample, two Listeners with the\
+                  \ same Port value), the implementation\ncan match requests to only\
+                  \ one of the Listeners using other\nListener fields.\n\nWhen multiple\
+                  \ listeners have the same value for the Protocol field, then\neach\
+                  \ of the Listeners with matching Protocol values MUST have different\n\
+                  values for other fields.\n\nThe set of fields that MUST be different\
+                  \ for a Listener differs per protocol.\nThe following rules define\
+                  \ the rules for what fields MUST be considered for\nListeners to\
+                  \ be distinct with each protocol currently defined in the\nGateway\
+                  \ API spec.\n\nThe set of listeners that all share a protocol value\
+                  \ MUST have _different_\nvalues for _at least one_ of these fields\
+                  \ to be distinct:\n\n* **HTTP, HTTPS, TLS**: Port, Hostname\n* **TCP,\
+                  \ UDP**: Port\n\nOne **very** important rule to call out involves\
+                  \ what happens when an\nimplementation:\n\n* Supports TCP protocol\
+                  \ Listeners, as well as HTTP, HTTPS, or TLS protocol\n  Listeners,\
+                  \ and\n* sees HTTP, HTTPS, or TLS protocols with the same `port`\
+                  \ as one with TCP\n  Protocol.\n\nIn this case all the Listeners\
+                  \ that share a port with the\nTCP Listener are not distinct and\
+                  \ so MUST NOT be accepted.\n\nIf an implementation does not support\
+                  \ TCP Protocol Listeners, then the\nprevious rule does not apply,\
+                  \ and the TCP Listeners SHOULD NOT be\naccepted.\n\nNote that the\
+                  \ `tls` field is not used for determining if a listener is distinct,\
+                  \ because\nListeners that _only_ differ on TLS config will still\
+                  \ conflict in all cases.\n\n### Listeners that are distinct only\
+                  \ by Hostname\n\nWhen the Listeners are distinct based only on Hostname,\
+                  \ inbound request\nhostnames MUST match from the most specific to\
+                  \ least specific Hostname\nvalues to choose the correct Listener\
+                  \ and its associated set of Routes.\n\nExact matches MUST be processed\
+                  \ before wildcard matches, and wildcard\nmatches MUST be processed\
+                  \ before fallback (empty Hostname value)\nmatches. For example,\
+                  \ `\"foo.example.com\"` takes precedence over\n`\"*.example.com\"\
+                  `, and `\"*.example.com\"` takes precedence over `\"\"`.\n\nAdditionally,\
+                  \ if there are multiple wildcard entries, more specific\nwildcard\
+                  \ entries must be processed before less specific wildcard entries.\n\
+                  For example, `\"*.foo.example.com\"` takes precedence over `\"*.example.com\"\
+                  `.\n\nThe precise definition here is that the higher the number\
+                  \ of dots in the\nhostname to the right of the wildcard character,\
+                  \ the higher the precedence.\n\nThe wildcard character will match\
+                  \ any number of characters _and dots_ to\nthe left, however, so\
+                  \ `\"*.example.com\"` will match both\n`\"foo.bar.example.com\"\
+                  ` _and_ `\"bar.example.com\"`.\n\n## Handling indistinct Listeners\n\
+                  \nIf a set of Listeners contains Listeners that are not distinct,\
+                  \ then those\nListeners are _Conflicted_, and the implementation\
+                  \ MUST set the \"Conflicted\"\ncondition in the Listener Status\
+                  \ to \"True\".\n\nThe words \"indistinct\" and \"conflicted\" are\
+                  \ considered equivalent for the\npurpose of this documentation.\n\
+                  \nImplementations MAY choose to accept a Gateway with some Conflicted\n\
+                  Listeners only if they only accept the partial Listener set that\
+                  \ contains\nno Conflicted Listeners.\n\nSpecifically, an implementation\
+                  \ MAY accept a partial Listener set subject to\nthe following rules:\n\
+                  \n* The implementation MUST NOT pick one conflicting Listener as\
+                  \ the winner.\n  ALL indistinct Listeners must not be accepted for\
+                  \ processing.\n* At least one distinct Listener MUST be present,\
+                  \ or else the Gateway effectively\n  contains _no_ Listeners, and\
+                  \ must be rejected from processing as a whole.\n\nThe implementation\
+                  \ MUST set a \"ListenersNotValid\" condition on the\nGateway Status\
+                  \ when the Gateway contains Conflicted Listeners whether or\nnot\
+                  \ they accept the Gateway. That Condition SHOULD clearly\nindicate\
+                  \ in the Message which Listeners are conflicted, and which are\n\
+                  Accepted. Additionally, the Listener status for those listeners\
+                  \ SHOULD\nindicate which Listeners are conflicted and not Accepted.\n\
+                  \n## General Listener behavior\n\nNote that, for all distinct Listeners,\
+                  \ requests SHOULD match at most one Listener.\nFor example, if Listeners\
+                  \ are defined for \"foo.example.com\" and \"*.example.com\", a\n\
+                  request to \"foo.example.com\" SHOULD only be routed using routes\
+                  \ attached\nto the \"foo.example.com\" Listener (and not the \"\
+                  *.example.com\" Listener).\n\nThis concept is known as \"Listener\
+                  \ Isolation\", and it is an Extended feature\nof Gateway API. Implementations\
+                  \ that do not support Listener Isolation MUST\nclearly document\
+                  \ this, and MUST NOT claim support for the\n`GatewayHTTPListenerIsolation`\
+                  \ feature.\n\nImplementations that _do_ support Listener Isolation\
+                  \ SHOULD claim support\nfor the Extended `GatewayHTTPListenerIsolation`\
+                  \ feature and pass the associated\nconformance tests.\n\n## Compatible\
+                  \ Listeners\n\nA Gateway's Listeners are considered _compatible_\
+                  \ if:\n\n1. They are distinct.\n2. The implementation can serve\
+                  \ them in compliance with the Addresses\n   requirement that all\
+                  \ Listeners are available on all assigned\n   addresses.\n\nCompatible\
+                  \ combinations in Extended support are expected to vary across\n\
+                  implementations. A combination that is compatible for one implementation\n\
+                  may not be compatible for another.\n\nFor example, an implementation\
+                  \ that cannot serve both TCP and UDP listeners\non the same address,\
+                  \ or cannot mix HTTPS and generic TLS listens on the same port\n\
+                  would not consider those cases compatible, even though they are\
+                  \ distinct.\n\nImplementations MAY merge separate Gateways onto\
+                  \ a single set of\nAddresses if all Listeners across all Gateways\
+                  \ are compatible.\n\nIn a future release the MinItems=1 requirement\
+                  \ MAY be dropped.\n\nSupport: Core"
+                items:
+                  description: 'Listener embodies the concept of a logical endpoint
+                    where a Gateway accepts
+
+                    network connections.'
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: "AllowedRoutes defines the types of routes that\
+                        \ MAY be attached to a\nListener and the trusted namespaces\
+                        \ where those Route resources MAY be\npresent.\n\nAlthough\
+                        \ a client request may match multiple route rules, only one\
+                        \ rule\nmay ultimately receive the request. Matching precedence\
+                        \ MUST be\ndetermined in order of the following criteria:\n\
+                        \n* The most specific match as defined by the Route type.\n\
+                        * The oldest Route based on creation timestamp. For example,\
+                        \ a Route with\n  a creation timestamp of \"2020-09-08 01:02:03\"\
+                        \ is given precedence over\n  a Route with a creation timestamp\
+                        \ of \"2020-09-08 01:02:04\".\n* If everything else is equivalent,\
+                        \ the Route appearing first in\n  alphabetical order (namespace/name)\
+                        \ should be given precedence. For\n  example, foo/bar is given\
+                        \ precedence over foo/baz.\n\nAll valid rules within a Route\
+                        \ attached to this Listener should be\nimplemented. Invalid\
+                        \ Route rules can be ignored (sometimes that will mean\nthe\
+                        \ full Route). If a Route rule transitions from valid to invalid,\n\
+                        support for that Route rule should be dropped to ensure consistency.\
+                        \ For\nexample, even if a filter specified by a Route rule\
+                        \ is invalid, the rest\nof the rules within that Route should\
+                        \ still be supported.\n\nSupport: Core"
+                      properties:
+                        kinds:
+                          description: 'Kinds specifies the groups and kinds of Routes
+                            that are allowed to bind
+
+                            to this Gateway Listener. When unspecified or empty, the
+                            kinds of Routes
+
+                            selected are determined using the Listener protocol.
+
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that
+                            are compatible
+
+                            with the application protocol specified in the Listener''s
+                            Protocol field.
+
+                            If an implementation does not support or recognize this
+                            resource type, it
+
+                            MUST set the "ResolvedRefs" condition to False for this
+                            Listener with the
+
+                            "InvalidRouteKinds" reason.
+
+
+                            Support: Core'
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        namespaces:
+                          default:
+                            from: Same
+                          description: 'Namespaces indicates namespaces from which
+                            Routes may be attached to this
+
+                            Listener. This is restricted to the namespace of this
+                            Gateway by default.
+
+
+                            Support: Core'
+                          properties:
+                            from:
+                              default: Same
+                              description: "From indicates where Routes will be selected\
+                                \ for this Gateway. Possible\nvalues are:\n\n* All:\
+                                \ Routes in all namespaces may be used by this Gateway.\n\
+                                * Selector: Routes in namespaces selected by the selector\
+                                \ may be used by\n  this Gateway.\n* Same: Only Routes\
+                                \ in the same namespace may be used by this Gateway.\n\
+                                \nSupport: Core"
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: 'Selector must be specified when From is
+                                set to "Selector". In that case,
+
+                                only Routes in Namespaces matching this Selector will
+                                be selected by this
+
+                                Gateway. This field is ignored for other values of
+                                "From".
+
+
+                                Support: Core'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: 'A label selector requirement is
+                                      a selector that contains values, a key, and
+                                      an operator that
+
+                                      relates the key and values.'
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: 'operator represents a key''s
+                                          relationship to a set of values.
+
+                                          Valid operators are In, NotIn, Exists and
+                                          DoesNotExist.'
+                                        type: string
+                                      values:
+                                        description: 'values is an array of string
+                                          values. If the operator is In or NotIn,
+
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist,
+
+                                          the values array must be empty. This array
+                                          is replaced during a strategic
+
+                                          merge patch.'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the
+
+                                    operator is "In", and the values array contains
+                                    only "value". The requirements are ANDed.'
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: "Hostname specifies the virtual hostname to match\
+                        \ for protocol types that\ndefine this concept. When unspecified,\
+                        \ all hostnames are matched. This\nfield is ignored for protocols\
+                        \ that don't require hostname based\nmatching.\n\nImplementations\
+                        \ MUST apply Hostname matching appropriately for each of\n\
+                        the following protocols:\n\n* TLS: The Listener Hostname MUST\
+                        \ match the SNI.\n* HTTP: The Listener Hostname MUST match\
+                        \ the Host header of the request.\n* HTTPS: The Listener Hostname\
+                        \ SHOULD match both the SNI and Host header.\n  Note that\
+                        \ this does not require the SNI and Host header to be the\
+                        \ same.\n  The semantics of this are described in more detail\
+                        \ below.\n\nTo ensure security, Section 11.1 of RFC-6066 emphasizes\
+                        \ that server\nimplementations that rely on SNI hostname matching\
+                        \ MUST also verify\nhostnames within the application protocol.\n\
+                        \nSection 9.1.2 of RFC-7540 provides a mechanism for servers\
+                        \ to reject the\nreuse of a connection by responding with\
+                        \ the HTTP 421 Misdirected Request\nstatus code. This indicates\
+                        \ that the origin server has rejected the\nrequest because\
+                        \ it appears to have been misdirected.\n\nTo detect misdirected\
+                        \ requests, Gateways SHOULD match the authority of\nthe requests\
+                        \ with all the SNI hostname(s) configured across all the\n\
+                        Gateway Listeners on the same port and protocol:\n\n* If another\
+                        \ Listener has an exact match or more specific wildcard entry,\n\
+                        \  the Gateway SHOULD return a 421.\n* If the current Listener\
+                        \ (selected by SNI matching during ClientHello)\n  does not\
+                        \ match the Host:\n    * If another Listener does match the\
+                        \ Host, the Gateway SHOULD return a\n      421.\n    * If\
+                        \ no other Listener matches the Host, the Gateway MUST return\
+                        \ a\n      404.\n\nFor HTTPRoute and TLSRoute resources, there\
+                        \ is an interaction with the\n`spec.hostnames` array. When\
+                        \ both listener and route specify hostnames,\nthere MUST be\
+                        \ an intersection between the values for a Route to be\naccepted.\
+                        \ For more information, refer to the Route specific Hostnames\n\
+                        documentation.\n\nHostnames that are prefixed with a wildcard\
+                        \ label (`*.`) are interpreted\nas a suffix match. That means\
+                        \ that a match for `*.example.com` would match\nboth `test.example.com`,\
+                        \ and `foo.test.example.com`, but not `example.com`.\n\nSupport:\
+                        \ Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: 'Name is the name of the Listener. This name MUST
+                        be unique within a
+
+                        Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: 'Port is the network port. Multiple listeners may
+                        use the
+
+                        same port, subject to the Listener compatibility rules.
+
+
+                        Support: Core'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: 'Protocol specifies the network protocol this listener
+                        expects to receive.
+
+
+                        Support: Core'
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: 'TLS is the TLS configuration for the Listener.
+                        This field is required if
+
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set
+                        this field
+
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+
+                        The association of SNIs to Certificate defined in ListenerTLSConfig
+                        is
+
+                        defined based on the Hostname field for this listener.
+
+
+                        The GatewayClass MUST use the longest matching SNI out of
+                        all
+
+                        available certificates for any TLS handshake.
+
+
+                        Support: Core'
+                      properties:
+                        certificateRefs:
+                          description: 'CertificateRefs contains a series of references
+                            to Kubernetes objects that
+
+                            contains TLS certificates and private keys. These certificates
+                            are used to
+
+                            establish a TLS handshake for requests that match the
+                            hostname of the
+
+                            associated listener.
+
+
+                            A single CertificateRef to a Kubernetes Secret has "Core"
+                            support.
+
+                            Implementations MAY choose to support attaching multiple
+                            certificates to
+
+                            a Listener, but this behavior is implementation-specific.
+
+
+                            References to a resource in different namespace are invalid
+                            UNLESS there
+
+                            is a ReferenceGrant in the target namespace that allows
+                            the certificate
+
+                            to be attached. If a ReferenceGrant does not allow this
+                            reference, the
+
+                            "ResolvedRefs" condition MUST be set to False for this
+                            listener with the
+
+                            "RefNotPermitted" reason.
+
+
+                            This field is required to have at least one element when
+                            the mode is set
+
+                            to "Terminate" (default) and is optional otherwise.
+
+
+                            CertificateRefs can reference to standard Kubernetes resources,
+                            i.e.
+
+                            Secret, or implementation-specific custom resources.
+
+
+                            Support: Core - A single reference to a Kubernetes Secret
+                            of type kubernetes.io/tls
+
+
+                            Support: Implementation-specific (More than one reference
+                            or other resource types)'
+                          items:
+                            description: 'SecretObjectReference identifies an API
+                              object including its namespace,
+
+                              defaulting to Secret.
+
+
+                              The API object must be valid in the cluster; the Group
+                              and Kind must
+
+                              be registered in the cluster for this reference to be
+                              valid.
+
+
+                              References to objects with invalid Group and Kind are
+                              not valid, and must
+
+                              be rejected by the implementation, with appropriate
+                              Conditions set
+
+                              on the containing object.'
+                            properties:
+                              group:
+                                default: ''
+                                description: 'Group is the group of the referent.
+                                  For example, "gateway.networking.k8s.io".
+
+                                  When unspecified or empty string, core API group
+                                  is inferred.'
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: 'Namespace is the namespace of the referenced
+                                  object. When unspecified, the local
+
+                                  namespace is inferred.
+
+
+                                  Note that when a namespace different than the local
+                                  namespace is specified,
+
+                                  a ReferenceGrant object is required in the referent
+                                  namespace to allow that
+
+                                  namespace''s owner to accept the reference. See
+                                  the ReferenceGrant
+
+                                  documentation for details.
+
+
+                                  Support: Core'
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        mode:
+                          default: Terminate
+                          description: "Mode defines the TLS behavior for the TLS\
+                            \ session initiated by the client.\nThere are two possible\
+                            \ modes:\n\n- Terminate: The TLS session between the downstream\
+                            \ client and the\n  Gateway is terminated at the Gateway.\
+                            \ This mode requires certificates\n  to be specified in\
+                            \ some way, such as populating the certificateRefs\n \
+                            \ field.\n- Passthrough: The TLS session is NOT terminated\
+                            \ by the Gateway. This\n  implies that the Gateway can't\
+                            \ decipher the TLS stream except for\n  the ClientHello\
+                            \ message of the TLS protocol. The certificateRefs field\n\
+                            \  is ignored in this mode.\n\nSupport: Core"
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: 'AnnotationValue is the value of an annotation
+                              in Gateway API. This is used
+
+                              for validation of maps such as TLS options. This roughly
+                              matches Kubernetes
+
+                              annotation validation, although the length validation
+                              in that case is based
+
+                              on the entire size of the annotations struct.'
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: 'Options are a list of key/value pairs to enable
+                            extended TLS
+
+                            configuration for each implementation. For example, configuring
+                            the
+
+                            minimum TLS version or supported cipher suites.
+
+
+                            A set of common keys MAY be defined by the API in the
+                            future. To avoid
+
+                            any ambiguity, implementation-specific definitions MUST
+                            use
+
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+
+                            Un-prefixed names are reserved for key names defined by
+                            Gateway API.
+
+
+                            Support: Implementation-specific'
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol
+                    == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname
+                    == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+              tls:
+                description: 'TLS specifies frontend and backend tls configuration
+                  for entire gateway.
+
+
+                  Support: Extended'
+                properties:
+                  backend:
+                    description: 'Backend describes TLS configuration for gateway
+                      when connecting
+
+                      to backends.
+
+
+                      Note that this contains only details for the Gateway as a TLS
+                      client,
+
+                      and does _not_ imply behavior about how to choose which backend
+                      should
+
+                      get a TLS connection. That is determined by the presence of
+                      a BackendTLSPolicy.
+
+
+                      Support: Core'
+                    properties:
+                      clientCertificateRef:
+                        description: "ClientCertificateRef references an object that\
+                          \ contains a client certificate\nand its associated private\
+                          \ key. It can reference standard Kubernetes resources,\n\
+                          i.e., Secret, or implementation-specific custom resources.\n\
+                          \nA ClientCertificateRef is considered invalid if:\n\n*\
+                          \ It refers to a resource that cannot be resolved (e.g.,\
+                          \ the referenced resource\n  does not exist) or is misconfigured\
+                          \ (e.g., a Secret does not contain the keys\n  named `tls.crt`\
+                          \ and `tls.key`). In this case, the `ResolvedRefs` condition\n\
+                          \  on the Gateway MUST be set to False with the Reason `InvalidClientCertificateRef`\n\
+                          \  and the Message of the Condition MUST indicate why the\
+                          \ reference is invalid.\n\n* It refers to a resource in\
+                          \ another namespace UNLESS there is a ReferenceGrant\n \
+                          \ in the target namespace that allows the certificate to\
+                          \ be attached.\n  If a ReferenceGrant does not allow this\
+                          \ reference, the `ResolvedRefs` condition\n  on the Gateway\
+                          \ MUST be set to False with the Reason `RefNotPermitted`.\n\
+                          \nImplementations MAY choose to perform further validation\
+                          \ of the certificate\ncontent (e.g., checking expiry or\
+                          \ enforcing specific formats). In such cases,\nan implementation-specific\
+                          \ Reason and Message MUST be set.\n\nSupport: Core - Reference\
+                          \ to a Kubernetes TLS Secret (with the type `kubernetes.io/tls`).\n\
+                          Support: Implementation-specific - Other resource kinds\
+                          \ or Secrets with a\ndifferent type (e.g., `Opaque`)."
+                        properties:
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Secret
+                            description: Kind is kind of the referent. For example
+                              "Secret".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the referenced
+                              object. When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  frontend:
+                    description: 'Frontend describes TLS config when client connects
+                      to Gateway.
+
+                      Support: Core'
+                    properties:
+                      default:
+                        description: 'Default specifies the default client certificate
+                          validation configuration
+
+                          for all Listeners handling HTTPS traffic, unless a per-port
+                          configuration
+
+                          is defined.
+
+
+                          support: Core'
+                        properties:
+                          validation:
+                            description: 'Validation holds configuration information
+                              for validating the frontend (client).
+
+                              Setting this field will result in mutual authentication
+                              when connecting to the gateway.
+
+                              In browsers this may result in a dialog appearing
+
+                              that requests a user to specify the client certificate.
+
+                              The maximum depth of a certificate chain accepted in
+                              verification is Implementation specific.
+
+
+                              Support: Core'
+                            properties:
+                              caCertificateRefs:
+                                description: "CACertificateRefs contains one or more\
+                                  \ references to Kubernetes\nobjects that contain\
+                                  \ a PEM-encoded TLS CA certificate bundle, which\n\
+                                  is used as a trust anchor to validate the certificates\
+                                  \ presented by\nthe client.\n\nA CACertificateRef\
+                                  \ is invalid if:\n\n* It refers to a resource that\
+                                  \ cannot be resolved (e.g., the\n  referenced resource\
+                                  \ does not exist) or is misconfigured (e.g., a\n\
+                                  \  ConfigMap does not contain a key named `ca.crt`).\
+                                  \ In this case, the\n  Reason on all matching HTTPS\
+                                  \ listeners must be set to `InvalidCACertificateRef`\n\
+                                  \  and the Message of the Condition must indicate\
+                                  \ which reference is invalid and why.\n\n* It refers\
+                                  \ to an unknown or unsupported kind of resource.\
+                                  \ In this\n  case, the Reason on all matching HTTPS\
+                                  \ listeners must be set to\n  `InvalidCACertificateKind`\
+                                  \ and the Message of the Condition must explain\n\
+                                  \  which kind of resource is unknown or unsupported.\n\
+                                  \n* It refers to a resource in another namespace\
+                                  \ UNLESS there is a\n  ReferenceGrant in the target\
+                                  \ namespace that allows the CA\n  certificate to\
+                                  \ be attached. If a ReferenceGrant does not allow\
+                                  \ this\n  reference, the `ResolvedRefs` on all matching\
+                                  \ HTTPS listeners condition\n  MUST be set with\
+                                  \ the Reason `RefNotPermitted`.\n\nImplementations\
+                                  \ MAY choose to perform further validation of the\n\
+                                  certificate content (e.g., checking expiry or enforcing\
+                                  \ specific formats).\nIn such cases, an implementation-specific\
+                                  \ Reason and Message MUST be set.\n\nIn all cases,\
+                                  \ the implementation MUST ensure that the `ResolvedRefs`\n\
+                                  condition is set to `status: False` on all targeted\
+                                  \ listeners (i.e.,\nlisteners serving HTTPS on a\
+                                  \ matching port). The condition MUST\ninclude a\
+                                  \ Reason and Message that indicate the cause of\
+                                  \ the error. If\nALL CACertificateRefs are invalid,\
+                                  \ the implementation MUST also ensure\nthe `Accepted`\
+                                  \ condition on the listener is set to `status: False`,\
+                                  \ with\nthe Reason `NoValidCACertificate`.\nImplementations\
+                                  \ MAY choose to support attaching multiple CA certificates\n\
+                                  to a listener, but this behavior is implementation-specific.\n\
+                                  \nSupport: Core - A single reference to a Kubernetes\
+                                  \ ConfigMap, with the\nCA certificate in a key named\
+                                  \ `ca.crt`.\n\nSupport: Implementation-specific\
+                                  \ - More than one reference, other kinds\nof resources,\
+                                  \ or a single reference that includes multiple certificates."
+                                items:
+                                  description: 'ObjectReference identifies an API
+                                    object including its namespace.
+
+
+                                    The API object must be valid in the cluster; the
+                                    Group and Kind must
+
+                                    be registered in the cluster for this reference
+                                    to be valid.
+
+
+                                    References to objects with invalid Group and Kind
+                                    are not valid, and must
+
+                                    be rejected by the implementation, with appropriate
+                                    Conditions set
+
+                                    on the containing object.'
+                                  properties:
+                                    group:
+                                      description: 'Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+
+                                        When set to the empty string, core API group
+                                        is inferred.'
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "ConfigMap" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace is the namespace of
+                                        the referenced object. When unspecified, the
+                                        local
+
+                                        namespace is inferred.
+
+
+                                        Note that when a namespace different than
+                                        the local namespace is specified,
+
+                                        a ReferenceGrant object is required in the
+                                        referent namespace to allow that
+
+                                        namespace''s owner to accept the reference.
+                                        See the ReferenceGrant
+
+                                        documentation for details.
+
+
+                                        Support: Core'
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                maxItems: 8
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mode:
+                                default: AllowValidOnly
+                                description: "FrontendValidationMode defines the mode\
+                                  \ for validating the client certificate.\nThere\
+                                  \ are two possible modes:\n\n- AllowValidOnly: In\
+                                  \ this mode, the gateway will accept connections\
+                                  \ only if\n  the client presents a valid certificate.\
+                                  \ This certificate must successfully\n  pass validation\
+                                  \ against the CA certificates specified in `CACertificateRefs`.\n\
+                                  - AllowInsecureFallback: In this mode, the gateway\
+                                  \ will accept connections\n  even if the client\
+                                  \ certificate is not presented or fails verification.\n\
+                                  \n  This approach delegates client authorization\
+                                  \ to the backend and introduce\n  a significant\
+                                  \ security risk. It should be used in testing environments\
+                                  \ or\n  on a temporary basis in non-testing environments.\n\
+                                  \nDefaults to AllowValidOnly.\n\nSupport: Core"
+                                enum:
+                                - AllowValidOnly
+                                - AllowInsecureFallback
+                                type: string
+                            required:
+                            - caCertificateRefs
+                            type: object
+                        type: object
+                      perPort:
+                        description: 'PerPort specifies tls configuration assigned
+                          per port.
+
+                          Per port configuration is optional. Once set this configuration
+                          overrides
+
+                          the default configuration for all Listeners handling HTTPS
+                          traffic
+
+                          that match this port.
+
+                          Each override port requires a unique TLS configuration.
+
+
+                          support: Core'
+                        items:
+                          properties:
+                            port:
+                              description: 'The Port indicates the Port Number to
+                                which the TLS configuration will be
+
+                                applied. This configuration will be applied to all
+                                Listeners handling HTTPS
+
+                                traffic that match this port.
+
+
+                                Support: Core'
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            tls:
+                              description: 'TLS store the configuration that will
+                                be applied to all Listeners handling
+
+                                HTTPS traffic and matching given port.
+
+
+                                Support: Core'
+                              properties:
+                                validation:
+                                  description: 'Validation holds configuration information
+                                    for validating the frontend (client).
+
+                                    Setting this field will result in mutual authentication
+                                    when connecting to the gateway.
+
+                                    In browsers this may result in a dialog appearing
+
+                                    that requests a user to specify the client certificate.
+
+                                    The maximum depth of a certificate chain accepted
+                                    in verification is Implementation specific.
+
+
+                                    Support: Core'
+                                  properties:
+                                    caCertificateRefs:
+                                      description: "CACertificateRefs contains one\
+                                        \ or more references to Kubernetes\nobjects\
+                                        \ that contain a PEM-encoded TLS CA certificate\
+                                        \ bundle, which\nis used as a trust anchor\
+                                        \ to validate the certificates presented by\n\
+                                        the client.\n\nA CACertificateRef is invalid\
+                                        \ if:\n\n* It refers to a resource that cannot\
+                                        \ be resolved (e.g., the\n  referenced resource\
+                                        \ does not exist) or is misconfigured (e.g.,\
+                                        \ a\n  ConfigMap does not contain a key named\
+                                        \ `ca.crt`). In this case, the\n  Reason on\
+                                        \ all matching HTTPS listeners must be set\
+                                        \ to `InvalidCACertificateRef`\n  and the\
+                                        \ Message of the Condition must indicate which\
+                                        \ reference is invalid and why.\n\n* It refers\
+                                        \ to an unknown or unsupported kind of resource.\
+                                        \ In this\n  case, the Reason on all matching\
+                                        \ HTTPS listeners must be set to\n  `InvalidCACertificateKind`\
+                                        \ and the Message of the Condition must explain\n\
+                                        \  which kind of resource is unknown or unsupported.\n\
+                                        \n* It refers to a resource in another namespace\
+                                        \ UNLESS there is a\n  ReferenceGrant in the\
+                                        \ target namespace that allows the CA\n  certificate\
+                                        \ to be attached. If a ReferenceGrant does\
+                                        \ not allow this\n  reference, the `ResolvedRefs`\
+                                        \ on all matching HTTPS listeners condition\n\
+                                        \  MUST be set with the Reason `RefNotPermitted`.\n\
+                                        \nImplementations MAY choose to perform further\
+                                        \ validation of the\ncertificate content (e.g.,\
+                                        \ checking expiry or enforcing specific formats).\n\
+                                        In such cases, an implementation-specific\
+                                        \ Reason and Message MUST be set.\n\nIn all\
+                                        \ cases, the implementation MUST ensure that\
+                                        \ the `ResolvedRefs`\ncondition is set to\
+                                        \ `status: False` on all targeted listeners\
+                                        \ (i.e.,\nlisteners serving HTTPS on a matching\
+                                        \ port). The condition MUST\ninclude a Reason\
+                                        \ and Message that indicate the cause of the\
+                                        \ error. If\nALL CACertificateRefs are invalid,\
+                                        \ the implementation MUST also ensure\nthe\
+                                        \ `Accepted` condition on the listener is\
+                                        \ set to `status: False`, with\nthe Reason\
+                                        \ `NoValidCACertificate`.\nImplementations\
+                                        \ MAY choose to support attaching multiple\
+                                        \ CA certificates\nto a listener, but this\
+                                        \ behavior is implementation-specific.\n\n\
+                                        Support: Core - A single reference to a Kubernetes\
+                                        \ ConfigMap, with the\nCA certificate in a\
+                                        \ key named `ca.crt`.\n\nSupport: Implementation-specific\
+                                        \ - More than one reference, other kinds\n\
+                                        of resources, or a single reference that includes\
+                                        \ multiple certificates."
+                                      items:
+                                        description: 'ObjectReference identifies an
+                                          API object including its namespace.
+
+
+                                          The API object must be valid in the cluster;
+                                          the Group and Kind must
+
+                                          be registered in the cluster for this reference
+                                          to be valid.
+
+
+                                          References to objects with invalid Group
+                                          and Kind are not valid, and must
+
+                                          be rejected by the implementation, with
+                                          appropriate Conditions set
+
+                                          on the containing object.'
+                                        properties:
+                                          group:
+                                            description: 'Group is the group of the
+                                              referent. For example, "gateway.networking.k8s.io".
+
+                                              When set to the empty string, core API
+                                              group is inferred.'
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            description: Kind is kind of the referent.
+                                              For example "ConfigMap" or "Service".
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: 'Namespace is the namespace
+                                              of the referenced object. When unspecified,
+                                              the local
+
+                                              namespace is inferred.
+
+
+                                              Note that when a namespace different
+                                              than the local namespace is specified,
+
+                                              a ReferenceGrant object is required
+                                              in the referent namespace to allow that
+
+                                              namespace''s owner to accept the reference.
+                                              See the ReferenceGrant
+
+                                              documentation for details.
+
+
+                                              Support: Core'
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                        required:
+                                        - group
+                                        - kind
+                                        - name
+                                        type: object
+                                      maxItems: 8
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mode:
+                                      default: AllowValidOnly
+                                      description: "FrontendValidationMode defines\
+                                        \ the mode for validating the client certificate.\n\
+                                        There are two possible modes:\n\n- AllowValidOnly:\
+                                        \ In this mode, the gateway will accept connections\
+                                        \ only if\n  the client presents a valid certificate.\
+                                        \ This certificate must successfully\n  pass\
+                                        \ validation against the CA certificates specified\
+                                        \ in `CACertificateRefs`.\n- AllowInsecureFallback:\
+                                        \ In this mode, the gateway will accept connections\n\
+                                        \  even if the client certificate is not presented\
+                                        \ or fails verification.\n\n  This approach\
+                                        \ delegates client authorization to the backend\
+                                        \ and introduce\n  a significant security\
+                                        \ risk. It should be used in testing environments\
+                                        \ or\n  on a temporary basis in non-testing\
+                                        \ environments.\n\nDefaults to AllowValidOnly.\n\
+                                        \nSupport: Core"
+                                      enum:
+                                      - AllowValidOnly
+                                      - AllowInsecureFallback
+                                      type: string
+                                  required:
+                                  - caCertificateRefs
+                                  type: object
+                              type: object
+                          required:
+                          - port
+                          - tls
+                          type: object
+                        maxItems: 64
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Port for TLS configuration must be unique within
+                            the Gateway
+                          rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                    required:
+                    - default
+                    type: object
+                type: object
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: "Addresses lists the network addresses that have been\
+                  \ bound to the\nGateway.\n\nThis list may differ from the addresses\
+                  \ provided in the spec under some\nconditions:\n\n  * no addresses\
+                  \ are specified, all addresses are dynamically assigned\n  * a combination\
+                  \ of specified and dynamic addresses are assigned\n  * a specified\
+                  \ address was unusable (e.g. already in use)"
+                items:
+                  description: GatewayStatusAddress describes a network address that
+                    is bound to a Gateway.
+                  oneOf:
+                  - properties:
+                      type:
+                        enum:
+                        - IPAddress
+                      value:
+                        anyOf:
+                        - format: ipv4
+                        - format: ipv6
+                  - properties:
+                      type:
+                        not:
+                          enum:
+                          - IPAddress
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: 'Value of the address. The validity of the values
+                        will depend
+
+                        on the type and support by the controller.
+
+
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`.'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Hostname value must only contain valid characters (matching
+                      ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
+                    rule: 'self.type == ''Hostname'' ? self.value.matches(r"""^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"""):
+                      true'
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              attachedListenerSets:
+                description: 'AttachedListenerSets represents the total number of
+                  ListenerSets that have been
+
+                  successfully attached to this Gateway.
+
+
+                  A ListenerSet is successfully attached to a Gateway when all the
+                  following conditions are met:
+
+                  - The ListenerSet is selected by the Gateway''s AllowedListeners
+                  field
+
+                  - The ListenerSet has a valid ParentRef selecting the Gateway
+
+                  - The ListenerSet''s status has the condition "Accepted: true"
+
+
+                  Uses for this field include troubleshooting AttachedListenerSets
+                  attachment and
+
+                  measuring blast radius/impact of changes to a Gateway.'
+                format: int32
+                type: integer
+              conditions:
+                default:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: 'Conditions describe the current conditions of the Gateway.
+
+
+                  Implementations should prefer to express Gateway conditions
+
+                  using the `GatewayConditionType` and `GatewayConditionReason`
+
+                  constants so that operators and tools can converge on a common
+
+                  vocabulary to describe Gateway state.
+
+
+                  Known condition types are:
+
+
+                  * "Accepted"
+
+                  * "Programmed"
+
+                  * "Ready"'
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: 'AttachedRoutes represents the total number of
+                        Routes that have been
+
+                        successfully attached to this Listener.
+
+
+                        Successful attachment of a Route to a Listener is based solely
+                        on the
+
+                        combination of the AllowedRoutes field on the corresponding
+                        Listener
+
+                        and the Route''s ParentRefs field. A Route is successfully
+                        attached to
+
+                        a Listener when it is selected by the Listener''s AllowedRoutes
+                        field
+
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+
+                        resource or a specific Listener as a parent resource (more
+                        detail on
+
+                        attachment semantics can be found in the documentation on
+                        the various
+
+                        Route kinds ParentRefs fields). Listener or Route status does
+                        not impact
+
+                        successful attachment, i.e. the AttachedRoutes field count
+                        MUST be set
+
+                        for Listeners, even if the Accepted condition of an individual
+                        Listener is set
+
+                        to "False". The AttachedRoutes number represents the number
+                        of Routes with
+
+                        the Accepted condition set to "True" that have been attached
+                        to this Listener.
+
+                        Routes with any other value for the Accepted condition MUST
+                        NOT be included
+
+                        in this count.
+
+
+                        Uses for this field include troubleshooting Route attachment
+                        and
+
+                        measuring blast radius/impact of changes to a Listener.'
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: 'SupportedKinds is the list indicating the Kinds
+                        supported by this
+
+                        listener. This MUST represent the kinds supported by an implementation
+                        for
+
+                        that Listener configuration.
+
+
+                        If kinds are specified in Spec that are not supported, they
+                        MUST NOT
+
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+
+                        condition to "False" with the "InvalidRouteKinds" reason.
+                        If both valid
+
+                        and invalid Route kinds are specified, the implementation
+                        MUST
+
+                        reference the valid Route kinds that have been specified.'
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_grpcroutes.yaml
@@ -1,0 +1,2578 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: grpcroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GRPCRoute
+    listKind: GRPCRouteList
+    plural: grpcroutes
+    singular: grpcroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'GRPCRoute provides a way to route gRPC requests. This includes
+          the capability
+
+          to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
+
+          Filters can be used to specify additional processing steps. Backends specify
+
+          where matching requests will be routed.
+
+
+          GRPCRoute falls under extended support within the Gateway API. Within the
+
+          following specification, the word "MUST" indicates that an implementation
+
+          supporting GRPCRoute must conform to the indicated requirement, but an
+
+          implementation not supporting this route type need not follow the requirement
+
+          unless explicitly indicated.
+
+
+          Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
+
+          accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e.
+          via
+
+          ALPN. If the implementation does not support this, then it MUST set the
+
+          "Accepted" condition to "False" for the affected listener with a reason
+          of
+
+          "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
+
+          with an upgrade from HTTP/1.
+
+
+          Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
+
+          support HTTP/2 over cleartext TCP (h2c,
+
+          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
+
+          upgrade from HTTP/1.1, i.e. with prior knowledge
+
+          (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
+
+          does not support this, then it MUST set the "Accepted" condition to "False"
+
+          for the affected listener with a reason of "UnsupportedProtocol".
+
+          Implementations MAY also accept HTTP/2 connections with an upgrade from
+
+          HTTP/1, i.e. without prior knowledge.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GRPCRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostnames to match against\
+                  \ the GRPC\nHost header to select a GRPCRoute to process the request.\
+                  \ This matches\nthe RFC 1123 definition of a hostname with 2 notable\
+                  \ exceptions:\n\n1. IPs are not allowed.\n2. A hostname may be prefixed\
+                  \ with a wildcard label (`*.`). The wildcard\n   label MUST appear\
+                  \ by itself as the first label.\n\nIf a hostname is specified by\
+                  \ both the Listener and GRPCRoute, there\nMUST be at least one intersecting\
+                  \ hostname for the GRPCRoute to be\nattached to the Listener. For\
+                  \ example:\n\n* A Listener with `test.example.com` as the hostname\
+                  \ matches GRPCRoutes\n  that have either not specified any hostnames,\
+                  \ or have specified at\n  least one of `test.example.com` or `*.example.com`.\n\
+                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes\n\
+                  \  that have either not specified any hostnames or have specified\
+                  \ at least\n  one hostname that matches the Listener hostname. For\
+                  \ example,\n  `test.example.com` and `*.example.com` would both\
+                  \ match. On the other\n  hand, `example.com` and `test.example.net`\
+                  \ would not match.\n\nHostnames that are prefixed with a wildcard\
+                  \ label (`*.`) are interpreted\nas a suffix match. That means that\
+                  \ a match for `*.example.com` would match\nboth `test.example.com`,\
+                  \ and `foo.test.example.com`, but not `example.com`.\n\nIf both\
+                  \ the Listener and GRPCRoute have specified hostnames, any\nGRPCRoute\
+                  \ hostnames that do not match the Listener hostname MUST be\nignored.\
+                  \ For example, if a Listener specified `*.example.com`, and the\n\
+                  GRPCRoute specified `test.example.com` and `test.example.net`,\n\
+                  `test.example.net` MUST NOT be considered for a match.\n\nIf both\
+                  \ the Listener and GRPCRoute have specified hostnames, and none\n\
+                  match with the criteria above, then the GRPCRoute MUST NOT be accepted\
+                  \ by\nthe implementation. The implementation MUST raise an 'Accepted'\
+                  \ Condition\nwith a status of `False` in the corresponding RouteParentStatus.\n\
+                  \nIf a Route (A) of type HTTPRoute or GRPCRoute is attached to a\n\
+                  Listener and that listener already has another Route (B) of the\
+                  \ other\ntype attached and the intersection of the hostnames of\
+                  \ A and B is\nnon-empty, then the implementation MUST accept exactly\
+                  \ one of these two\nroutes, determined by the following criteria,\
+                  \ in order:\n\n* The oldest Route based on creation timestamp.\n\
+                  * The Route appearing first in alphabetical order by\n  \"{namespace}/{name}\"\
+                  .\n\nThe rejected Route MUST raise an 'Accepted' condition with\
+                  \ a status of\n'False' in the corresponding RouteParentStatus.\n\
+                  \nSupport: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network\
+                    \ host. This matches\nthe RFC 1123 definition of a hostname with\
+                    \ 2 notable exceptions:\n\n 1. IPs are not allowed.\n 2. A hostname\
+                    \ may be prefixed with a wildcard label (`*.`). The wildcard\n\
+                    \    label must appear by itself as the first label.\n\nHostname\
+                    \ can be \"precise\" which is a domain name without the terminating\n\
+                    dot of a network host (e.g. \"foo.example.com\") or \"wildcard\"\
+                    , which is a\ndomain name prefixed with a single wildcard label\
+                    \ (e.g. `*.example.com`).\n\nNote that as per RFC1035 and RFC1123,\
+                    \ a *label* must consist of lower case\nalphanumeric characters\
+                    \ or '-', and must start and end with an alphanumeric\ncharacter.\
+                    \ No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: Rules are a list of GRPC matchers, filters and actions.
+                items:
+                  description: 'GRPCRouteRule defines the semantics for matching a
+                    gRPC request based on
+
+                    conditions (matches), processing it (filters), and forwarding
+                    the request to
+
+                    an API object (backendRefs).'
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent.
+
+
+                        Failure behavior here depends on how many BackendRefs are
+                        specified and
+
+                        how many are invalid.
+
+
+                        If *all* entries in BackendRefs are invalid, and there are
+                        also no filters
+
+                        specified in this route rule, *all* traffic which matches
+                        this rule MUST
+
+                        receive an `UNAVAILABLE` status.
+
+
+                        See the GRPCBackendRef definition for the rules about what
+                        makes a single
+
+                        GRPCBackendRef invalid.
+
+
+                        When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST
+                        be returned for
+
+                        requests that would have otherwise been routed to an invalid
+                        backend. If
+
+                        multiple backends are specified, and some are invalid, the
+                        proportion of
+
+                        requests that would otherwise have been routed to an invalid
+                        backend
+
+                        MUST receive an `UNAVAILABLE` status.
+
+
+                        For example, if two backends are specified with equal weights,
+                        and one is
+
+                        invalid, 50 percent of traffic MUST receive an `UNAVAILABLE`
+                        status.
+
+                        Implementations may choose how that 50 percent is determined.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Core'
+                      items:
+                        description: 'GRPCBackendRef defines how a GRPCRoute forwards
+                          a gRPC request.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.'
+                        properties:
+                          filters:
+                            description: 'Filters defined at this level MUST be executed
+                              if and only if the
+
+                              request is being forwarded to the backend defined here.
+
+
+                              Support: Implementation-specific (For broader support
+                              of filters, use the
+
+                              Filters field in GRPCRouteRule.)'
+                            items:
+                              description: 'GRPCRouteFilter defines processing steps
+                                that must be completed during the
+
+                                request or response lifecycle. GRPCRouteFilters are
+                                meant as an extension
+
+                                point to express processing that may be done in Gateway
+                                implementations. Some
+
+                                examples include request or response modification,
+                                implementing
+
+                                authentication strategies, rate-limiting, and traffic
+                                shaping. API
+
+                                guarantee/conformance is defined based on the type
+                                of the filter.'
+                              properties:
+                                extensionRef:
+                                  description: 'ExtensionRef is an optional, implementation-specific
+                                    extension to the
+
+                                    "filter" behavior.  For example, resource "myroutefilter"
+                                    in group
+
+                                    "networking.example.net"). ExtensionRef MUST NOT
+                                    be used for core and
+
+                                    extended filters.
+
+
+                                    Support: Implementation-specific
+
+
+                                    This filter can be used multiple times within
+                                    the same rule.'
+                                  properties:
+                                    group:
+                                      description: 'Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+
+                                        When unspecified or empty string, core API
+                                        group is inferred.'
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: 'RequestHeaderModifier defines a schema
+                                    for a filter that modifies request
+
+                                    headers.
+
+
+                                    Support: Core'
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,\
+                                        \ value) to the request\nbefore the action.\
+                                        \ It appends to any existing values associated\n\
+                                        with the header name.\n\nInput:\n  GET /foo\
+                                        \ HTTP/1.1\n  my-header: foo\n\nConfig:\n\
+                                        \  add:\n  - name: \"my-header\"\n    value:\
+                                        \ \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from\
+                                        \ the HTTP request before the action. The\n\
+                                        value of Remove is a list of HTTP header names.\
+                                        \ Note that the header\nnames are case-insensitive\
+                                        \ (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                        \nInput:\n  GET /foo HTTP/1.1\n  my-header1:\
+                                        \ foo\n  my-header2: bar\n  my-header3: baz\n\
+                                        \nConfig:\n  remove: [\"my-header1\", \"my-header3\"\
+                                        ]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2:\
+                                        \ bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with\
+                                        \ the given header (name, value)\nbefore the\
+                                        \ action.\n\nInput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo\n\nConfig:\n  set:\n  -\
+                                        \ name: \"my-header\"\n    value: \"bar\"\n\
+                                        \nOutput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                        \ bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: 'RequestMirror defines a schema for
+                                    a filter that mirrors requests.
+
+                                    Requests are sent to the specified destination,
+                                    but responses from
+
+                                    that destination are ignored.
+
+
+                                    This filter can be used multiple times within
+                                    the same rule. Note that
+
+                                    not all implementations will be able to support
+                                    mirroring to multiple
+
+                                    backends.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    backendRef:
+                                      description: 'BackendRef references a resource
+                                        where mirrored requests are sent.
+
+
+                                        Mirrored requests must be sent only to a single
+                                        destination endpoint
+
+                                        within this BackendRef, irrespective of how
+                                        many endpoints are present
+
+                                        within this BackendRef.
+
+
+                                        If the referent cannot be found, this BackendRef
+                                        is invalid and must be
+
+                                        dropped from the Gateway. The controller must
+                                        ensure the "ResolvedRefs"
+
+                                        condition on the Route status is set to `status:
+                                        False` and not configure
+
+                                        this backend in the underlying implementation.
+
+
+                                        If there is a cross-namespace reference to
+                                        an *existing* object
+
+                                        that is not allowed by a ReferenceGrant, the
+                                        controller must ensure the
+
+                                        "ResolvedRefs"  condition on the Route is
+                                        set to `status: False`,
+
+                                        with the "RefNotPermitted" reason and not
+                                        configure this backend in the
+
+                                        underlying implementation.
+
+
+                                        In either error case, the Message of the `ResolvedRefs`
+                                        Condition
+
+                                        should be used to provide more detail about
+                                        the problem.
+
+
+                                        Support: Extended for Kubernetes Service
+
+
+                                        Support: Implementation-specific for any other
+                                        resource'
+                                      properties:
+                                        group:
+                                          default: ''
+                                          description: 'Group is the group of the
+                                            referent. For example, "gateway.networking.k8s.io".
+
+                                            When unspecified or empty string, core
+                                            API group is inferred.'
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: 'Kind is the Kubernetes resource
+                                            kind of the referent. For example
+
+                                            "Service".
+
+
+                                            Defaults to "Service" when not specified.
+
+
+                                            ExternalName services can refer to CNAME
+                                            DNS records that may live
+
+                                            outside of the cluster and as such are
+                                            difficult to reason about in
+
+                                            terms of conformance. They also may not
+                                            be safe to forward to (see
+
+                                            CVE-2021-25740 for more information).
+                                            Implementations SHOULD NOT
+
+                                            support ExternalName Services.
+
+
+                                            Support: Core (Services with a type other
+                                            than ExternalName)
+
+
+                                            Support: Implementation-specific (Services
+                                            with type ExternalName)'
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: 'Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local
+
+                                            namespace is inferred.
+
+
+                                            Note that when a namespace different than
+                                            the local namespace is specified,
+
+                                            a ReferenceGrant object is required in
+                                            the referent namespace to allow that
+
+                                            namespace''s owner to accept the reference.
+                                            See the ReferenceGrant
+
+                                            documentation for details.
+
+
+                                            Support: Core'
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: 'Port specifies the destination
+                                            port number to use for this resource.
+
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this
+
+                                            case, the port number is the service port
+                                            number, not the target port.
+
+                                            For other resources, destination port
+                                            might be derived from the referent
+
+                                            resource or this field.'
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: 'Fraction represents the fraction
+                                        of requests that should be
+
+                                        mirrored to BackendRef.
+
+
+                                        Only one of Fraction or Percent may be specified.
+                                        If neither field
+
+                                        is specified, 100% of requests will be mirrored.'
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: 'Percent represents the percentage
+                                        of requests that should be
+
+                                        mirrored to BackendRef. Its minimum value
+                                        is 0 (indicating 0% of
+
+                                        requests) and its maximum value is 100 (indicating
+                                        100% of requests).
+
+
+                                        Only one of Fraction or Percent may be specified.
+                                        If neither field
+
+                                        is specified, 100% of requests will be mirrored.'
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - backendRef
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
+                                responseHeaderModifier:
+                                  description: 'ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response
+
+                                    headers.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,\
+                                        \ value) to the request\nbefore the action.\
+                                        \ It appends to any existing values associated\n\
+                                        with the header name.\n\nInput:\n  GET /foo\
+                                        \ HTTP/1.1\n  my-header: foo\n\nConfig:\n\
+                                        \  add:\n  - name: \"my-header\"\n    value:\
+                                        \ \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from\
+                                        \ the HTTP request before the action. The\n\
+                                        value of Remove is a list of HTTP header names.\
+                                        \ Note that the header\nnames are case-insensitive\
+                                        \ (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                        \nInput:\n  GET /foo HTTP/1.1\n  my-header1:\
+                                        \ foo\n  my-header2: bar\n  my-header3: baz\n\
+                                        \nConfig:\n  remove: [\"my-header1\", \"my-header3\"\
+                                        ]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2:\
+                                        \ bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with\
+                                        \ the given header (name, value)\nbefore the\
+                                        \ action.\n\nInput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo\n\nConfig:\n  set:\n  -\
+                                        \ name: \"my-header\"\n    value: \"bar\"\n\
+                                        \nOutput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                        \ bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter\
+                                    \ to apply. As with other API fields,\ntypes are\
+                                    \ classified into three conformance levels:\n\n\
+                                    - Core: Filter types and their corresponding configuration\
+                                    \ defined by\n  \"Support: Core\" in this package,\
+                                    \ e.g. \"RequestHeaderModifier\". All\n  implementations\
+                                    \ supporting GRPCRoute MUST support core filters.\n\
+                                    \n- Extended: Filter types and their corresponding\
+                                    \ configuration defined by\n  \"Support: Extended\"\
+                                    \ in this package, e.g. \"RequestMirror\". Implementers\n\
+                                    \  are encouraged to support extended filters.\n\
+                                    \n- Implementation-specific: Filters that are\
+                                    \ defined and supported by specific vendors.\n\
+                                    \  In the future, filters showing convergence\
+                                    \ in behavior across multiple\n  implementations\
+                                    \ will be considered for inclusion in extended\
+                                    \ or core\n  conformance levels. Filter-specific\
+                                    \ configuration for such filters\n  is specified\
+                                    \ using the ExtensionRef field. `Type` MUST be\
+                                    \ set to\n  \"ExtensionRef\" for custom filters.\n\
+                                    \nImplementers are encouraged to define custom\
+                                    \ implementation types to\nextend the core API\
+                                    \ with implementation-specific behavior.\n\nIf\
+                                    \ a reference to a custom filter type cannot be\
+                                    \ resolved, the filter\nMUST NOT be skipped. Instead,\
+                                    \ requests that would have been processed by\n\
+                                    that filter MUST receive a HTTP error response."
+                                  enum:
+                                  - ResponseHeaderModifier
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-type: atomic
+                            x-kubernetes-validations:
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    filters:
+                      description: "Filters define the filters that are applied to\
+                        \ requests that match\nthis rule.\n\nThe effects of ordering\
+                        \ of multiple behaviors are currently unspecified.\nThis can\
+                        \ change in the future based on feedback during the alpha\
+                        \ stage.\n\nConformance-levels at this level are defined based\
+                        \ on the type of filter:\n\n- ALL core filters MUST be supported\
+                        \ by all implementations that support\n  GRPCRoute.\n- Implementers\
+                        \ are encouraged to support extended filters.\n- Implementation-specific\
+                        \ custom filters have no API guarantees across\n  implementations.\n\
+                        \nSpecifying the same filter multiple times is not supported\
+                        \ unless explicitly\nindicated in the filter.\n\nIf an implementation\
+                        \ cannot support a combination of filters, it must clearly\n\
+                        document that limitation. In cases where incompatible or unsupported\n\
+                        filters are specified and cause the `Accepted` condition to\
+                        \ be set to status\n`False`, implementations may use the `IncompatibleFilters`\
+                        \ reason to specify\nthis configuration error.\n\nSupport:\
+                        \ Core"
+                      items:
+                        description: 'GRPCRouteFilter defines processing steps that
+                          must be completed during the
+
+                          request or response lifecycle. GRPCRouteFilters are meant
+                          as an extension
+
+                          point to express processing that may be done in Gateway
+                          implementations. Some
+
+                          examples include request or response modification, implementing
+
+                          authentication strategies, rate-limiting, and traffic shaping.
+                          API
+
+                          guarantee/conformance is defined based on the type of the
+                          filter.'
+                        properties:
+                          extensionRef:
+                            description: 'ExtensionRef is an optional, implementation-specific
+                              extension to the
+
+                              "filter" behavior.  For example, resource "myroutefilter"
+                              in group
+
+                              "networking.example.net"). ExtensionRef MUST NOT be
+                              used for core and
+
+                              extended filters.
+
+
+                              Support: Implementation-specific
+
+
+                              This filter can be used multiple times within the same
+                              rule.'
+                            properties:
+                              group:
+                                description: 'Group is the group of the referent.
+                                  For example, "gateway.networking.k8s.io".
+
+                                  When unspecified or empty string, core API group
+                                  is inferred.'
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: 'RequestHeaderModifier defines a schema for
+                              a filter that modifies request
+
+                              headers.
+
+
+                              Support: Core'
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,\
+                                  \ value) to the request\nbefore the action. It appends\
+                                  \ to any existing values associated\nwith the header\
+                                  \ name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                  \ foo\n\nConfig:\n  add:\n  - name: \"my-header\"\
+                                  \n    value: \"bar,baz\"\n\nOutput:\n  GET /foo\
+                                  \ HTTP/1.1\n  my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the\
+                                  \ HTTP request before the action. The\nvalue of\
+                                  \ Remove is a list of HTTP header names. Note that\
+                                  \ the header\nnames are case-insensitive (see\n\
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n\
+                                  \  my-header2: bar\n  my-header3: baz\n\nConfig:\n\
+                                  \  remove: [\"my-header1\", \"my-header3\"]\n\n\
+                                  Output:\n  GET /foo HTTP/1.1\n  my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the\
+                                  \ given header (name, value)\nbefore the action.\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\
+                                  \nConfig:\n  set:\n  - name: \"my-header\"\n   \
+                                  \ value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                  \  my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: 'RequestMirror defines a schema for a filter
+                              that mirrors requests.
+
+                              Requests are sent to the specified destination, but
+                              responses from
+
+                              that destination are ignored.
+
+
+                              This filter can be used multiple times within the same
+                              rule. Note that
+
+                              not all implementations will be able to support mirroring
+                              to multiple
+
+                              backends.
+
+
+                              Support: Extended'
+                            properties:
+                              backendRef:
+                                description: 'BackendRef references a resource where
+                                  mirrored requests are sent.
+
+
+                                  Mirrored requests must be sent only to a single
+                                  destination endpoint
+
+                                  within this BackendRef, irrespective of how many
+                                  endpoints are present
+
+                                  within this BackendRef.
+
+
+                                  If the referent cannot be found, this BackendRef
+                                  is invalid and must be
+
+                                  dropped from the Gateway. The controller must ensure
+                                  the "ResolvedRefs"
+
+                                  condition on the Route status is set to `status:
+                                  False` and not configure
+
+                                  this backend in the underlying implementation.
+
+
+                                  If there is a cross-namespace reference to an *existing*
+                                  object
+
+                                  that is not allowed by a ReferenceGrant, the controller
+                                  must ensure the
+
+                                  "ResolvedRefs"  condition on the Route is set to
+                                  `status: False`,
+
+                                  with the "RefNotPermitted" reason and not configure
+                                  this backend in the
+
+                                  underlying implementation.
+
+
+                                  In either error case, the Message of the `ResolvedRefs`
+                                  Condition
+
+                                  should be used to provide more detail about the
+                                  problem.
+
+
+                                  Support: Extended for Kubernetes Service
+
+
+                                  Support: Implementation-specific for any other resource'
+                                properties:
+                                  group:
+                                    default: ''
+                                    description: 'Group is the group of the referent.
+                                      For example, "gateway.networking.k8s.io".
+
+                                      When unspecified or empty string, core API group
+                                      is inferred.'
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: 'Kind is the Kubernetes resource
+                                      kind of the referent. For example
+
+                                      "Service".
+
+
+                                      Defaults to "Service" when not specified.
+
+
+                                      ExternalName services can refer to CNAME DNS
+                                      records that may live
+
+                                      outside of the cluster and as such are difficult
+                                      to reason about in
+
+                                      terms of conformance. They also may not be safe
+                                      to forward to (see
+
+                                      CVE-2021-25740 for more information). Implementations
+                                      SHOULD NOT
+
+                                      support ExternalName Services.
+
+
+                                      Support: Core (Services with a type other than
+                                      ExternalName)
+
+
+                                      Support: Implementation-specific (Services with
+                                      type ExternalName)'
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace is the namespace of the
+                                      backend. When unspecified, the local
+
+                                      namespace is inferred.
+
+
+                                      Note that when a namespace different than the
+                                      local namespace is specified,
+
+                                      a ReferenceGrant object is required in the referent
+                                      namespace to allow that
+
+                                      namespace''s owner to accept the reference.
+                                      See the ReferenceGrant
+
+                                      documentation for details.
+
+
+                                      Support: Core'
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: 'Port specifies the destination port
+                                      number to use for this resource.
+
+                                      Port is required when the referent is a Kubernetes
+                                      Service. In this
+
+                                      case, the port number is the service port number,
+                                      not the target port.
+
+                                      For other resources, destination port might
+                                      be derived from the referent
+
+                                      resource or this field.'
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              fraction:
+                                description: 'Fraction represents the fraction of
+                                  requests that should be
+
+                                  mirrored to BackendRef.
+
+
+                                  Only one of Fraction or Percent may be specified.
+                                  If neither field
+
+                                  is specified, 100% of requests will be mirrored.'
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: 'Percent represents the percentage of
+                                  requests that should be
+
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating
+                                  0% of
+
+                                  requests) and its maximum value is 100 (indicating
+                                  100% of requests).
+
+
+                                  Only one of Fraction or Percent may be specified.
+                                  If neither field
+
+                                  is specified, 100% of requests will be mirrored.'
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                            - backendRef
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
+                          responseHeaderModifier:
+                            description: 'ResponseHeaderModifier defines a schema
+                              for a filter that modifies response
+
+                              headers.
+
+
+                              Support: Extended'
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,\
+                                  \ value) to the request\nbefore the action. It appends\
+                                  \ to any existing values associated\nwith the header\
+                                  \ name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                  \ foo\n\nConfig:\n  add:\n  - name: \"my-header\"\
+                                  \n    value: \"bar,baz\"\n\nOutput:\n  GET /foo\
+                                  \ HTTP/1.1\n  my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the\
+                                  \ HTTP request before the action. The\nvalue of\
+                                  \ Remove is a list of HTTP header names. Note that\
+                                  \ the header\nnames are case-insensitive (see\n\
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n\
+                                  \  my-header2: bar\n  my-header3: baz\n\nConfig:\n\
+                                  \  remove: [\"my-header1\", \"my-header3\"]\n\n\
+                                  Output:\n  GET /foo HTTP/1.1\n  my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the\
+                                  \ given header (name, value)\nbefore the action.\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\
+                                  \nConfig:\n  set:\n  - name: \"my-header\"\n   \
+                                  \ value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                  \  my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.\
+                              \ As with other API fields,\ntypes are classified into\
+                              \ three conformance levels:\n\n- Core: Filter types\
+                              \ and their corresponding configuration defined by\n\
+                              \  \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\"\
+                              . All\n  implementations supporting GRPCRoute MUST support\
+                              \ core filters.\n\n- Extended: Filter types and their\
+                              \ corresponding configuration defined by\n  \"Support:\
+                              \ Extended\" in this package, e.g. \"RequestMirror\"\
+                              . Implementers\n  are encouraged to support extended\
+                              \ filters.\n\n- Implementation-specific: Filters that\
+                              \ are defined and supported by specific vendors.\n \
+                              \ In the future, filters showing convergence in behavior\
+                              \ across multiple\n  implementations will be considered\
+                              \ for inclusion in extended or core\n  conformance levels.\
+                              \ Filter-specific configuration for such filters\n \
+                              \ is specified using the ExtensionRef field. `Type`\
+                              \ MUST be set to\n  \"ExtensionRef\" for custom filters.\n\
+                              \nImplementers are encouraged to define custom implementation\
+                              \ types to\nextend the core API with implementation-specific\
+                              \ behavior.\n\nIf a reference to a custom filter type\
+                              \ cannot be resolved, the filter\nMUST NOT be skipped.\
+                              \ Instead, requests that would have been processed by\n\
+                              that filter MUST receive a HTTP error response."
+                            enum:
+                            - ResponseHeaderModifier
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: atomic
+                      x-kubernetes-validations:
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                    matches:
+                      description: "Matches define conditions used for matching the\
+                        \ rule against incoming\ngRPC requests. Each match is independent,\
+                        \ i.e. this rule will be matched\nif **any** one of the matches\
+                        \ is satisfied.\n\nFor example, take the following matches\
+                        \ configuration:\n\n```\nmatches:\n- method:\n    service:\
+                        \ foo.bar\n  headers:\n    values:\n      version: 2\n- method:\n\
+                        \    service: foo.bar.v2\n```\n\nFor a request to match against\
+                        \ this rule, it MUST satisfy\nEITHER of the two conditions:\n\
+                        \n- service of foo.bar AND contains the header `version: 2`\n\
+                        - service of foo.bar.v2\n\nSee the documentation for GRPCRouteMatch\
+                        \ on how to specify multiple\nmatch conditions to be ANDed\
+                        \ together.\n\nIf no matches are specified, the implementation\
+                        \ MUST match every gRPC request.\n\nProxy or Load Balancer\
+                        \ routing configuration generated from GRPCRoutes\nMUST prioritize\
+                        \ rules based on the following criteria, continuing on\nties.\
+                        \ Merging MUST not be done between GRPCRoutes and HTTPRoutes.\n\
+                        Precedence MUST be given to the rule with the largest number\
+                        \ of:\n\n* Characters in a matching non-wildcard hostname.\n\
+                        * Characters in a matching hostname.\n* Characters in a matching\
+                        \ service.\n* Characters in a matching method.\n* Header matches.\n\
+                        \nIf ties still exist across multiple Routes, matching precedence\
+                        \ MUST be\ndetermined in order of the following criteria,\
+                        \ continuing on ties:\n\n* The oldest Route based on creation\
+                        \ timestamp.\n* The Route appearing first in alphabetical\
+                        \ order by\n  \"{namespace}/{name}\".\n\nIf ties still exist\
+                        \ within the Route that has been given precedence,\nmatching\
+                        \ precedence MUST be granted to the first matching rule meeting\n\
+                        the above criteria."
+                      items:
+                        description: "GRPCRouteMatch defines the predicate used to\
+                          \ match requests to a given\naction. Multiple match types\
+                          \ are ANDed together, i.e. the match will\nevaluate to true\
+                          \ only if all conditions are satisfied.\n\nFor example,\
+                          \ the match below will match a gRPC request only if its\
+                          \ service\nis `foo` AND it contains the `version: v1` header:\n\
+                          \n```\nmatches:\n  - method:\n    type: Exact\n    service:\
+                          \ \"foo\"\n  - headers:\n    name: \"version\"\n    value\
+                          \ \"v1\"\n\n```"
+                        properties:
+                          headers:
+                            description: 'Headers specifies gRPC request header matchers.
+                              Multiple match values are
+
+                              ANDed together, meaning, a request MUST match all the
+                              specified headers
+
+                              to select the route.'
+                            items:
+                              description: 'GRPCHeaderMatch describes how to select
+                                a gRPC route by matching gRPC request
+
+                                headers.'
+                              properties:
+                                name:
+                                  description: 'Name is the name of the gRPC Header
+                                    to be matched.
+
+
+                                    If multiple entries specify equivalent header
+                                    names, only the first
+
+                                    entry with an equivalent name MUST be considered
+                                    for a match. Subsequent
+
+                                    entries with an equivalent header name MUST be
+                                    ignored. Due to the
+
+                                    case-insensitivity of header names, "foo" and
+                                    "Foo" are considered
+
+                                    equivalent.'
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: Type specifies how to match against
+                                    the value of the header.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of the gRPC Header
+                                    to be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: 'Method specifies a gRPC request service/method
+                              matcher. If this field is
+
+                              not specified, all services and methods will match.'
+                            properties:
+                              method:
+                                description: 'Value of the method to match against.
+                                  If left empty or omitted, will
+
+                                  match all services.
+
+
+                                  At least one of Service and Method MUST be a non-empty
+                                  string.'
+                                maxLength: 1024
+                                type: string
+                              service:
+                                description: 'Value of the service to match against.
+                                  If left empty or omitted, will
+
+                                  match any service.
+
+
+                                  At least one of Service and Method MUST be a non-empty
+                                  string.'
+                                maxLength: 1024
+                                type: string
+                              type:
+                                default: Exact
+                                description: 'Type specifies how to match against
+                                  the service and/or method.
+
+                                  Support: Core (Exact with service and method specified)
+
+
+                                  Support: Implementation-specific (Exact with method
+                                  specified but no service specified)
+
+
+                                  Support: Implementation-specific (RegularExpression)'
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: One or both of 'service' or 'method' must be
+                                specified
+                              rule: 'has(self.type) ? has(self.service) || has(self.method)
+                                : true'
+                            - message: service must only contain valid characters
+                                (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.service) ? self.service.matches(r"""^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$"""):
+                                true'
+                            - message: method must only contain valid characters (matching
+                                ^[A-Za-z_][A-Za-z_0-9]*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
+                                true'
+                        type: object
+                      maxItems: 64
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: 'Name is the name of the route rule. This name
+                        MUST be unique within a Route if it is set.
+
+
+                        Support: Extended'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? (has(self[0].matches) ? self[0].matches.size()
+                    : 0) : 0) + (self.size() > 1 ? (has(self[1].matches) ? self[1].matches.size()
+                    : 0) : 0) + (self.size() > 2 ? (has(self[2].matches) ? self[2].matches.size()
+                    : 0) : 0) + (self.size() > 3 ? (has(self[3].matches) ? self[3].matches.size()
+                    : 0) : 0) + (self.size() > 4 ? (has(self[4].matches) ? self[4].matches.size()
+                    : 0) : 0) + (self.size() > 5 ? (has(self[5].matches) ? self[5].matches.size()
+                    : 0) : 0) + (self.size() > 6 ? (has(self[6].matches) ? self[6].matches.size()
+                    : 0) : 0) + (self.size() > 7 ? (has(self[7].matches) ? self[7].matches.size()
+                    : 0) : 0) + (self.size() > 8 ? (has(self[8].matches) ? self[8].matches.size()
+                    : 0) : 0) + (self.size() > 9 ? (has(self[9].matches) ? self[9].matches.size()
+                    : 0) : 0) + (self.size() > 10 ? (has(self[10].matches) ? self[10].matches.size()
+                    : 0) : 0) + (self.size() > 11 ? (has(self[11].matches) ? self[11].matches.size()
+                    : 0) : 0) + (self.size() > 12 ? (has(self[12].matches) ? self[12].matches.size()
+                    : 0) : 0) + (self.size() > 13 ? (has(self[13].matches) ? self[13].matches.size()
+                    : 0) : 0) + (self.size() > 14 ? (has(self[14].matches) ? self[14].matches.size()
+                    : 0) : 0) + (self.size() > 15 ? (has(self[15].matches) ? self[15].matches.size()
+                    : 0) : 0) <= 128'
+            type: object
+          status:
+            description: Status defines the current state of GRPCRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_httproutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_httproutes.yaml
@@ -1,0 +1,9217 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'HTTPRoute provides a way to route HTTP requests. This includes
+          the capability
+
+          to match requests by hostname, path, header, or query param. Filters can
+          be
+
+          used to specify additional processing steps. Backends specify where matching
+
+          requests should be routed.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostnames that should match\
+                  \ against the HTTP Host\nheader to select a HTTPRoute used to process\
+                  \ the request. Implementations\nMUST ignore any port value specified\
+                  \ in the HTTP Host header while\nperforming a match and (absent\
+                  \ of any applicable header modification\nconfiguration) MUST forward\
+                  \ this header unmodified to the backend.\n\nValid values for Hostnames\
+                  \ are determined by RFC 1123 definition of a\nhostname with 2 notable\
+                  \ exceptions:\n\n1. IPs are not allowed.\n2. A hostname may be prefixed\
+                  \ with a wildcard label (`*.`). The wildcard\n   label must appear\
+                  \ by itself as the first label.\n\nIf a hostname is specified by\
+                  \ both the Listener and HTTPRoute, there\nmust be at least one intersecting\
+                  \ hostname for the HTTPRoute to be\nattached to the Listener. For\
+                  \ example:\n\n* A Listener with `test.example.com` as the hostname\
+                  \ matches HTTPRoutes\n  that have either not specified any hostnames,\
+                  \ or have specified at\n  least one of `test.example.com` or `*.example.com`.\n\
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes\n\
+                  \  that have either not specified any hostnames or have specified\
+                  \ at least\n  one hostname that matches the Listener hostname. For\
+                  \ example,\n  `*.example.com`, `test.example.com`, and `foo.test.example.com`\
+                  \ would\n  all match. On the other hand, `example.com` and `test.example.net`\
+                  \ would\n  not match.\n\nHostnames that are prefixed with a wildcard\
+                  \ label (`*.`) are interpreted\nas a suffix match. That means that\
+                  \ a match for `*.example.com` would match\nboth `test.example.com`,\
+                  \ and `foo.test.example.com`, but not `example.com`.\n\nIf both\
+                  \ the Listener and HTTPRoute have specified hostnames, any\nHTTPRoute\
+                  \ hostnames that do not match the Listener hostname MUST be\nignored.\
+                  \ For example, if a Listener specified `*.example.com`, and the\n\
+                  HTTPRoute specified `test.example.com` and `test.example.net`,\n\
+                  `test.example.net` must not be considered for a match.\n\nIf both\
+                  \ the Listener and HTTPRoute have specified hostnames, and none\n\
+                  match with the criteria above, then the HTTPRoute is not accepted.\
+                  \ The\nimplementation must raise an 'Accepted' Condition with a\
+                  \ status of\n`False` in the corresponding RouteParentStatus.\n\n\
+                  In the event that multiple HTTPRoutes specify intersecting hostnames\
+                  \ (e.g.\noverlapping wildcard matching and exact matching hostnames),\
+                  \ precedence must\nbe given to rules from the HTTPRoute with the\
+                  \ largest number of:\n\n* Characters in a matching non-wildcard\
+                  \ hostname.\n* Characters in a matching hostname.\n\nIf ties exist\
+                  \ across multiple Routes, the matching precedence rules for\nHTTPRouteMatches\
+                  \ takes over.\n\nSupport: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network\
+                    \ host. This matches\nthe RFC 1123 definition of a hostname with\
+                    \ 2 notable exceptions:\n\n 1. IPs are not allowed.\n 2. A hostname\
+                    \ may be prefixed with a wildcard label (`*.`). The wildcard\n\
+                    \    label must appear by itself as the first label.\n\nHostname\
+                    \ can be \"precise\" which is a domain name without the terminating\n\
+                    dot of a network host (e.g. \"foo.example.com\") or \"wildcard\"\
+                    , which is a\ndomain name prefixed with a single wildcard label\
+                    \ (e.g. `*.example.com`).\n\nNote that as per RFC1035 and RFC1123,\
+                    \ a *label* must consist of lower case\nalphanumeric characters\
+                    \ or '-', and must start and end with an alphanumeric\ncharacter.\
+                    \ No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: Rules are a list of HTTP matchers, filters and actions.
+                items:
+                  description: 'HTTPRouteRule defines semantics for matching an HTTP
+                    request based on
+
+                    conditions (matches), processing it (filters), and forwarding
+                    the request to
+
+                    an API object (backendRefs).'
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent.
+
+
+                        Failure behavior here depends on how many BackendRefs are
+                        specified and
+
+                        how many are invalid.
+
+
+                        If *all* entries in BackendRefs are invalid, and there are
+                        also no filters
+
+                        specified in this route rule, *all* traffic which matches
+                        this rule MUST
+
+                        receive a 500 status code.
+
+
+                        See the HTTPBackendRef definition for the rules about what
+                        makes a single
+
+                        HTTPBackendRef invalid.
+
+
+                        When a HTTPBackendRef is invalid, 500 status codes MUST be
+                        returned for
+
+                        requests that would have otherwise been routed to an invalid
+                        backend. If
+
+                        multiple backends are specified, and some are invalid, the
+                        proportion of
+
+                        requests that would otherwise have been routed to an invalid
+                        backend
+
+                        MUST receive a 500 status code.
+
+
+                        For example, if two backends are specified with equal weights,
+                        and one is
+
+                        invalid, 50 percent of traffic must receive a 500. Implementations
+                        may
+
+                        choose how that 50 percent is determined.
+
+
+                        When a HTTPBackendRef refers to a Service that has no ready
+                        endpoints,
+
+                        implementations SHOULD return a 503 for requests to that backend
+                        instead.
+
+                        If an implementation chooses to do this, all of the above
+                        rules for 500 responses
+
+                        MUST also apply for responses that return a 503.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Core'
+                      items:
+                        description: 'HTTPBackendRef defines how a HTTPRoute forwards
+                          a HTTP request.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.'
+                        properties:
+                          filters:
+                            description: 'Filters defined at this level should be
+                              executed if and only if the
+
+                              request is being forwarded to the backend defined here.
+
+
+                              Support: Implementation-specific (For broader support
+                              of filters, use the
+
+                              Filters field in HTTPRouteRule.)'
+                            items:
+                              description: 'HTTPRouteFilter defines processing steps
+                                that must be completed during the
+
+                                request or response lifecycle. HTTPRouteFilters are
+                                meant as an extension
+
+                                point to express processing that may be done in Gateway
+                                implementations. Some
+
+                                examples include request or response modification,
+                                implementing
+
+                                authentication strategies, rate-limiting, and traffic
+                                shaping. API
+
+                                guarantee/conformance is defined based on the type
+                                of the filter.'
+                              properties:
+                                cors:
+                                  description: 'CORS defines a schema for a filter
+                                    that responds to the
+
+                                    cross-origin request based on HTTP response header.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    allowCredentials:
+                                      description: 'AllowCredentials indicates whether
+                                        the actual cross-origin request allows
+
+                                        to include credentials.
+
+
+                                        When set to true, the gateway will include
+                                        the `Access-Control-Allow-Credentials`
+
+                                        response header with value true (case-sensitive).
+
+
+                                        When set to false or omitted the gateway will
+                                        omit the header
+
+                                        `Access-Control-Allow-Credentials` entirely
+                                        (this is the standard CORS
+
+                                        behavior).
+
+
+                                        Support: Extended'
+                                      type: boolean
+                                    allowHeaders:
+                                      description: 'AllowHeaders indicates which HTTP
+                                        request headers are supported for
+
+                                        accessing the requested resource.
+
+
+                                        Header names are not case-sensitive.
+
+
+                                        Multiple header names in the value of the
+                                        `Access-Control-Allow-Headers`
+
+                                        response header are separated by a comma (",").
+
+
+                                        When the `AllowHeaders` field is configured
+                                        with one or more headers, the
+
+                                        gateway must return the `Access-Control-Allow-Headers`
+                                        response header
+
+                                        which value is present in the `AllowHeaders`
+                                        field.
+
+
+                                        If any header name in the `Access-Control-Request-Headers`
+                                        request header
+
+                                        is not included in the list of header names
+                                        specified by the response
+
+                                        header `Access-Control-Allow-Headers`, it
+                                        will present an error on the
+
+                                        client side.
+
+
+                                        If any header name in the `Access-Control-Allow-Headers`
+                                        response header
+
+                                        does not recognize by the client, it will
+                                        also occur an error on the
+
+                                        client side.
+
+
+                                        A wildcard indicates that the requests with
+                                        all HTTP headers are allowed.
+
+                                        If config contains the wildcard "*" in allowHeaders
+                                        and the request is
+
+                                        not credentialed, the `Access-Control-Allow-Headers`
+                                        response header
+
+                                        can either use the `*` wildcard or the value
+                                        of
+
+                                        Access-Control-Request-Headers from the request.
+
+
+                                        When the request is credentialed, the gateway
+                                        must not specify the `*`
+
+                                        wildcard in the `Access-Control-Allow-Headers`
+                                        response header. When
+
+                                        also the `AllowCredentials` field is true
+                                        and `AllowHeaders` field
+
+                                        is specified with the `*` wildcard, the gateway
+                                        must specify one or more
+
+                                        HTTP headers in the value of the `Access-Control-Allow-Headers`
+                                        response
+
+                                        header. The value of the header `Access-Control-Allow-Headers`
+                                        is same as
+
+                                        the `Access-Control-Request-Headers` header
+                                        provided by the client. If
+
+                                        the header `Access-Control-Request-Headers`
+                                        is not included in the
+
+                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+
+                                        response header, instead of specifying the
+                                        `*` wildcard.
+
+
+                                        Support: Extended'
+                                      items:
+                                        description: "HTTPHeaderName is the name of\
+                                          \ an HTTP header.\n\nValid values include:\n\
+                                          \n* \"Authorization\"\n* \"Set-Cookie\"\n\
+                                          \nInvalid values include:\n\n  - \":method\"\
+                                          \ - \":\" is an invalid character. This\
+                                          \ means that HTTP/2 pseudo\n    headers\
+                                          \ are not currently supported by this type.\n\
+                                          \  - \"/invalid\" - \"/ \" is an invalid\
+                                          \ character"
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowHeaders cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowMethods:
+                                      description: 'AllowMethods indicates which HTTP
+                                        methods are supported for accessing the
+
+                                        requested resource.
+
+
+                                        Valid values are any method defined by RFC9110,
+                                        along with the special
+
+                                        value `*`, which represents all HTTP methods
+                                        are allowed.
+
+
+                                        Method names are case-sensitive, so these
+                                        values are also case-sensitive.
+
+                                        (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+
+                                        Multiple method names in the value of the
+                                        `Access-Control-Allow-Methods`
+
+                                        response header are separated by a comma (",").
+
+
+                                        A CORS-safelisted method is a method that
+                                        is `GET`, `HEAD`, or `POST`.
+
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-method)
+                                        The
+
+                                        CORS-safelisted methods are always allowed,
+                                        regardless of whether they
+
+                                        are specified in the `AllowMethods` field.
+
+
+                                        When the `AllowMethods` field is configured
+                                        with one or more methods, the
+
+                                        gateway must return the `Access-Control-Allow-Methods`
+                                        response header
+
+                                        which value is present in the `AllowMethods`
+                                        field.
+
+
+                                        If the HTTP method of the `Access-Control-Request-Method`
+                                        request header
+
+                                        is not included in the list of methods specified
+                                        by the response header
+
+                                        `Access-Control-Allow-Methods`, it will present
+                                        an error on the client
+
+                                        side.
+
+
+                                        If config contains the wildcard "*" in allowMethods
+                                        and the request is
+
+                                        not credentialed, the `Access-Control-Allow-Methods`
+                                        response header
+
+                                        can either use the `*` wildcard or the value
+                                        of
+
+                                        Access-Control-Request-Method from the request.
+
+
+                                        When the request is credentialed, the gateway
+                                        must not specify the `*`
+
+                                        wildcard in the `Access-Control-Allow-Methods`
+                                        response header. When
+
+                                        also the `AllowCredentials` field is true
+                                        and `AllowMethods` field
+
+                                        specified with the `*` wildcard, the gateway
+                                        must specify one HTTP method
+
+                                        in the value of the Access-Control-Allow-Methods
+                                        response header. The
+
+                                        value of the header `Access-Control-Allow-Methods`
+                                        is same as the
+
+                                        `Access-Control-Request-Method` header provided
+                                        by the client. If the
+
+                                        header `Access-Control-Request-Method` is
+                                        not included in the request,
+
+                                        the gateway will omit the `Access-Control-Allow-Methods`
+                                        response header,
+
+                                        instead of specifying the `*` wildcard.
+
+
+                                        Support: Extended'
+                                      items:
+                                        enum:
+                                        - GET
+                                        - HEAD
+                                        - POST
+                                        - PUT
+                                        - DELETE
+                                        - CONNECT
+                                        - OPTIONS
+                                        - TRACE
+                                        - PATCH
+                                        - '*'
+                                        type: string
+                                      maxItems: 9
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowMethods cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowOrigins:
+                                      description: "AllowOrigins indicates whether\
+                                        \ the response can be shared with requested\n\
+                                        resource from the given `Origin`.\n\nThe `Origin`\
+                                        \ consists of a scheme and a host, with an\
+                                        \ optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\
+                                        \nValid values for scheme are: `http` and\
+                                        \ `https`.\n\nValid values for port are any\
+                                        \ integer between 1 and 65535 (the list of\n\
+                                        available TCP/UDP ports). Note that, if not\
+                                        \ included, port `80` is\nassumed for `http`\
+                                        \ scheme origins, and port `443` is assumed\
+                                        \ for `https`\norigins. This may affect origin\
+                                        \ matching.\n\nThe host part of the origin\
+                                        \ may contain the wildcard character `*`.\
+                                        \ These\nwildcard characters behave as follows:\n\
+                                        \n* `*` is a greedy match to the _left_, including\
+                                        \ any number of\n  DNS labels to the left\
+                                        \ of its position. This also means that\n\
+                                        \  `*` will include any number of period `.`\
+                                        \ characters to the\n  left of its position.\n\
+                                        * A wildcard by itself matches all hosts.\n\
+                                        \nAn origin value that includes _only_ the\
+                                        \ `*` character indicates requests\nfrom all\
+                                        \ `Origin`s are allowed.\n\nWhen the `AllowOrigins`\
+                                        \ field is configured with multiple origins,\
+                                        \ it\nmeans the server supports clients from\
+                                        \ multiple origins. If the request\n`Origin`\
+                                        \ matches the configured allowed origins,\
+                                        \ the gateway must return\nthe given `Origin`\
+                                        \ and sets value of the header\n`Access-Control-Allow-Origin`\
+                                        \ same as the `Origin` header provided by\
+                                        \ the\nclient.\n\nThe status code of a successful\
+                                        \ response to a \"preflight\" request is\n\
+                                        always an OK status (i.e., 204 or 200).\n\n\
+                                        If the request `Origin` does not match the\
+                                        \ configured allowed origins,\nthe gateway\
+                                        \ returns 204/200 response but doesn't set\
+                                        \ the relevant\ncross-origin response headers.\
+                                        \ Alternatively, the gateway responds with\n\
+                                        403 status to the \"preflight\" request is\
+                                        \ denied, coupled with omitting\nthe CORS\
+                                        \ headers. The cross-origin request fails\
+                                        \ on the client side.\nTherefore, the client\
+                                        \ doesn't attempt the actual cross-origin\
+                                        \ request.\n\nConversely, if the request `Origin`\
+                                        \ matches one of the configured\nallowed origins,\
+                                        \ the gateway sets the response header\n`Access-Control-Allow-Origin`\
+                                        \ to the same value as the `Origin`\nheader\
+                                        \ provided by the client.\n\nWhen config has\
+                                        \ the wildcard (\"*\") in allowOrigins, and\
+                                        \ the request\nis not credentialed (e.g.,\
+                                        \ it is a preflight request), the\n`Access-Control-Allow-Origin`\
+                                        \ response header either contains the\nwildcard\
+                                        \ as well or the Origin from the request.\n\
+                                        \nWhen the request is credentialed, the gateway\
+                                        \ must not specify the `*`\nwildcard in the\
+                                        \ `Access-Control-Allow-Origin` response header.\
+                                        \ When\nalso the `AllowCredentials` field\
+                                        \ is true and `AllowOrigins` field\nspecified\
+                                        \ with the `*` wildcard, the gateway must\
+                                        \ return a single origin\nin the value of\
+                                        \ the `Access-Control-Allow-Origin` response\
+                                        \ header,\ninstead of specifying the `*` wildcard.\
+                                        \ The value of the header\n`Access-Control-Allow-Origin`\
+                                        \ is same as the `Origin` header provided\
+                                        \ by\nthe client.\n\nSupport: Extended"
+                                      items:
+                                        description: 'The CORSOrigin MUST NOT be a
+                                          relative URI, and it MUST follow the URI
+                                          syntax and
+
+                                          encoding rules specified in RFC3986.  The
+                                          CORSOrigin MUST include both a
+
+                                          scheme ("http" or "https") and a scheme-specific-part,
+                                          or it should be a single ''*'' character.
+
+                                          URIs that include an authority MUST include
+                                          a fully qualified domain name or
+
+                                          IP address as the host.'
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    exposeHeaders:
+                                      description: 'ExposeHeaders indicates which
+                                        HTTP response headers can be exposed
+
+                                        to client-side scripts in response to a cross-origin
+                                        request.
+
+
+                                        A CORS-safelisted response header is an HTTP
+                                        header in a CORS response
+
+                                        that it is considered safe to expose to the
+                                        client scripts.
+
+                                        The CORS-safelisted response headers include
+                                        the following headers:
+
+                                        `Cache-Control`
+
+                                        `Content-Language`
+
+                                        `Content-Length`
+
+                                        `Content-Type`
+
+                                        `Expires`
+
+                                        `Last-Modified`
+
+                                        `Pragma`
+
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+
+                                        The CORS-safelisted response headers are exposed
+                                        to client by default.
+
+
+                                        When an HTTP header name is specified using
+                                        the `ExposeHeaders` field,
+
+                                        this additional header will be exposed as
+                                        part of the response to the
+
+                                        client.
+
+
+                                        Header names are not case-sensitive.
+
+
+                                        Multiple header names in the value of the
+                                        `Access-Control-Expose-Headers`
+
+                                        response header are separated by a comma (",").
+
+
+                                        A wildcard indicates that the responses with
+                                        all HTTP headers are exposed
+
+                                        to clients. The `Access-Control-Expose-Headers`
+                                        response header can only
+
+                                        use `*` wildcard as value when the request
+                                        is not credentialed.
+
+
+                                        When the `exposeHeaders` config field contains
+                                        the "*" wildcard and
+
+                                        the request is credentialed, the gateway cannot
+                                        use the `*` wildcard in
+
+                                        the `Access-Control-Expose-Headers` response
+                                        header.
+
+
+                                        Support: Extended'
+                                      items:
+                                        description: "HTTPHeaderName is the name of\
+                                          \ an HTTP header.\n\nValid values include:\n\
+                                          \n* \"Authorization\"\n* \"Set-Cookie\"\n\
+                                          \nInvalid values include:\n\n  - \":method\"\
+                                          \ - \":\" is an invalid character. This\
+                                          \ means that HTTP/2 pseudo\n    headers\
+                                          \ are not currently supported by this type.\n\
+                                          \  - \"/invalid\" - \"/ \" is an invalid\
+                                          \ character"
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    maxAge:
+                                      default: 5
+                                      description: 'MaxAge indicates the duration
+                                        (in seconds) for the client to cache the
+
+                                        results of a "preflight" request.
+
+
+                                        The information provided by the `Access-Control-Allow-Methods`
+                                        and
+
+                                        `Access-Control-Allow-Headers` response headers
+                                        can be cached by the
+
+                                        client until the time specified by `Access-Control-Max-Age`
+                                        elapses.
+
+
+                                        The default value of `Access-Control-Max-Age`
+                                        response header is 5
+
+                                        (seconds).
+
+
+                                        When the `MaxAge` field is unspecified, the
+                                        gateway sets the response
+
+                                        header "Access-Control-Max-Age: 5" by default.'
+                                      format: int32
+                                      minimum: 1
+                                      type: integer
+                                  type: object
+                                extensionRef:
+                                  description: 'ExtensionRef is an optional, implementation-specific
+                                    extension to the
+
+                                    "filter" behavior.  For example, resource "myroutefilter"
+                                    in group
+
+                                    "networking.example.net"). ExtensionRef MUST NOT
+                                    be used for core and
+
+                                    extended filters.
+
+
+                                    This filter can be used multiple times within
+                                    the same rule.
+
+
+                                    Support: Implementation-specific'
+                                  properties:
+                                    group:
+                                      description: 'Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+
+                                        When unspecified or empty string, core API
+                                        group is inferred.'
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: 'RequestHeaderModifier defines a schema
+                                    for a filter that modifies request
+
+                                    headers.
+
+
+                                    Support: Core'
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,\
+                                        \ value) to the request\nbefore the action.\
+                                        \ It appends to any existing values associated\n\
+                                        with the header name.\n\nInput:\n  GET /foo\
+                                        \ HTTP/1.1\n  my-header: foo\n\nConfig:\n\
+                                        \  add:\n  - name: \"my-header\"\n    value:\
+                                        \ \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from\
+                                        \ the HTTP request before the action. The\n\
+                                        value of Remove is a list of HTTP header names.\
+                                        \ Note that the header\nnames are case-insensitive\
+                                        \ (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                        \nInput:\n  GET /foo HTTP/1.1\n  my-header1:\
+                                        \ foo\n  my-header2: bar\n  my-header3: baz\n\
+                                        \nConfig:\n  remove: [\"my-header1\", \"my-header3\"\
+                                        ]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2:\
+                                        \ bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with\
+                                        \ the given header (name, value)\nbefore the\
+                                        \ action.\n\nInput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo\n\nConfig:\n  set:\n  -\
+                                        \ name: \"my-header\"\n    value: \"bar\"\n\
+                                        \nOutput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                        \ bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: 'RequestMirror defines a schema for
+                                    a filter that mirrors requests.
+
+                                    Requests are sent to the specified destination,
+                                    but responses from
+
+                                    that destination are ignored.
+
+
+                                    This filter can be used multiple times within
+                                    the same rule. Note that
+
+                                    not all implementations will be able to support
+                                    mirroring to multiple
+
+                                    backends.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    backendRef:
+                                      description: 'BackendRef references a resource
+                                        where mirrored requests are sent.
+
+
+                                        Mirrored requests must be sent only to a single
+                                        destination endpoint
+
+                                        within this BackendRef, irrespective of how
+                                        many endpoints are present
+
+                                        within this BackendRef.
+
+
+                                        If the referent cannot be found, this BackendRef
+                                        is invalid and must be
+
+                                        dropped from the Gateway. The controller must
+                                        ensure the "ResolvedRefs"
+
+                                        condition on the Route status is set to `status:
+                                        False` and not configure
+
+                                        this backend in the underlying implementation.
+
+
+                                        If there is a cross-namespace reference to
+                                        an *existing* object
+
+                                        that is not allowed by a ReferenceGrant, the
+                                        controller must ensure the
+
+                                        "ResolvedRefs"  condition on the Route is
+                                        set to `status: False`,
+
+                                        with the "RefNotPermitted" reason and not
+                                        configure this backend in the
+
+                                        underlying implementation.
+
+
+                                        In either error case, the Message of the `ResolvedRefs`
+                                        Condition
+
+                                        should be used to provide more detail about
+                                        the problem.
+
+
+                                        Support: Extended for Kubernetes Service
+
+
+                                        Support: Implementation-specific for any other
+                                        resource'
+                                      properties:
+                                        group:
+                                          default: ''
+                                          description: 'Group is the group of the
+                                            referent. For example, "gateway.networking.k8s.io".
+
+                                            When unspecified or empty string, core
+                                            API group is inferred.'
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: 'Kind is the Kubernetes resource
+                                            kind of the referent. For example
+
+                                            "Service".
+
+
+                                            Defaults to "Service" when not specified.
+
+
+                                            ExternalName services can refer to CNAME
+                                            DNS records that may live
+
+                                            outside of the cluster and as such are
+                                            difficult to reason about in
+
+                                            terms of conformance. They also may not
+                                            be safe to forward to (see
+
+                                            CVE-2021-25740 for more information).
+                                            Implementations SHOULD NOT
+
+                                            support ExternalName Services.
+
+
+                                            Support: Core (Services with a type other
+                                            than ExternalName)
+
+
+                                            Support: Implementation-specific (Services
+                                            with type ExternalName)'
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: 'Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local
+
+                                            namespace is inferred.
+
+
+                                            Note that when a namespace different than
+                                            the local namespace is specified,
+
+                                            a ReferenceGrant object is required in
+                                            the referent namespace to allow that
+
+                                            namespace''s owner to accept the reference.
+                                            See the ReferenceGrant
+
+                                            documentation for details.
+
+
+                                            Support: Core'
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: 'Port specifies the destination
+                                            port number to use for this resource.
+
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this
+
+                                            case, the port number is the service port
+                                            number, not the target port.
+
+                                            For other resources, destination port
+                                            might be derived from the referent
+
+                                            resource or this field.'
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: 'Fraction represents the fraction
+                                        of requests that should be
+
+                                        mirrored to BackendRef.
+
+
+                                        Only one of Fraction or Percent may be specified.
+                                        If neither field
+
+                                        is specified, 100% of requests will be mirrored.'
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: 'Percent represents the percentage
+                                        of requests that should be
+
+                                        mirrored to BackendRef. Its minimum value
+                                        is 0 (indicating 0% of
+
+                                        requests) and its maximum value is 100 (indicating
+                                        100% of requests).
+
+
+                                        Only one of Fraction or Percent may be specified.
+                                        If neither field
+
+                                        is specified, 100% of requests will be mirrored.'
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - backendRef
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
+                                requestRedirect:
+                                  description: 'RequestRedirect defines a schema for
+                                    a filter that responds to the
+
+                                    request with an HTTP redirection.
+
+
+                                    Support: Core'
+                                  properties:
+                                    hostname:
+                                      description: 'Hostname is the hostname to be
+                                        used in the value of the `Location`
+
+                                        header in the response.
+
+                                        When empty, the hostname in the `Host` header
+                                        of the request is used.
+
+
+                                        Support: Core'
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: 'Path defines parameters used to
+                                        modify the path of the incoming request.
+
+                                        The modified path is then used to construct
+                                        the `Location` header. When
+
+                                        empty, the request path is used as-is.
+
+
+                                        Support: Extended'
+                                      properties:
+                                        replaceFullPath:
+                                          description: 'ReplaceFullPath specifies
+                                            the value with which to replace the full
+                                            path
+
+                                            of a request during a rewrite or redirect.'
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: 'ReplacePrefixMatch specifies
+                                            the value with which to replace the prefix
+
+                                            match of a request during a rewrite or
+                                            redirect. For example, a request
+
+                                            to "/foo/bar" with a prefix match of "/foo"
+                                            and a ReplacePrefixMatch
+
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+
+                                            Note that this matches the behavior of
+                                            the PathPrefix match type. This
+
+                                            matches full path elements. A path element
+                                            refers to the list of labels
+
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is
+
+                                            ignored. For example, the paths `/abc`,
+                                            `/abc/`, and `/abc/def` would all
+
+                                            match the prefix `/abc`, but the path
+                                            `/abcd` would not.
+
+
+                                            ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch.
+
+                                            Using any other HTTPRouteMatch type on
+                                            the same HTTPRouteRule will result in
+
+                                            the implementation setting the Accepted
+                                            Condition for the Route to `status: False`.
+
+
+                                            Request Path | Prefix Match | Replace
+                                            Prefix | Modified Path'
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: 'Type defines the type of path
+                                            modifier. Additional types may be
+
+                                            added in a future release of the API.
+
+
+                                            Note that values may be added to this
+                                            enum, implementations
+
+                                            must ensure that unknown values will not
+                                            cause a crash.
+
+
+                                            Unknown values here must result in the
+                                            implementation setting the
+
+                                            Accepted Condition for the Route to `status:
+                                            False`, with a
+
+                                            Reason of `UnsupportedValue`.'
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                    port:
+                                      description: "Port is the port to be used in\
+                                        \ the value of the `Location`\nheader in the\
+                                        \ response.\n\nIf no port is specified, the\
+                                        \ redirect port MUST be derived using the\n\
+                                        following rules:\n\n* If redirect scheme is\
+                                        \ not-empty, the redirect port MUST be the\
+                                        \ well-known\n  port associated with the redirect\
+                                        \ scheme. Specifically \"http\" to port 80\n\
+                                        \  and \"https\" to port 443. If the redirect\
+                                        \ scheme does not have a\n  well-known port,\
+                                        \ the listener port of the Gateway SHOULD\
+                                        \ be used.\n* If redirect scheme is empty,\
+                                        \ the redirect port MUST be the Gateway\n\
+                                        \  Listener port.\n\nImplementations SHOULD\
+                                        \ NOT add the port number in the 'Location'\n\
+                                        header in the following cases:\n\n* A Location\
+                                        \ header that will use HTTP (whether that\
+                                        \ is determined via\n  the Listener protocol\
+                                        \ or the Scheme field) _and_ use port 80.\n\
+                                        * A Location header that will use HTTPS (whether\
+                                        \ that is determined via\n  the Listener protocol\
+                                        \ or the Scheme field) _and_ use port 443.\n\
+                                        \nSupport: Extended"
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: 'Scheme is the scheme to be used
+                                        in the value of the `Location` header in
+
+                                        the response. When empty, the scheme of the
+                                        request is used.
+
+
+                                        Scheme redirects can affect the port of the
+                                        redirect, for more information,
+
+                                        refer to the documentation for the port field
+                                        of this filter.
+
+
+                                        Note that values may be added to this enum,
+                                        implementations
+
+                                        must ensure that unknown values will not cause
+                                        a crash.
+
+
+                                        Unknown values here must result in the implementation
+                                        setting the
+
+                                        Accepted Condition for the Route to `status:
+                                        False`, with a
+
+                                        Reason of `UnsupportedValue`.
+
+
+                                        Support: Extended'
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: 'StatusCode is the HTTP status
+                                        code to be used in response.
+
+
+                                        Note that values may be added to this enum,
+                                        implementations
+
+                                        must ensure that unknown values will not cause
+                                        a crash.
+
+
+                                        Unknown values here must result in the implementation
+                                        setting the
+
+                                        Accepted Condition for the Route to `status:
+                                        False`, with a
+
+                                        Reason of `UnsupportedValue`.
+
+
+                                        Support: Core'
+                                      enum:
+                                      - 301
+                                      - 302
+                                      - 303
+                                      - 307
+                                      - 308
+                                      type: integer
+                                  type: object
+                                responseHeaderModifier:
+                                  description: 'ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response
+
+                                    headers.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,\
+                                        \ value) to the request\nbefore the action.\
+                                        \ It appends to any existing values associated\n\
+                                        with the header name.\n\nInput:\n  GET /foo\
+                                        \ HTTP/1.1\n  my-header: foo\n\nConfig:\n\
+                                        \  add:\n  - name: \"my-header\"\n    value:\
+                                        \ \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from\
+                                        \ the HTTP request before the action. The\n\
+                                        value of Remove is a list of HTTP header names.\
+                                        \ Note that the header\nnames are case-insensitive\
+                                        \ (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                        \nInput:\n  GET /foo HTTP/1.1\n  my-header1:\
+                                        \ foo\n  my-header2: bar\n  my-header3: baz\n\
+                                        \nConfig:\n  remove: [\"my-header1\", \"my-header3\"\
+                                        ]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2:\
+                                        \ bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with\
+                                        \ the given header (name, value)\nbefore the\
+                                        \ action.\n\nInput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo\n\nConfig:\n  set:\n  -\
+                                        \ name: \"my-header\"\n    value: \"bar\"\n\
+                                        \nOutput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                        \ bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter\
+                                    \ to apply. As with other API fields,\ntypes are\
+                                    \ classified into three conformance levels:\n\n\
+                                    - Core: Filter types and their corresponding configuration\
+                                    \ defined by\n  \"Support: Core\" in this package,\
+                                    \ e.g. \"RequestHeaderModifier\". All\n  implementations\
+                                    \ must support core filters.\n\n- Extended: Filter\
+                                    \ types and their corresponding configuration\
+                                    \ defined by\n  \"Support: Extended\" in this\
+                                    \ package, e.g. \"RequestMirror\". Implementers\n\
+                                    \  are encouraged to support extended filters.\n\
+                                    \n- Implementation-specific: Filters that are\
+                                    \ defined and supported by\n  specific vendors.\n\
+                                    \  In the future, filters showing convergence\
+                                    \ in behavior across multiple\n  implementations\
+                                    \ will be considered for inclusion in extended\
+                                    \ or core\n  conformance levels. Filter-specific\
+                                    \ configuration for such filters\n  is specified\
+                                    \ using the ExtensionRef field. `Type` should\
+                                    \ be set to\n  \"ExtensionRef\" for custom filters.\n\
+                                    \nImplementers are encouraged to define custom\
+                                    \ implementation types to\nextend the core API\
+                                    \ with implementation-specific behavior.\n\nIf\
+                                    \ a reference to a custom filter type cannot be\
+                                    \ resolved, the filter\nMUST NOT be skipped. Instead,\
+                                    \ requests that would have been processed by\n\
+                                    that filter MUST receive a HTTP error response.\n\
+                                    \nNote that values may be added to this enum,\
+                                    \ implementations\nmust ensure that unknown values\
+                                    \ will not cause a crash.\n\nUnknown values here\
+                                    \ must result in the implementation setting the\n\
+                                    Accepted Condition for the Route to `status: False`,\
+                                    \ with a\nReason of `UnsupportedValue`."
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - ResponseHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - URLRewrite
+                                  - ExtensionRef
+                                  - CORS
+                                  type: string
+                                urlRewrite:
+                                  description: 'URLRewrite defines a schema for a
+                                    filter that modifies a request during forwarding.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    hostname:
+                                      description: 'Hostname is the value to be used
+                                        to replace the Host header value during
+
+                                        forwarding.
+
+
+                                        Support: Extended'
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: 'Path defines a path rewrite.
+
+
+                                        Support: Extended'
+                                      properties:
+                                        replaceFullPath:
+                                          description: 'ReplaceFullPath specifies
+                                            the value with which to replace the full
+                                            path
+
+                                            of a request during a rewrite or redirect.'
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: 'ReplacePrefixMatch specifies
+                                            the value with which to replace the prefix
+
+                                            match of a request during a rewrite or
+                                            redirect. For example, a request
+
+                                            to "/foo/bar" with a prefix match of "/foo"
+                                            and a ReplacePrefixMatch
+
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+
+                                            Note that this matches the behavior of
+                                            the PathPrefix match type. This
+
+                                            matches full path elements. A path element
+                                            refers to the list of labels
+
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is
+
+                                            ignored. For example, the paths `/abc`,
+                                            `/abc/`, and `/abc/def` would all
+
+                                            match the prefix `/abc`, but the path
+                                            `/abcd` would not.
+
+
+                                            ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch.
+
+                                            Using any other HTTPRouteMatch type on
+                                            the same HTTPRouteRule will result in
+
+                                            the implementation setting the Accepted
+                                            Condition for the Route to `status: False`.
+
+
+                                            Request Path | Prefix Match | Replace
+                                            Prefix | Modified Path'
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: 'Type defines the type of path
+                                            modifier. Additional types may be
+
+                                            added in a future release of the API.
+
+
+                                            Note that values may be added to this
+                                            enum, implementations
+
+                                            must ensure that unknown values will not
+                                            cause a crash.
+
+
+                                            Unknown values here must result in the
+                                            implementation setting the
+
+                                            Accepted Condition for the Route to `status:
+                                            False`, with a
+
+                                            Reason of `UnsupportedValue`.'
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.requestRedirect must be nil if the
+                                  filter.type is not RequestRedirect
+                                rule: '!(has(self.requestRedirect) && self.type !=
+                                  ''RequestRedirect'')'
+                              - message: filter.requestRedirect must be specified
+                                  for RequestRedirect filter.type
+                                rule: '!(!has(self.requestRedirect) && self.type ==
+                                  ''RequestRedirect'')'
+                              - message: filter.urlRewrite must be nil if the filter.type
+                                  is not URLRewrite
+                                rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                              - message: filter.urlRewrite must be specified for URLRewrite
+                                  filter.type
+                                rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-type: atomic
+                            x-kubernetes-validations:
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: CORS filter cannot be repeated
+                              rule: self.filter(f, f.type == 'CORS').size() <= 1
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                            - message: RequestRedirect filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestRedirect').size()
+                                <= 1
+                            - message: URLRewrite filter cannot be repeated
+                              rule: self.filter(f, f.type == 'URLRewrite').size()
+                                <= 1
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    filters:
+                      description: "Filters define the filters that are applied to\
+                        \ requests that match\nthis rule.\n\nWherever possible, implementations\
+                        \ SHOULD implement filters in the order\nthey are specified.\n\
+                        \nImplementations MAY choose to implement this ordering strictly,\
+                        \ rejecting\nany combination or order of filters that cannot\
+                        \ be supported. If implementations\nchoose a strict interpretation\
+                        \ of filter ordering, they MUST clearly document\nthat behavior.\n\
+                        \nTo reject an invalid combination or order of filters, implementations\
+                        \ SHOULD\nconsider the Route Rules with this configuration\
+                        \ invalid. If all Route Rules\nin a Route are invalid, the\
+                        \ entire Route would be considered invalid. If only\na portion\
+                        \ of Route Rules are invalid, implementations MUST set the\n\
+                        \"PartiallyInvalid\" condition for the Route.\n\nConformance-levels\
+                        \ at this level are defined based on the type of filter:\n\
+                        \n- ALL core filters MUST be supported by all implementations.\n\
+                        - Implementers are encouraged to support extended filters.\n\
+                        - Implementation-specific custom filters have no API guarantees\
+                        \ across\n  implementations.\n\nSpecifying the same filter\
+                        \ multiple times is not supported unless explicitly\nindicated\
+                        \ in the filter.\n\nAll filters are expected to be compatible\
+                        \ with each other except for the\nURLRewrite and RequestRedirect\
+                        \ filters, which may not be combined. If an\nimplementation\
+                        \ cannot support other combinations of filters, they must\
+                        \ clearly\ndocument that limitation. In cases where incompatible\
+                        \ or unsupported\nfilters are specified and cause the `Accepted`\
+                        \ condition to be set to status\n`False`, implementations\
+                        \ may use the `IncompatibleFilters` reason to specify\nthis\
+                        \ configuration error.\n\nSupport: Core"
+                      items:
+                        description: 'HTTPRouteFilter defines processing steps that
+                          must be completed during the
+
+                          request or response lifecycle. HTTPRouteFilters are meant
+                          as an extension
+
+                          point to express processing that may be done in Gateway
+                          implementations. Some
+
+                          examples include request or response modification, implementing
+
+                          authentication strategies, rate-limiting, and traffic shaping.
+                          API
+
+                          guarantee/conformance is defined based on the type of the
+                          filter.'
+                        properties:
+                          cors:
+                            description: 'CORS defines a schema for a filter that
+                              responds to the
+
+                              cross-origin request based on HTTP response header.
+
+
+                              Support: Extended'
+                            properties:
+                              allowCredentials:
+                                description: 'AllowCredentials indicates whether the
+                                  actual cross-origin request allows
+
+                                  to include credentials.
+
+
+                                  When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+
+                                  response header with value true (case-sensitive).
+
+
+                                  When set to false or omitted the gateway will omit
+                                  the header
+
+                                  `Access-Control-Allow-Credentials` entirely (this
+                                  is the standard CORS
+
+                                  behavior).
+
+
+                                  Support: Extended'
+                                type: boolean
+                              allowHeaders:
+                                description: 'AllowHeaders indicates which HTTP request
+                                  headers are supported for
+
+                                  accessing the requested resource.
+
+
+                                  Header names are not case-sensitive.
+
+
+                                  Multiple header names in the value of the `Access-Control-Allow-Headers`
+
+                                  response header are separated by a comma (",").
+
+
+                                  When the `AllowHeaders` field is configured with
+                                  one or more headers, the
+
+                                  gateway must return the `Access-Control-Allow-Headers`
+                                  response header
+
+                                  which value is present in the `AllowHeaders` field.
+
+
+                                  If any header name in the `Access-Control-Request-Headers`
+                                  request header
+
+                                  is not included in the list of header names specified
+                                  by the response
+
+                                  header `Access-Control-Allow-Headers`, it will present
+                                  an error on the
+
+                                  client side.
+
+
+                                  If any header name in the `Access-Control-Allow-Headers`
+                                  response header
+
+                                  does not recognize by the client, it will also occur
+                                  an error on the
+
+                                  client side.
+
+
+                                  A wildcard indicates that the requests with all
+                                  HTTP headers are allowed.
+
+                                  If config contains the wildcard "*" in allowHeaders
+                                  and the request is
+
+                                  not credentialed, the `Access-Control-Allow-Headers`
+                                  response header
+
+                                  can either use the `*` wildcard or the value of
+
+                                  Access-Control-Request-Headers from the request.
+
+
+                                  When the request is credentialed, the gateway must
+                                  not specify the `*`
+
+                                  wildcard in the `Access-Control-Allow-Headers` response
+                                  header. When
+
+                                  also the `AllowCredentials` field is true and `AllowHeaders`
+                                  field
+
+                                  is specified with the `*` wildcard, the gateway
+                                  must specify one or more
+
+                                  HTTP headers in the value of the `Access-Control-Allow-Headers`
+                                  response
+
+                                  header. The value of the header `Access-Control-Allow-Headers`
+                                  is same as
+
+                                  the `Access-Control-Request-Headers` header provided
+                                  by the client. If
+
+                                  the header `Access-Control-Request-Headers` is not
+                                  included in the
+
+                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+
+                                  response header, instead of specifying the `*` wildcard.
+
+
+                                  Support: Extended'
+                                items:
+                                  description: "HTTPHeaderName is the name of an HTTP\
+                                    \ header.\n\nValid values include:\n\n* \"Authorization\"\
+                                    \n* \"Set-Cookie\"\n\nInvalid values include:\n\
+                                    \n  - \":method\" - \":\" is an invalid character.\
+                                    \ This means that HTTP/2 pseudo\n    headers are\
+                                    \ not currently supported by this type.\n  - \"\
+                                    /invalid\" - \"/ \" is an invalid character"
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowHeaders cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowMethods:
+                                description: 'AllowMethods indicates which HTTP methods
+                                  are supported for accessing the
+
+                                  requested resource.
+
+
+                                  Valid values are any method defined by RFC9110,
+                                  along with the special
+
+                                  value `*`, which represents all HTTP methods are
+                                  allowed.
+
+
+                                  Method names are case-sensitive, so these values
+                                  are also case-sensitive.
+
+                                  (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+
+                                  Multiple method names in the value of the `Access-Control-Allow-Methods`
+
+                                  response header are separated by a comma (",").
+
+
+                                  A CORS-safelisted method is a method that is `GET`,
+                                  `HEAD`, or `POST`.
+
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-method)
+                                  The
+
+                                  CORS-safelisted methods are always allowed, regardless
+                                  of whether they
+
+                                  are specified in the `AllowMethods` field.
+
+
+                                  When the `AllowMethods` field is configured with
+                                  one or more methods, the
+
+                                  gateway must return the `Access-Control-Allow-Methods`
+                                  response header
+
+                                  which value is present in the `AllowMethods` field.
+
+
+                                  If the HTTP method of the `Access-Control-Request-Method`
+                                  request header
+
+                                  is not included in the list of methods specified
+                                  by the response header
+
+                                  `Access-Control-Allow-Methods`, it will present
+                                  an error on the client
+
+                                  side.
+
+
+                                  If config contains the wildcard "*" in allowMethods
+                                  and the request is
+
+                                  not credentialed, the `Access-Control-Allow-Methods`
+                                  response header
+
+                                  can either use the `*` wildcard or the value of
+
+                                  Access-Control-Request-Method from the request.
+
+
+                                  When the request is credentialed, the gateway must
+                                  not specify the `*`
+
+                                  wildcard in the `Access-Control-Allow-Methods` response
+                                  header. When
+
+                                  also the `AllowCredentials` field is true and `AllowMethods`
+                                  field
+
+                                  specified with the `*` wildcard, the gateway must
+                                  specify one HTTP method
+
+                                  in the value of the Access-Control-Allow-Methods
+                                  response header. The
+
+                                  value of the header `Access-Control-Allow-Methods`
+                                  is same as the
+
+                                  `Access-Control-Request-Method` header provided
+                                  by the client. If the
+
+                                  header `Access-Control-Request-Method` is not included
+                                  in the request,
+
+                                  the gateway will omit the `Access-Control-Allow-Methods`
+                                  response header,
+
+                                  instead of specifying the `*` wildcard.
+
+
+                                  Support: Extended'
+                                items:
+                                  enum:
+                                  - GET
+                                  - HEAD
+                                  - POST
+                                  - PUT
+                                  - DELETE
+                                  - CONNECT
+                                  - OPTIONS
+                                  - TRACE
+                                  - PATCH
+                                  - '*'
+                                  type: string
+                                maxItems: 9
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowMethods cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowOrigins:
+                                description: "AllowOrigins indicates whether the response\
+                                  \ can be shared with requested\nresource from the\
+                                  \ given `Origin`.\n\nThe `Origin` consists of a\
+                                  \ scheme and a host, with an optional port, and\n\
+                                  takes the form `<scheme>://<host>(:<port>)`.\n\n\
+                                  Valid values for scheme are: `http` and `https`.\n\
+                                  \nValid values for port are any integer between\
+                                  \ 1 and 65535 (the list of\navailable TCP/UDP ports).\
+                                  \ Note that, if not included, port `80` is\nassumed\
+                                  \ for `http` scheme origins, and port `443` is assumed\
+                                  \ for `https`\norigins. This may affect origin matching.\n\
+                                  \nThe host part of the origin may contain the wildcard\
+                                  \ character `*`. These\nwildcard characters behave\
+                                  \ as follows:\n\n* `*` is a greedy match to the\
+                                  \ _left_, including any number of\n  DNS labels\
+                                  \ to the left of its position. This also means that\n\
+                                  \  `*` will include any number of period `.` characters\
+                                  \ to the\n  left of its position.\n* A wildcard\
+                                  \ by itself matches all hosts.\n\nAn origin value\
+                                  \ that includes _only_ the `*` character indicates\
+                                  \ requests\nfrom all `Origin`s are allowed.\n\n\
+                                  When the `AllowOrigins` field is configured with\
+                                  \ multiple origins, it\nmeans the server supports\
+                                  \ clients from multiple origins. If the request\n\
+                                  `Origin` matches the configured allowed origins,\
+                                  \ the gateway must return\nthe given `Origin` and\
+                                  \ sets value of the header\n`Access-Control-Allow-Origin`\
+                                  \ same as the `Origin` header provided by the\n\
+                                  client.\n\nThe status code of a successful response\
+                                  \ to a \"preflight\" request is\nalways an OK status\
+                                  \ (i.e., 204 or 200).\n\nIf the request `Origin`\
+                                  \ does not match the configured allowed origins,\n\
+                                  the gateway returns 204/200 response but doesn't\
+                                  \ set the relevant\ncross-origin response headers.\
+                                  \ Alternatively, the gateway responds with\n403\
+                                  \ status to the \"preflight\" request is denied,\
+                                  \ coupled with omitting\nthe CORS headers. The cross-origin\
+                                  \ request fails on the client side.\nTherefore,\
+                                  \ the client doesn't attempt the actual cross-origin\
+                                  \ request.\n\nConversely, if the request `Origin`\
+                                  \ matches one of the configured\nallowed origins,\
+                                  \ the gateway sets the response header\n`Access-Control-Allow-Origin`\
+                                  \ to the same value as the `Origin`\nheader provided\
+                                  \ by the client.\n\nWhen config has the wildcard\
+                                  \ (\"*\") in allowOrigins, and the request\nis not\
+                                  \ credentialed (e.g., it is a preflight request),\
+                                  \ the\n`Access-Control-Allow-Origin` response header\
+                                  \ either contains the\nwildcard as well or the Origin\
+                                  \ from the request.\n\nWhen the request is credentialed,\
+                                  \ the gateway must not specify the `*`\nwildcard\
+                                  \ in the `Access-Control-Allow-Origin` response\
+                                  \ header. When\nalso the `AllowCredentials` field\
+                                  \ is true and `AllowOrigins` field\nspecified with\
+                                  \ the `*` wildcard, the gateway must return a single\
+                                  \ origin\nin the value of the `Access-Control-Allow-Origin`\
+                                  \ response header,\ninstead of specifying the `*`\
+                                  \ wildcard. The value of the header\n`Access-Control-Allow-Origin`\
+                                  \ is same as the `Origin` header provided by\nthe\
+                                  \ client.\n\nSupport: Extended"
+                                items:
+                                  description: 'The CORSOrigin MUST NOT be a relative
+                                    URI, and it MUST follow the URI syntax and
+
+                                    encoding rules specified in RFC3986.  The CORSOrigin
+                                    MUST include both a
+
+                                    scheme ("http" or "https") and a scheme-specific-part,
+                                    or it should be a single ''*'' character.
+
+                                    URIs that include an authority MUST include a
+                                    fully qualified domain name or
+
+                                    IP address as the host.'
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              exposeHeaders:
+                                description: 'ExposeHeaders indicates which HTTP response
+                                  headers can be exposed
+
+                                  to client-side scripts in response to a cross-origin
+                                  request.
+
+
+                                  A CORS-safelisted response header is an HTTP header
+                                  in a CORS response
+
+                                  that it is considered safe to expose to the client
+                                  scripts.
+
+                                  The CORS-safelisted response headers include the
+                                  following headers:
+
+                                  `Cache-Control`
+
+                                  `Content-Language`
+
+                                  `Content-Length`
+
+                                  `Content-Type`
+
+                                  `Expires`
+
+                                  `Last-Modified`
+
+                                  `Pragma`
+
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+
+                                  The CORS-safelisted response headers are exposed
+                                  to client by default.
+
+
+                                  When an HTTP header name is specified using the
+                                  `ExposeHeaders` field,
+
+                                  this additional header will be exposed as part of
+                                  the response to the
+
+                                  client.
+
+
+                                  Header names are not case-sensitive.
+
+
+                                  Multiple header names in the value of the `Access-Control-Expose-Headers`
+
+                                  response header are separated by a comma (",").
+
+
+                                  A wildcard indicates that the responses with all
+                                  HTTP headers are exposed
+
+                                  to clients. The `Access-Control-Expose-Headers`
+                                  response header can only
+
+                                  use `*` wildcard as value when the request is not
+                                  credentialed.
+
+
+                                  When the `exposeHeaders` config field contains the
+                                  "*" wildcard and
+
+                                  the request is credentialed, the gateway cannot
+                                  use the `*` wildcard in
+
+                                  the `Access-Control-Expose-Headers` response header.
+
+
+                                  Support: Extended'
+                                items:
+                                  description: "HTTPHeaderName is the name of an HTTP\
+                                    \ header.\n\nValid values include:\n\n* \"Authorization\"\
+                                    \n* \"Set-Cookie\"\n\nInvalid values include:\n\
+                                    \n  - \":method\" - \":\" is an invalid character.\
+                                    \ This means that HTTP/2 pseudo\n    headers are\
+                                    \ not currently supported by this type.\n  - \"\
+                                    /invalid\" - \"/ \" is an invalid character"
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              maxAge:
+                                default: 5
+                                description: 'MaxAge indicates the duration (in seconds)
+                                  for the client to cache the
+
+                                  results of a "preflight" request.
+
+
+                                  The information provided by the `Access-Control-Allow-Methods`
+                                  and
+
+                                  `Access-Control-Allow-Headers` response headers
+                                  can be cached by the
+
+                                  client until the time specified by `Access-Control-Max-Age`
+                                  elapses.
+
+
+                                  The default value of `Access-Control-Max-Age` response
+                                  header is 5
+
+                                  (seconds).
+
+
+                                  When the `MaxAge` field is unspecified, the gateway
+                                  sets the response
+
+                                  header "Access-Control-Max-Age: 5" by default.'
+                                format: int32
+                                minimum: 1
+                                type: integer
+                            type: object
+                          extensionRef:
+                            description: 'ExtensionRef is an optional, implementation-specific
+                              extension to the
+
+                              "filter" behavior.  For example, resource "myroutefilter"
+                              in group
+
+                              "networking.example.net"). ExtensionRef MUST NOT be
+                              used for core and
+
+                              extended filters.
+
+
+                              This filter can be used multiple times within the same
+                              rule.
+
+
+                              Support: Implementation-specific'
+                            properties:
+                              group:
+                                description: 'Group is the group of the referent.
+                                  For example, "gateway.networking.k8s.io".
+
+                                  When unspecified or empty string, core API group
+                                  is inferred.'
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: 'RequestHeaderModifier defines a schema for
+                              a filter that modifies request
+
+                              headers.
+
+
+                              Support: Core'
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,\
+                                  \ value) to the request\nbefore the action. It appends\
+                                  \ to any existing values associated\nwith the header\
+                                  \ name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                  \ foo\n\nConfig:\n  add:\n  - name: \"my-header\"\
+                                  \n    value: \"bar,baz\"\n\nOutput:\n  GET /foo\
+                                  \ HTTP/1.1\n  my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the\
+                                  \ HTTP request before the action. The\nvalue of\
+                                  \ Remove is a list of HTTP header names. Note that\
+                                  \ the header\nnames are case-insensitive (see\n\
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n\
+                                  \  my-header2: bar\n  my-header3: baz\n\nConfig:\n\
+                                  \  remove: [\"my-header1\", \"my-header3\"]\n\n\
+                                  Output:\n  GET /foo HTTP/1.1\n  my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the\
+                                  \ given header (name, value)\nbefore the action.\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\
+                                  \nConfig:\n  set:\n  - name: \"my-header\"\n   \
+                                  \ value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                  \  my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: 'RequestMirror defines a schema for a filter
+                              that mirrors requests.
+
+                              Requests are sent to the specified destination, but
+                              responses from
+
+                              that destination are ignored.
+
+
+                              This filter can be used multiple times within the same
+                              rule. Note that
+
+                              not all implementations will be able to support mirroring
+                              to multiple
+
+                              backends.
+
+
+                              Support: Extended'
+                            properties:
+                              backendRef:
+                                description: 'BackendRef references a resource where
+                                  mirrored requests are sent.
+
+
+                                  Mirrored requests must be sent only to a single
+                                  destination endpoint
+
+                                  within this BackendRef, irrespective of how many
+                                  endpoints are present
+
+                                  within this BackendRef.
+
+
+                                  If the referent cannot be found, this BackendRef
+                                  is invalid and must be
+
+                                  dropped from the Gateway. The controller must ensure
+                                  the "ResolvedRefs"
+
+                                  condition on the Route status is set to `status:
+                                  False` and not configure
+
+                                  this backend in the underlying implementation.
+
+
+                                  If there is a cross-namespace reference to an *existing*
+                                  object
+
+                                  that is not allowed by a ReferenceGrant, the controller
+                                  must ensure the
+
+                                  "ResolvedRefs"  condition on the Route is set to
+                                  `status: False`,
+
+                                  with the "RefNotPermitted" reason and not configure
+                                  this backend in the
+
+                                  underlying implementation.
+
+
+                                  In either error case, the Message of the `ResolvedRefs`
+                                  Condition
+
+                                  should be used to provide more detail about the
+                                  problem.
+
+
+                                  Support: Extended for Kubernetes Service
+
+
+                                  Support: Implementation-specific for any other resource'
+                                properties:
+                                  group:
+                                    default: ''
+                                    description: 'Group is the group of the referent.
+                                      For example, "gateway.networking.k8s.io".
+
+                                      When unspecified or empty string, core API group
+                                      is inferred.'
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: 'Kind is the Kubernetes resource
+                                      kind of the referent. For example
+
+                                      "Service".
+
+
+                                      Defaults to "Service" when not specified.
+
+
+                                      ExternalName services can refer to CNAME DNS
+                                      records that may live
+
+                                      outside of the cluster and as such are difficult
+                                      to reason about in
+
+                                      terms of conformance. They also may not be safe
+                                      to forward to (see
+
+                                      CVE-2021-25740 for more information). Implementations
+                                      SHOULD NOT
+
+                                      support ExternalName Services.
+
+
+                                      Support: Core (Services with a type other than
+                                      ExternalName)
+
+
+                                      Support: Implementation-specific (Services with
+                                      type ExternalName)'
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace is the namespace of the
+                                      backend. When unspecified, the local
+
+                                      namespace is inferred.
+
+
+                                      Note that when a namespace different than the
+                                      local namespace is specified,
+
+                                      a ReferenceGrant object is required in the referent
+                                      namespace to allow that
+
+                                      namespace''s owner to accept the reference.
+                                      See the ReferenceGrant
+
+                                      documentation for details.
+
+
+                                      Support: Core'
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: 'Port specifies the destination port
+                                      number to use for this resource.
+
+                                      Port is required when the referent is a Kubernetes
+                                      Service. In this
+
+                                      case, the port number is the service port number,
+                                      not the target port.
+
+                                      For other resources, destination port might
+                                      be derived from the referent
+
+                                      resource or this field.'
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              fraction:
+                                description: 'Fraction represents the fraction of
+                                  requests that should be
+
+                                  mirrored to BackendRef.
+
+
+                                  Only one of Fraction or Percent may be specified.
+                                  If neither field
+
+                                  is specified, 100% of requests will be mirrored.'
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: 'Percent represents the percentage of
+                                  requests that should be
+
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating
+                                  0% of
+
+                                  requests) and its maximum value is 100 (indicating
+                                  100% of requests).
+
+
+                                  Only one of Fraction or Percent may be specified.
+                                  If neither field
+
+                                  is specified, 100% of requests will be mirrored.'
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                            - backendRef
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
+                          requestRedirect:
+                            description: 'RequestRedirect defines a schema for a filter
+                              that responds to the
+
+                              request with an HTTP redirection.
+
+
+                              Support: Core'
+                            properties:
+                              hostname:
+                                description: 'Hostname is the hostname to be used
+                                  in the value of the `Location`
+
+                                  header in the response.
+
+                                  When empty, the hostname in the `Host` header of
+                                  the request is used.
+
+
+                                  Support: Core'
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: 'Path defines parameters used to modify
+                                  the path of the incoming request.
+
+                                  The modified path is then used to construct the
+                                  `Location` header. When
+
+                                  empty, the request path is used as-is.
+
+
+                                  Support: Extended'
+                                properties:
+                                  replaceFullPath:
+                                    description: 'ReplaceFullPath specifies the value
+                                      with which to replace the full path
+
+                                      of a request during a rewrite or redirect.'
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: 'ReplacePrefixMatch specifies the
+                                      value with which to replace the prefix
+
+                                      match of a request during a rewrite or redirect.
+                                      For example, a request
+
+                                      to "/foo/bar" with a prefix match of "/foo"
+                                      and a ReplacePrefixMatch
+
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+
+                                      Note that this matches the behavior of the PathPrefix
+                                      match type. This
+
+                                      matches full path elements. A path element refers
+                                      to the list of labels
+
+                                      in the path split by the `/` separator. When
+                                      specified, a trailing `/` is
+
+                                      ignored. For example, the paths `/abc`, `/abc/`,
+                                      and `/abc/def` would all
+
+                                      match the prefix `/abc`, but the path `/abcd`
+                                      would not.
+
+
+                                      ReplacePrefixMatch is only compatible with a
+                                      `PathPrefix` HTTPRouteMatch.
+
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in
+
+                                      the implementation setting the Accepted Condition
+                                      for the Route to `status: False`.
+
+
+                                      Request Path | Prefix Match | Replace Prefix
+                                      | Modified Path'
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: 'Type defines the type of path modifier.
+                                      Additional types may be
+
+                                      added in a future release of the API.
+
+
+                                      Note that values may be added to this enum,
+                                      implementations
+
+                                      must ensure that unknown values will not cause
+                                      a crash.
+
+
+                                      Unknown values here must result in the implementation
+                                      setting the
+
+                                      Accepted Condition for the Route to `status:
+                                      False`, with a
+
+                                      Reason of `UnsupportedValue`.'
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                              port:
+                                description: "Port is the port to be used in the value\
+                                  \ of the `Location`\nheader in the response.\n\n\
+                                  If no port is specified, the redirect port MUST\
+                                  \ be derived using the\nfollowing rules:\n\n* If\
+                                  \ redirect scheme is not-empty, the redirect port\
+                                  \ MUST be the well-known\n  port associated with\
+                                  \ the redirect scheme. Specifically \"http\" to\
+                                  \ port 80\n  and \"https\" to port 443. If the redirect\
+                                  \ scheme does not have a\n  well-known port, the\
+                                  \ listener port of the Gateway SHOULD be used.\n\
+                                  * If redirect scheme is empty, the redirect port\
+                                  \ MUST be the Gateway\n  Listener port.\n\nImplementations\
+                                  \ SHOULD NOT add the port number in the 'Location'\n\
+                                  header in the following cases:\n\n* A Location header\
+                                  \ that will use HTTP (whether that is determined\
+                                  \ via\n  the Listener protocol or the Scheme field)\
+                                  \ _and_ use port 80.\n* A Location header that will\
+                                  \ use HTTPS (whether that is determined via\n  the\
+                                  \ Listener protocol or the Scheme field) _and_ use\
+                                  \ port 443.\n\nSupport: Extended"
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: 'Scheme is the scheme to be used in the
+                                  value of the `Location` header in
+
+                                  the response. When empty, the scheme of the request
+                                  is used.
+
+
+                                  Scheme redirects can affect the port of the redirect,
+                                  for more information,
+
+                                  refer to the documentation for the port field of
+                                  this filter.
+
+
+                                  Note that values may be added to this enum, implementations
+
+                                  must ensure that unknown values will not cause a
+                                  crash.
+
+
+                                  Unknown values here must result in the implementation
+                                  setting the
+
+                                  Accepted Condition for the Route to `status: False`,
+                                  with a
+
+                                  Reason of `UnsupportedValue`.
+
+
+                                  Support: Extended'
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: 'StatusCode is the HTTP status code to
+                                  be used in response.
+
+
+                                  Note that values may be added to this enum, implementations
+
+                                  must ensure that unknown values will not cause a
+                                  crash.
+
+
+                                  Unknown values here must result in the implementation
+                                  setting the
+
+                                  Accepted Condition for the Route to `status: False`,
+                                  with a
+
+                                  Reason of `UnsupportedValue`.
+
+
+                                  Support: Core'
+                                enum:
+                                - 301
+                                - 302
+                                - 303
+                                - 307
+                                - 308
+                                type: integer
+                            type: object
+                          responseHeaderModifier:
+                            description: 'ResponseHeaderModifier defines a schema
+                              for a filter that modifies response
+
+                              headers.
+
+
+                              Support: Extended'
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,\
+                                  \ value) to the request\nbefore the action. It appends\
+                                  \ to any existing values associated\nwith the header\
+                                  \ name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                  \ foo\n\nConfig:\n  add:\n  - name: \"my-header\"\
+                                  \n    value: \"bar,baz\"\n\nOutput:\n  GET /foo\
+                                  \ HTTP/1.1\n  my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the\
+                                  \ HTTP request before the action. The\nvalue of\
+                                  \ Remove is a list of HTTP header names. Note that\
+                                  \ the header\nnames are case-insensitive (see\n\
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n\
+                                  \  my-header2: bar\n  my-header3: baz\n\nConfig:\n\
+                                  \  remove: [\"my-header1\", \"my-header3\"]\n\n\
+                                  Output:\n  GET /foo HTTP/1.1\n  my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the\
+                                  \ given header (name, value)\nbefore the action.\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\
+                                  \nConfig:\n  set:\n  - name: \"my-header\"\n   \
+                                  \ value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                  \  my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.\
+                              \ As with other API fields,\ntypes are classified into\
+                              \ three conformance levels:\n\n- Core: Filter types\
+                              \ and their corresponding configuration defined by\n\
+                              \  \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\"\
+                              . All\n  implementations must support core filters.\n\
+                              \n- Extended: Filter types and their corresponding configuration\
+                              \ defined by\n  \"Support: Extended\" in this package,\
+                              \ e.g. \"RequestMirror\". Implementers\n  are encouraged\
+                              \ to support extended filters.\n\n- Implementation-specific:\
+                              \ Filters that are defined and supported by\n  specific\
+                              \ vendors.\n  In the future, filters showing convergence\
+                              \ in behavior across multiple\n  implementations will\
+                              \ be considered for inclusion in extended or core\n\
+                              \  conformance levels. Filter-specific configuration\
+                              \ for such filters\n  is specified using the ExtensionRef\
+                              \ field. `Type` should be set to\n  \"ExtensionRef\"\
+                              \ for custom filters.\n\nImplementers are encouraged\
+                              \ to define custom implementation types to\nextend the\
+                              \ core API with implementation-specific behavior.\n\n\
+                              If a reference to a custom filter type cannot be resolved,\
+                              \ the filter\nMUST NOT be skipped. Instead, requests\
+                              \ that would have been processed by\nthat filter MUST\
+                              \ receive a HTTP error response.\n\nNote that values\
+                              \ may be added to this enum, implementations\nmust ensure\
+                              \ that unknown values will not cause a crash.\n\nUnknown\
+                              \ values here must result in the implementation setting\
+                              \ the\nAccepted Condition for the Route to `status:\
+                              \ False`, with a\nReason of `UnsupportedValue`."
+                            enum:
+                            - RequestHeaderModifier
+                            - ResponseHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - URLRewrite
+                            - ExtensionRef
+                            - CORS
+                            type: string
+                          urlRewrite:
+                            description: 'URLRewrite defines a schema for a filter
+                              that modifies a request during forwarding.
+
+
+                              Support: Extended'
+                            properties:
+                              hostname:
+                                description: 'Hostname is the value to be used to
+                                  replace the Host header value during
+
+                                  forwarding.
+
+
+                                  Support: Extended'
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: 'Path defines a path rewrite.
+
+
+                                  Support: Extended'
+                                properties:
+                                  replaceFullPath:
+                                    description: 'ReplaceFullPath specifies the value
+                                      with which to replace the full path
+
+                                      of a request during a rewrite or redirect.'
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: 'ReplacePrefixMatch specifies the
+                                      value with which to replace the prefix
+
+                                      match of a request during a rewrite or redirect.
+                                      For example, a request
+
+                                      to "/foo/bar" with a prefix match of "/foo"
+                                      and a ReplacePrefixMatch
+
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+
+                                      Note that this matches the behavior of the PathPrefix
+                                      match type. This
+
+                                      matches full path elements. A path element refers
+                                      to the list of labels
+
+                                      in the path split by the `/` separator. When
+                                      specified, a trailing `/` is
+
+                                      ignored. For example, the paths `/abc`, `/abc/`,
+                                      and `/abc/def` would all
+
+                                      match the prefix `/abc`, but the path `/abcd`
+                                      would not.
+
+
+                                      ReplacePrefixMatch is only compatible with a
+                                      `PathPrefix` HTTPRouteMatch.
+
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in
+
+                                      the implementation setting the Accepted Condition
+                                      for the Route to `status: False`.
+
+
+                                      Request Path | Prefix Match | Replace Prefix
+                                      | Modified Path'
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: 'Type defines the type of path modifier.
+                                      Additional types may be
+
+                                      added in a future release of the API.
+
+
+                                      Note that values may be added to this enum,
+                                      implementations
+
+                                      must ensure that unknown values will not cause
+                                      a crash.
+
+
+                                      Unknown values here must result in the implementation
+                                      setting the
+
+                                      Accepted Condition for the Route to `status:
+                                      False`, with a
+
+                                      Reason of `UnsupportedValue`.'
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                            type: object
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.requestRedirect must be nil if the filter.type
+                            is not RequestRedirect
+                          rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
+                        - message: filter.requestRedirect must be specified for RequestRedirect
+                            filter.type
+                          rule: '!(!has(self.requestRedirect) && self.type == ''RequestRedirect'')'
+                        - message: filter.urlRewrite must be nil if the filter.type
+                            is not URLRewrite
+                          rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                        - message: filter.urlRewrite must be specified for URLRewrite
+                            filter.type
+                          rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: atomic
+                      x-kubernetes-validations:
+                      - message: May specify either httpRouteFilterRequestRedirect
+                          or httpRouteFilterRequestRewrite, but not both
+                        rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
+                          self.exists(f, f.type == ''URLRewrite''))'
+                      - message: CORS filter cannot be repeated
+                        rule: self.filter(f, f.type == 'CORS').size() <= 1
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                      - message: RequestRedirect filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestRedirect').size() <=
+                          1
+                      - message: URLRewrite filter cannot be repeated
+                        rule: self.filter(f, f.type == 'URLRewrite').size() <= 1
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: "Matches define conditions used for matching the\
+                        \ rule against incoming\nHTTP requests. Each match is independent,\
+                        \ i.e. this rule will be matched\nif **any** one of the matches\
+                        \ is satisfied.\n\nFor example, take the following matches\
+                        \ configuration:\n\n```\nmatches:\n- path:\n    value: \"\
+                        /foo\"\n  headers:\n  - name: \"version\"\n    value: \"v2\"\
+                        \n- path:\n    value: \"/v2/foo\"\n```\n\nFor a request to\
+                        \ match against this rule, a request must satisfy\nEITHER\
+                        \ of the two conditions:\n\n- path prefixed with `/foo` AND\
+                        \ contains the header `version: v2`\n- path prefix of `/v2/foo`\n\
+                        \nSee the documentation for HTTPRouteMatch on how to specify\
+                        \ multiple\nmatch conditions that should be ANDed together.\n\
+                        \nIf no matches are specified, the default is a prefix\npath\
+                        \ match on \"/\", which has the effect of matching every\n\
+                        HTTP request.\n\nProxy or Load Balancer routing configuration\
+                        \ generated from HTTPRoutes\nMUST prioritize matches based\
+                        \ on the following criteria, continuing on\nties. Across all\
+                        \ rules specified on applicable Routes, precedence must be\n\
+                        given to the match having:\n\n* \"Exact\" path match.\n* \"\
+                        Prefix\" path match with largest number of characters.\n*\
+                        \ Method match.\n* Largest number of header matches.\n* Largest\
+                        \ number of query param matches.\n\nNote: The precedence of\
+                        \ RegularExpression path matches are implementation-specific.\n\
+                        \nIf ties still exist across multiple Routes, matching precedence\
+                        \ MUST be\ndetermined in order of the following criteria,\
+                        \ continuing on ties:\n\n* The oldest Route based on creation\
+                        \ timestamp.\n* The Route appearing first in alphabetical\
+                        \ order by\n  \"{namespace}/{name}\".\n\nIf ties still exist\
+                        \ within an HTTPRoute, matching precedence MUST be granted\n\
+                        to the FIRST matching rule (in list order) with a match meeting\
+                        \ the above\ncriteria.\n\nWhen no rules matching a request\
+                        \ have been successfully attached to the\nparent a request\
+                        \ is coming from, a HTTP 404 status code MUST be returned."
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to\
+                          \ match requests to a given\naction. Multiple match types\
+                          \ are ANDed together, i.e. the match will\nevaluate to true\
+                          \ only if all conditions are satisfied.\n\nFor example,\
+                          \ the match below will match a HTTP request only if its\
+                          \ path\nstarts with `/foo` AND it contains the `version:\
+                          \ v1` header:\n\n```\nmatch:\n\n\tpath:\n\t  value: \"/foo\"\
+                          \n\theaders:\n\t- name: \"version\"\n\t  value \"v1\"\n\n\
+                          ```"
+                        properties:
+                          headers:
+                            description: 'Headers specifies HTTP request header matchers.
+                              Multiple match values are
+
+                              ANDed together, meaning, a request must match all the
+                              specified headers
+
+                              to select the route.'
+                            items:
+                              description: 'HTTPHeaderMatch describes how to select
+                                a HTTP route by matching HTTP request
+
+                                headers.'
+                              properties:
+                                name:
+                                  description: 'Name is the name of the HTTP Header
+                                    to be matched. Name matching MUST be
+
+                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                    If multiple entries specify equivalent header
+                                    names, only the first
+
+                                    entry with an equivalent name MUST be considered
+                                    for a match. Subsequent
+
+                                    entries with an equivalent header name MUST be
+                                    ignored. Due to the
+
+                                    case-insensitivity of header names, "foo" and
+                                    "Foo" are considered
+
+                                    equivalent.
+
+
+                                    When a header is repeated in an HTTP request,
+                                    it is
+
+                                    implementation-specific behavior as to how this
+                                    is represented.
+
+                                    Generally, proxies should follow the guidance
+                                    from the RFC:
+
+                                    https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                    regarding
+
+                                    processing a repeated header, with special handling
+                                    for "Set-Cookie".'
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: 'Type specifies how to match against
+                                    the value of the header.
+
+
+                                    Support: Core (Exact)
+
+
+                                    Support: Implementation-specific (RegularExpression)
+
+
+                                    Since RegularExpression HeaderMatchType has implementation-specific
+
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects
+
+                                    of regular expressions. Please read the implementation''s
+                                    documentation to
+
+                                    determine the supported dialect.'
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: 'Method specifies HTTP method matcher.
+
+                              When specified, this route will be matched only if the
+                              request has the
+
+                              specified method.
+
+
+                              Support: Extended'
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: 'Path specifies a HTTP request path matcher.
+                              If this field is not
+
+                              specified, a default prefix match on the "/" path is
+                              provided.'
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: 'Type specifies how to match against
+                                  the path Value.
+
+
+                                  Support: Core (Exact, PathPrefix)
+
+
+                                  Support: Implementation-specific (RegularExpression)'
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: value must be an absolute path and start with
+                                '/' when type one of ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.startsWith(''/'')
+                                : true'
+                            - message: must not contain '//' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''//'')
+                                : true'
+                            - message: must not contain '/./' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/./'')
+                                : true'
+                            - message: must not contain '/../' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/../'')
+                                : true'
+                            - message: must not contain '%2f' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2f'')
+                                : true'
+                            - message: must not contain '%2F' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2F'')
+                                : true'
+                            - message: must not contain '#' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''#'')
+                                : true'
+                            - message: must not end with '/..' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/..'')
+                                : true'
+                            - message: must not end with '/.' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
+                                : true'
+                            - message: type must be one of ['Exact', 'PathPrefix',
+                                'RegularExpression']
+                              rule: self.type in ['Exact','PathPrefix'] || self.type
+                                == 'RegularExpression'
+                            - message: must only contain valid characters (matching
+                                ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                for types ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                : true'
+                          queryParams:
+                            description: 'QueryParams specifies HTTP query parameter
+                              matchers. Multiple match
+
+                              values are ANDed together, meaning, a request must match
+                              all the
+
+                              specified query parameters to select the route.
+
+
+                              Support: Extended'
+                            items:
+                              description: 'HTTPQueryParamMatch describes how to select
+                                a HTTP route by matching HTTP
+
+                                query parameters.'
+                              properties:
+                                name:
+                                  description: 'Name is the name of the HTTP query
+                                    param to be matched. This must be an
+
+                                    exact string match. (See
+
+                                    https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                    If multiple entries specify equivalent query param
+                                    names, only the first
+
+                                    entry with an equivalent name MUST be considered
+                                    for a match. Subsequent
+
+                                    entries with an equivalent query param name MUST
+                                    be ignored.
+
+
+                                    If a query param is repeated in an HTTP request,
+                                    the behavior is
+
+                                    purposely left undefined, since different data
+                                    planes have different
+
+                                    capabilities. However, it is *recommended* that
+                                    implementations should
+
+                                    match against the first value of the param if
+                                    the data plane supports it,
+
+                                    as this behavior is expected in other load balancing
+                                    contexts outside of
+
+                                    the Gateway API.
+
+
+                                    Users SHOULD NOT route traffic based on repeated
+                                    query params to guard
+
+                                    themselves against potential differences in the
+                                    implementations.'
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: 'Type specifies how to match against
+                                    the value of the query parameter.
+
+
+                                    Support: Extended (Exact)
+
+
+                                    Support: Implementation-specific (RegularExpression)
+
+
+                                    Since RegularExpression QueryParamMatchType has
+                                    Implementation-specific
+
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other
+
+                                    dialects of regular expressions. Please read the
+                                    implementation''s
+
+                                    documentation to determine the supported dialect.'
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 64
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: 'Name is the name of the route rule. This name
+                        MUST be unique within a Route if it is set.
+
+
+                        Support: Extended'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    timeouts:
+                      description: 'Timeouts defines the timeouts that can be configured
+                        for an HTTP request.
+
+
+                        Support: Extended'
+                      properties:
+                        backendRequest:
+                          description: 'BackendRequest specifies a timeout for an
+                            individual request from the gateway
+
+                            to a backend. This covers the time from when the request
+                            first starts being
+
+                            sent from the gateway to when the full response has been
+                            received from the backend.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD
+                            disable the timeout
+
+                            completely. Implementations that cannot completely disable
+                            the timeout MUST
+
+                            instead interpret the zero duration as the longest possible
+                            value to which
+
+                            the timeout can be set.
+
+
+                            An entire client HTTP transaction with a gateway, covered
+                            by the Request timeout,
+
+                            may result in more than one call from the gateway to the
+                            destination backend,
+
+                            for example, if automatic retries are supported.
+
+
+                            The value of BackendRequest must be a Gateway API Duration
+                            string as defined by
+
+                            GEP-2257.  When this field is unspecified, its behavior
+                            is implementation-specific;
+
+                            when specified, the value of BackendRequest must be no
+                            more than the value of the
+
+                            Request timeout (since the Request timeout encompasses
+                            the BackendRequest timeout).
+
+
+                            Support: Extended'
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: 'Request specifies the maximum duration for
+                            a gateway to respond to an HTTP request.
+
+                            If the gateway has not been able to respond before this
+                            deadline is met, the gateway
+
+                            MUST return a timeout error.
+
+
+                            For example, setting the `rules.timeouts.request` field
+                            to the value `10s` in an
+
+                            `HTTPRoute` will cause a timeout if a client request is
+                            taking longer than 10 seconds
+
+                            to complete.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD
+                            disable the timeout
+
+                            completely. Implementations that cannot completely disable
+                            the timeout MUST
+
+                            instead interpret the zero duration as the longest possible
+                            value to which
+
+                            the timeout can be set.
+
+
+                            This timeout is intended to cover as close to the whole
+                            request-response transaction
+
+                            as possible although an implementation MAY choose to start
+                            the timeout after the entire
+
+                            request stream has been received instead of immediately
+                            after the transaction is
+
+                            initiated by the client.
+
+
+                            The value of Request is a Gateway API Duration string
+                            as defined by GEP-2257. When this
+
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+
+                            Support: Extended'
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
+                  type: object
+                  x-kubernetes-validations:
+                  - message: RequestRedirect filter must not be used together with
+                      backendRefs
+                    rule: '(has(self.backendRefs) && size(self.backendRefs) > 0) ?
+                      (!has(self.filters) || self.filters.all(f, !has(f.requestRedirect))):
+                      true'
+                  - message: When using RequestRedirect filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      ? ((size(self.matches) != 1 || !has(self.matches[0].path) ||
+                      self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: When using URLRewrite filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                  - message: Within backendRefs, when using RequestRedirect filter
+                      with path.replacePrefixMatch, exactly one PathPrefix match must
+                      be specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      )) ? ((size(self.matches) != 1 || !has(self.matches[0].path)
+                      || self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: Within backendRefs, When using URLRewrite filter with
+                      path.replacePrefixMatch, exactly one PathPrefix match must be
+                      specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) )) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: 'HTTPRoute provides a way to route HTTP requests. This includes
+          the capability
+
+          to match requests by hostname, path, header, or query param. Filters can
+          be
+
+          used to specify additional processing steps. Backends specify where matching
+
+          requests should be routed.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostnames that should match\
+                  \ against the HTTP Host\nheader to select a HTTPRoute used to process\
+                  \ the request. Implementations\nMUST ignore any port value specified\
+                  \ in the HTTP Host header while\nperforming a match and (absent\
+                  \ of any applicable header modification\nconfiguration) MUST forward\
+                  \ this header unmodified to the backend.\n\nValid values for Hostnames\
+                  \ are determined by RFC 1123 definition of a\nhostname with 2 notable\
+                  \ exceptions:\n\n1. IPs are not allowed.\n2. A hostname may be prefixed\
+                  \ with a wildcard label (`*.`). The wildcard\n   label must appear\
+                  \ by itself as the first label.\n\nIf a hostname is specified by\
+                  \ both the Listener and HTTPRoute, there\nmust be at least one intersecting\
+                  \ hostname for the HTTPRoute to be\nattached to the Listener. For\
+                  \ example:\n\n* A Listener with `test.example.com` as the hostname\
+                  \ matches HTTPRoutes\n  that have either not specified any hostnames,\
+                  \ or have specified at\n  least one of `test.example.com` or `*.example.com`.\n\
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes\n\
+                  \  that have either not specified any hostnames or have specified\
+                  \ at least\n  one hostname that matches the Listener hostname. For\
+                  \ example,\n  `*.example.com`, `test.example.com`, and `foo.test.example.com`\
+                  \ would\n  all match. On the other hand, `example.com` and `test.example.net`\
+                  \ would\n  not match.\n\nHostnames that are prefixed with a wildcard\
+                  \ label (`*.`) are interpreted\nas a suffix match. That means that\
+                  \ a match for `*.example.com` would match\nboth `test.example.com`,\
+                  \ and `foo.test.example.com`, but not `example.com`.\n\nIf both\
+                  \ the Listener and HTTPRoute have specified hostnames, any\nHTTPRoute\
+                  \ hostnames that do not match the Listener hostname MUST be\nignored.\
+                  \ For example, if a Listener specified `*.example.com`, and the\n\
+                  HTTPRoute specified `test.example.com` and `test.example.net`,\n\
+                  `test.example.net` must not be considered for a match.\n\nIf both\
+                  \ the Listener and HTTPRoute have specified hostnames, and none\n\
+                  match with the criteria above, then the HTTPRoute is not accepted.\
+                  \ The\nimplementation must raise an 'Accepted' Condition with a\
+                  \ status of\n`False` in the corresponding RouteParentStatus.\n\n\
+                  In the event that multiple HTTPRoutes specify intersecting hostnames\
+                  \ (e.g.\noverlapping wildcard matching and exact matching hostnames),\
+                  \ precedence must\nbe given to rules from the HTTPRoute with the\
+                  \ largest number of:\n\n* Characters in a matching non-wildcard\
+                  \ hostname.\n* Characters in a matching hostname.\n\nIf ties exist\
+                  \ across multiple Routes, the matching precedence rules for\nHTTPRouteMatches\
+                  \ takes over.\n\nSupport: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network\
+                    \ host. This matches\nthe RFC 1123 definition of a hostname with\
+                    \ 2 notable exceptions:\n\n 1. IPs are not allowed.\n 2. A hostname\
+                    \ may be prefixed with a wildcard label (`*.`). The wildcard\n\
+                    \    label must appear by itself as the first label.\n\nHostname\
+                    \ can be \"precise\" which is a domain name without the terminating\n\
+                    dot of a network host (e.g. \"foo.example.com\") or \"wildcard\"\
+                    , which is a\ndomain name prefixed with a single wildcard label\
+                    \ (e.g. `*.example.com`).\n\nNote that as per RFC1035 and RFC1123,\
+                    \ a *label* must consist of lower case\nalphanumeric characters\
+                    \ or '-', and must start and end with an alphanumeric\ncharacter.\
+                    \ No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: Rules are a list of HTTP matchers, filters and actions.
+                items:
+                  description: 'HTTPRouteRule defines semantics for matching an HTTP
+                    request based on
+
+                    conditions (matches), processing it (filters), and forwarding
+                    the request to
+
+                    an API object (backendRefs).'
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent.
+
+
+                        Failure behavior here depends on how many BackendRefs are
+                        specified and
+
+                        how many are invalid.
+
+
+                        If *all* entries in BackendRefs are invalid, and there are
+                        also no filters
+
+                        specified in this route rule, *all* traffic which matches
+                        this rule MUST
+
+                        receive a 500 status code.
+
+
+                        See the HTTPBackendRef definition for the rules about what
+                        makes a single
+
+                        HTTPBackendRef invalid.
+
+
+                        When a HTTPBackendRef is invalid, 500 status codes MUST be
+                        returned for
+
+                        requests that would have otherwise been routed to an invalid
+                        backend. If
+
+                        multiple backends are specified, and some are invalid, the
+                        proportion of
+
+                        requests that would otherwise have been routed to an invalid
+                        backend
+
+                        MUST receive a 500 status code.
+
+
+                        For example, if two backends are specified with equal weights,
+                        and one is
+
+                        invalid, 50 percent of traffic must receive a 500. Implementations
+                        may
+
+                        choose how that 50 percent is determined.
+
+
+                        When a HTTPBackendRef refers to a Service that has no ready
+                        endpoints,
+
+                        implementations SHOULD return a 503 for requests to that backend
+                        instead.
+
+                        If an implementation chooses to do this, all of the above
+                        rules for 500 responses
+
+                        MUST also apply for responses that return a 503.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Core'
+                      items:
+                        description: 'HTTPBackendRef defines how a HTTPRoute forwards
+                          a HTTP request.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.'
+                        properties:
+                          filters:
+                            description: 'Filters defined at this level should be
+                              executed if and only if the
+
+                              request is being forwarded to the backend defined here.
+
+
+                              Support: Implementation-specific (For broader support
+                              of filters, use the
+
+                              Filters field in HTTPRouteRule.)'
+                            items:
+                              description: 'HTTPRouteFilter defines processing steps
+                                that must be completed during the
+
+                                request or response lifecycle. HTTPRouteFilters are
+                                meant as an extension
+
+                                point to express processing that may be done in Gateway
+                                implementations. Some
+
+                                examples include request or response modification,
+                                implementing
+
+                                authentication strategies, rate-limiting, and traffic
+                                shaping. API
+
+                                guarantee/conformance is defined based on the type
+                                of the filter.'
+                              properties:
+                                cors:
+                                  description: 'CORS defines a schema for a filter
+                                    that responds to the
+
+                                    cross-origin request based on HTTP response header.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    allowCredentials:
+                                      description: 'AllowCredentials indicates whether
+                                        the actual cross-origin request allows
+
+                                        to include credentials.
+
+
+                                        When set to true, the gateway will include
+                                        the `Access-Control-Allow-Credentials`
+
+                                        response header with value true (case-sensitive).
+
+
+                                        When set to false or omitted the gateway will
+                                        omit the header
+
+                                        `Access-Control-Allow-Credentials` entirely
+                                        (this is the standard CORS
+
+                                        behavior).
+
+
+                                        Support: Extended'
+                                      type: boolean
+                                    allowHeaders:
+                                      description: 'AllowHeaders indicates which HTTP
+                                        request headers are supported for
+
+                                        accessing the requested resource.
+
+
+                                        Header names are not case-sensitive.
+
+
+                                        Multiple header names in the value of the
+                                        `Access-Control-Allow-Headers`
+
+                                        response header are separated by a comma (",").
+
+
+                                        When the `AllowHeaders` field is configured
+                                        with one or more headers, the
+
+                                        gateway must return the `Access-Control-Allow-Headers`
+                                        response header
+
+                                        which value is present in the `AllowHeaders`
+                                        field.
+
+
+                                        If any header name in the `Access-Control-Request-Headers`
+                                        request header
+
+                                        is not included in the list of header names
+                                        specified by the response
+
+                                        header `Access-Control-Allow-Headers`, it
+                                        will present an error on the
+
+                                        client side.
+
+
+                                        If any header name in the `Access-Control-Allow-Headers`
+                                        response header
+
+                                        does not recognize by the client, it will
+                                        also occur an error on the
+
+                                        client side.
+
+
+                                        A wildcard indicates that the requests with
+                                        all HTTP headers are allowed.
+
+                                        If config contains the wildcard "*" in allowHeaders
+                                        and the request is
+
+                                        not credentialed, the `Access-Control-Allow-Headers`
+                                        response header
+
+                                        can either use the `*` wildcard or the value
+                                        of
+
+                                        Access-Control-Request-Headers from the request.
+
+
+                                        When the request is credentialed, the gateway
+                                        must not specify the `*`
+
+                                        wildcard in the `Access-Control-Allow-Headers`
+                                        response header. When
+
+                                        also the `AllowCredentials` field is true
+                                        and `AllowHeaders` field
+
+                                        is specified with the `*` wildcard, the gateway
+                                        must specify one or more
+
+                                        HTTP headers in the value of the `Access-Control-Allow-Headers`
+                                        response
+
+                                        header. The value of the header `Access-Control-Allow-Headers`
+                                        is same as
+
+                                        the `Access-Control-Request-Headers` header
+                                        provided by the client. If
+
+                                        the header `Access-Control-Request-Headers`
+                                        is not included in the
+
+                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+
+                                        response header, instead of specifying the
+                                        `*` wildcard.
+
+
+                                        Support: Extended'
+                                      items:
+                                        description: "HTTPHeaderName is the name of\
+                                          \ an HTTP header.\n\nValid values include:\n\
+                                          \n* \"Authorization\"\n* \"Set-Cookie\"\n\
+                                          \nInvalid values include:\n\n  - \":method\"\
+                                          \ - \":\" is an invalid character. This\
+                                          \ means that HTTP/2 pseudo\n    headers\
+                                          \ are not currently supported by this type.\n\
+                                          \  - \"/invalid\" - \"/ \" is an invalid\
+                                          \ character"
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowHeaders cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowMethods:
+                                      description: 'AllowMethods indicates which HTTP
+                                        methods are supported for accessing the
+
+                                        requested resource.
+
+
+                                        Valid values are any method defined by RFC9110,
+                                        along with the special
+
+                                        value `*`, which represents all HTTP methods
+                                        are allowed.
+
+
+                                        Method names are case-sensitive, so these
+                                        values are also case-sensitive.
+
+                                        (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+
+                                        Multiple method names in the value of the
+                                        `Access-Control-Allow-Methods`
+
+                                        response header are separated by a comma (",").
+
+
+                                        A CORS-safelisted method is a method that
+                                        is `GET`, `HEAD`, or `POST`.
+
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-method)
+                                        The
+
+                                        CORS-safelisted methods are always allowed,
+                                        regardless of whether they
+
+                                        are specified in the `AllowMethods` field.
+
+
+                                        When the `AllowMethods` field is configured
+                                        with one or more methods, the
+
+                                        gateway must return the `Access-Control-Allow-Methods`
+                                        response header
+
+                                        which value is present in the `AllowMethods`
+                                        field.
+
+
+                                        If the HTTP method of the `Access-Control-Request-Method`
+                                        request header
+
+                                        is not included in the list of methods specified
+                                        by the response header
+
+                                        `Access-Control-Allow-Methods`, it will present
+                                        an error on the client
+
+                                        side.
+
+
+                                        If config contains the wildcard "*" in allowMethods
+                                        and the request is
+
+                                        not credentialed, the `Access-Control-Allow-Methods`
+                                        response header
+
+                                        can either use the `*` wildcard or the value
+                                        of
+
+                                        Access-Control-Request-Method from the request.
+
+
+                                        When the request is credentialed, the gateway
+                                        must not specify the `*`
+
+                                        wildcard in the `Access-Control-Allow-Methods`
+                                        response header. When
+
+                                        also the `AllowCredentials` field is true
+                                        and `AllowMethods` field
+
+                                        specified with the `*` wildcard, the gateway
+                                        must specify one HTTP method
+
+                                        in the value of the Access-Control-Allow-Methods
+                                        response header. The
+
+                                        value of the header `Access-Control-Allow-Methods`
+                                        is same as the
+
+                                        `Access-Control-Request-Method` header provided
+                                        by the client. If the
+
+                                        header `Access-Control-Request-Method` is
+                                        not included in the request,
+
+                                        the gateway will omit the `Access-Control-Allow-Methods`
+                                        response header,
+
+                                        instead of specifying the `*` wildcard.
+
+
+                                        Support: Extended'
+                                      items:
+                                        enum:
+                                        - GET
+                                        - HEAD
+                                        - POST
+                                        - PUT
+                                        - DELETE
+                                        - CONNECT
+                                        - OPTIONS
+                                        - TRACE
+                                        - PATCH
+                                        - '*'
+                                        type: string
+                                      maxItems: 9
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowMethods cannot contain '*' alongside
+                                          other methods
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    allowOrigins:
+                                      description: "AllowOrigins indicates whether\
+                                        \ the response can be shared with requested\n\
+                                        resource from the given `Origin`.\n\nThe `Origin`\
+                                        \ consists of a scheme and a host, with an\
+                                        \ optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\
+                                        \nValid values for scheme are: `http` and\
+                                        \ `https`.\n\nValid values for port are any\
+                                        \ integer between 1 and 65535 (the list of\n\
+                                        available TCP/UDP ports). Note that, if not\
+                                        \ included, port `80` is\nassumed for `http`\
+                                        \ scheme origins, and port `443` is assumed\
+                                        \ for `https`\norigins. This may affect origin\
+                                        \ matching.\n\nThe host part of the origin\
+                                        \ may contain the wildcard character `*`.\
+                                        \ These\nwildcard characters behave as follows:\n\
+                                        \n* `*` is a greedy match to the _left_, including\
+                                        \ any number of\n  DNS labels to the left\
+                                        \ of its position. This also means that\n\
+                                        \  `*` will include any number of period `.`\
+                                        \ characters to the\n  left of its position.\n\
+                                        * A wildcard by itself matches all hosts.\n\
+                                        \nAn origin value that includes _only_ the\
+                                        \ `*` character indicates requests\nfrom all\
+                                        \ `Origin`s are allowed.\n\nWhen the `AllowOrigins`\
+                                        \ field is configured with multiple origins,\
+                                        \ it\nmeans the server supports clients from\
+                                        \ multiple origins. If the request\n`Origin`\
+                                        \ matches the configured allowed origins,\
+                                        \ the gateway must return\nthe given `Origin`\
+                                        \ and sets value of the header\n`Access-Control-Allow-Origin`\
+                                        \ same as the `Origin` header provided by\
+                                        \ the\nclient.\n\nThe status code of a successful\
+                                        \ response to a \"preflight\" request is\n\
+                                        always an OK status (i.e., 204 or 200).\n\n\
+                                        If the request `Origin` does not match the\
+                                        \ configured allowed origins,\nthe gateway\
+                                        \ returns 204/200 response but doesn't set\
+                                        \ the relevant\ncross-origin response headers.\
+                                        \ Alternatively, the gateway responds with\n\
+                                        403 status to the \"preflight\" request is\
+                                        \ denied, coupled with omitting\nthe CORS\
+                                        \ headers. The cross-origin request fails\
+                                        \ on the client side.\nTherefore, the client\
+                                        \ doesn't attempt the actual cross-origin\
+                                        \ request.\n\nConversely, if the request `Origin`\
+                                        \ matches one of the configured\nallowed origins,\
+                                        \ the gateway sets the response header\n`Access-Control-Allow-Origin`\
+                                        \ to the same value as the `Origin`\nheader\
+                                        \ provided by the client.\n\nWhen config has\
+                                        \ the wildcard (\"*\") in allowOrigins, and\
+                                        \ the request\nis not credentialed (e.g.,\
+                                        \ it is a preflight request), the\n`Access-Control-Allow-Origin`\
+                                        \ response header either contains the\nwildcard\
+                                        \ as well or the Origin from the request.\n\
+                                        \nWhen the request is credentialed, the gateway\
+                                        \ must not specify the `*`\nwildcard in the\
+                                        \ `Access-Control-Allow-Origin` response header.\
+                                        \ When\nalso the `AllowCredentials` field\
+                                        \ is true and `AllowOrigins` field\nspecified\
+                                        \ with the `*` wildcard, the gateway must\
+                                        \ return a single origin\nin the value of\
+                                        \ the `Access-Control-Allow-Origin` response\
+                                        \ header,\ninstead of specifying the `*` wildcard.\
+                                        \ The value of the header\n`Access-Control-Allow-Origin`\
+                                        \ is same as the `Origin` header provided\
+                                        \ by\nthe client.\n\nSupport: Extended"
+                                      items:
+                                        description: 'The CORSOrigin MUST NOT be a
+                                          relative URI, and it MUST follow the URI
+                                          syntax and
+
+                                          encoding rules specified in RFC3986.  The
+                                          CORSOrigin MUST include both a
+
+                                          scheme ("http" or "https") and a scheme-specific-part,
+                                          or it should be a single ''*'' character.
+
+                                          URIs that include an authority MUST include
+                                          a fully qualified domain name or
+
+                                          IP address as the host.'
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: AllowOrigins cannot contain '*' alongside
+                                          other origins
+                                        rule: '!(''*'' in self && self.size() > 1)'
+                                    exposeHeaders:
+                                      description: 'ExposeHeaders indicates which
+                                        HTTP response headers can be exposed
+
+                                        to client-side scripts in response to a cross-origin
+                                        request.
+
+
+                                        A CORS-safelisted response header is an HTTP
+                                        header in a CORS response
+
+                                        that it is considered safe to expose to the
+                                        client scripts.
+
+                                        The CORS-safelisted response headers include
+                                        the following headers:
+
+                                        `Cache-Control`
+
+                                        `Content-Language`
+
+                                        `Content-Length`
+
+                                        `Content-Type`
+
+                                        `Expires`
+
+                                        `Last-Modified`
+
+                                        `Pragma`
+
+                                        (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+
+                                        The CORS-safelisted response headers are exposed
+                                        to client by default.
+
+
+                                        When an HTTP header name is specified using
+                                        the `ExposeHeaders` field,
+
+                                        this additional header will be exposed as
+                                        part of the response to the
+
+                                        client.
+
+
+                                        Header names are not case-sensitive.
+
+
+                                        Multiple header names in the value of the
+                                        `Access-Control-Expose-Headers`
+
+                                        response header are separated by a comma (",").
+
+
+                                        A wildcard indicates that the responses with
+                                        all HTTP headers are exposed
+
+                                        to clients. The `Access-Control-Expose-Headers`
+                                        response header can only
+
+                                        use `*` wildcard as value when the request
+                                        is not credentialed.
+
+
+                                        When the `exposeHeaders` config field contains
+                                        the "*" wildcard and
+
+                                        the request is credentialed, the gateway cannot
+                                        use the `*` wildcard in
+
+                                        the `Access-Control-Expose-Headers` response
+                                        header.
+
+
+                                        Support: Extended'
+                                      items:
+                                        description: "HTTPHeaderName is the name of\
+                                          \ an HTTP header.\n\nValid values include:\n\
+                                          \n* \"Authorization\"\n* \"Set-Cookie\"\n\
+                                          \nInvalid values include:\n\n  - \":method\"\
+                                          \ - \":\" is an invalid character. This\
+                                          \ means that HTTP/2 pseudo\n    headers\
+                                          \ are not currently supported by this type.\n\
+                                          \  - \"/invalid\" - \"/ \" is an invalid\
+                                          \ character"
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      maxItems: 64
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    maxAge:
+                                      default: 5
+                                      description: 'MaxAge indicates the duration
+                                        (in seconds) for the client to cache the
+
+                                        results of a "preflight" request.
+
+
+                                        The information provided by the `Access-Control-Allow-Methods`
+                                        and
+
+                                        `Access-Control-Allow-Headers` response headers
+                                        can be cached by the
+
+                                        client until the time specified by `Access-Control-Max-Age`
+                                        elapses.
+
+
+                                        The default value of `Access-Control-Max-Age`
+                                        response header is 5
+
+                                        (seconds).
+
+
+                                        When the `MaxAge` field is unspecified, the
+                                        gateway sets the response
+
+                                        header "Access-Control-Max-Age: 5" by default.'
+                                      format: int32
+                                      minimum: 1
+                                      type: integer
+                                  type: object
+                                extensionRef:
+                                  description: 'ExtensionRef is an optional, implementation-specific
+                                    extension to the
+
+                                    "filter" behavior.  For example, resource "myroutefilter"
+                                    in group
+
+                                    "networking.example.net"). ExtensionRef MUST NOT
+                                    be used for core and
+
+                                    extended filters.
+
+
+                                    This filter can be used multiple times within
+                                    the same rule.
+
+
+                                    Support: Implementation-specific'
+                                  properties:
+                                    group:
+                                      description: 'Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+
+                                        When unspecified or empty string, core API
+                                        group is inferred.'
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: 'RequestHeaderModifier defines a schema
+                                    for a filter that modifies request
+
+                                    headers.
+
+
+                                    Support: Core'
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,\
+                                        \ value) to the request\nbefore the action.\
+                                        \ It appends to any existing values associated\n\
+                                        with the header name.\n\nInput:\n  GET /foo\
+                                        \ HTTP/1.1\n  my-header: foo\n\nConfig:\n\
+                                        \  add:\n  - name: \"my-header\"\n    value:\
+                                        \ \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from\
+                                        \ the HTTP request before the action. The\n\
+                                        value of Remove is a list of HTTP header names.\
+                                        \ Note that the header\nnames are case-insensitive\
+                                        \ (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                        \nInput:\n  GET /foo HTTP/1.1\n  my-header1:\
+                                        \ foo\n  my-header2: bar\n  my-header3: baz\n\
+                                        \nConfig:\n  remove: [\"my-header1\", \"my-header3\"\
+                                        ]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2:\
+                                        \ bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with\
+                                        \ the given header (name, value)\nbefore the\
+                                        \ action.\n\nInput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo\n\nConfig:\n  set:\n  -\
+                                        \ name: \"my-header\"\n    value: \"bar\"\n\
+                                        \nOutput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                        \ bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: 'RequestMirror defines a schema for
+                                    a filter that mirrors requests.
+
+                                    Requests are sent to the specified destination,
+                                    but responses from
+
+                                    that destination are ignored.
+
+
+                                    This filter can be used multiple times within
+                                    the same rule. Note that
+
+                                    not all implementations will be able to support
+                                    mirroring to multiple
+
+                                    backends.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    backendRef:
+                                      description: 'BackendRef references a resource
+                                        where mirrored requests are sent.
+
+
+                                        Mirrored requests must be sent only to a single
+                                        destination endpoint
+
+                                        within this BackendRef, irrespective of how
+                                        many endpoints are present
+
+                                        within this BackendRef.
+
+
+                                        If the referent cannot be found, this BackendRef
+                                        is invalid and must be
+
+                                        dropped from the Gateway. The controller must
+                                        ensure the "ResolvedRefs"
+
+                                        condition on the Route status is set to `status:
+                                        False` and not configure
+
+                                        this backend in the underlying implementation.
+
+
+                                        If there is a cross-namespace reference to
+                                        an *existing* object
+
+                                        that is not allowed by a ReferenceGrant, the
+                                        controller must ensure the
+
+                                        "ResolvedRefs"  condition on the Route is
+                                        set to `status: False`,
+
+                                        with the "RefNotPermitted" reason and not
+                                        configure this backend in the
+
+                                        underlying implementation.
+
+
+                                        In either error case, the Message of the `ResolvedRefs`
+                                        Condition
+
+                                        should be used to provide more detail about
+                                        the problem.
+
+
+                                        Support: Extended for Kubernetes Service
+
+
+                                        Support: Implementation-specific for any other
+                                        resource'
+                                      properties:
+                                        group:
+                                          default: ''
+                                          description: 'Group is the group of the
+                                            referent. For example, "gateway.networking.k8s.io".
+
+                                            When unspecified or empty string, core
+                                            API group is inferred.'
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: 'Kind is the Kubernetes resource
+                                            kind of the referent. For example
+
+                                            "Service".
+
+
+                                            Defaults to "Service" when not specified.
+
+
+                                            ExternalName services can refer to CNAME
+                                            DNS records that may live
+
+                                            outside of the cluster and as such are
+                                            difficult to reason about in
+
+                                            terms of conformance. They also may not
+                                            be safe to forward to (see
+
+                                            CVE-2021-25740 for more information).
+                                            Implementations SHOULD NOT
+
+                                            support ExternalName Services.
+
+
+                                            Support: Core (Services with a type other
+                                            than ExternalName)
+
+
+                                            Support: Implementation-specific (Services
+                                            with type ExternalName)'
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: 'Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local
+
+                                            namespace is inferred.
+
+
+                                            Note that when a namespace different than
+                                            the local namespace is specified,
+
+                                            a ReferenceGrant object is required in
+                                            the referent namespace to allow that
+
+                                            namespace''s owner to accept the reference.
+                                            See the ReferenceGrant
+
+                                            documentation for details.
+
+
+                                            Support: Core'
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: 'Port specifies the destination
+                                            port number to use for this resource.
+
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this
+
+                                            case, the port number is the service port
+                                            number, not the target port.
+
+                                            For other resources, destination port
+                                            might be derived from the referent
+
+                                            resource or this field.'
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                    fraction:
+                                      description: 'Fraction represents the fraction
+                                        of requests that should be
+
+                                        mirrored to BackendRef.
+
+
+                                        Only one of Fraction or Percent may be specified.
+                                        If neither field
+
+                                        is specified, 100% of requests will be mirrored.'
+                                      properties:
+                                        denominator:
+                                          default: 100
+                                          format: int32
+                                          minimum: 1
+                                          type: integer
+                                        numerator:
+                                          format: int32
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - numerator
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: numerator must be less than or equal
+                                          to denominator
+                                        rule: self.numerator <= self.denominator
+                                    percent:
+                                      description: 'Percent represents the percentage
+                                        of requests that should be
+
+                                        mirrored to BackendRef. Its minimum value
+                                        is 0 (indicating 0% of
+
+                                        requests) and its maximum value is 100 (indicating
+                                        100% of requests).
+
+
+                                        Only one of Fraction or Percent may be specified.
+                                        If neither field
+
+                                        is specified, 100% of requests will be mirrored.'
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - backendRef
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: Only one of percent or fraction may be
+                                      specified in HTTPRequestMirrorFilter
+                                    rule: '!(has(self.percent) && has(self.fraction))'
+                                requestRedirect:
+                                  description: 'RequestRedirect defines a schema for
+                                    a filter that responds to the
+
+                                    request with an HTTP redirection.
+
+
+                                    Support: Core'
+                                  properties:
+                                    hostname:
+                                      description: 'Hostname is the hostname to be
+                                        used in the value of the `Location`
+
+                                        header in the response.
+
+                                        When empty, the hostname in the `Host` header
+                                        of the request is used.
+
+
+                                        Support: Core'
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: 'Path defines parameters used to
+                                        modify the path of the incoming request.
+
+                                        The modified path is then used to construct
+                                        the `Location` header. When
+
+                                        empty, the request path is used as-is.
+
+
+                                        Support: Extended'
+                                      properties:
+                                        replaceFullPath:
+                                          description: 'ReplaceFullPath specifies
+                                            the value with which to replace the full
+                                            path
+
+                                            of a request during a rewrite or redirect.'
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: 'ReplacePrefixMatch specifies
+                                            the value with which to replace the prefix
+
+                                            match of a request during a rewrite or
+                                            redirect. For example, a request
+
+                                            to "/foo/bar" with a prefix match of "/foo"
+                                            and a ReplacePrefixMatch
+
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+
+                                            Note that this matches the behavior of
+                                            the PathPrefix match type. This
+
+                                            matches full path elements. A path element
+                                            refers to the list of labels
+
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is
+
+                                            ignored. For example, the paths `/abc`,
+                                            `/abc/`, and `/abc/def` would all
+
+                                            match the prefix `/abc`, but the path
+                                            `/abcd` would not.
+
+
+                                            ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch.
+
+                                            Using any other HTTPRouteMatch type on
+                                            the same HTTPRouteRule will result in
+
+                                            the implementation setting the Accepted
+                                            Condition for the Route to `status: False`.
+
+
+                                            Request Path | Prefix Match | Replace
+                                            Prefix | Modified Path'
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: 'Type defines the type of path
+                                            modifier. Additional types may be
+
+                                            added in a future release of the API.
+
+
+                                            Note that values may be added to this
+                                            enum, implementations
+
+                                            must ensure that unknown values will not
+                                            cause a crash.
+
+
+                                            Unknown values here must result in the
+                                            implementation setting the
+
+                                            Accepted Condition for the Route to `status:
+                                            False`, with a
+
+                                            Reason of `UnsupportedValue`.'
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                    port:
+                                      description: "Port is the port to be used in\
+                                        \ the value of the `Location`\nheader in the\
+                                        \ response.\n\nIf no port is specified, the\
+                                        \ redirect port MUST be derived using the\n\
+                                        following rules:\n\n* If redirect scheme is\
+                                        \ not-empty, the redirect port MUST be the\
+                                        \ well-known\n  port associated with the redirect\
+                                        \ scheme. Specifically \"http\" to port 80\n\
+                                        \  and \"https\" to port 443. If the redirect\
+                                        \ scheme does not have a\n  well-known port,\
+                                        \ the listener port of the Gateway SHOULD\
+                                        \ be used.\n* If redirect scheme is empty,\
+                                        \ the redirect port MUST be the Gateway\n\
+                                        \  Listener port.\n\nImplementations SHOULD\
+                                        \ NOT add the port number in the 'Location'\n\
+                                        header in the following cases:\n\n* A Location\
+                                        \ header that will use HTTP (whether that\
+                                        \ is determined via\n  the Listener protocol\
+                                        \ or the Scheme field) _and_ use port 80.\n\
+                                        * A Location header that will use HTTPS (whether\
+                                        \ that is determined via\n  the Listener protocol\
+                                        \ or the Scheme field) _and_ use port 443.\n\
+                                        \nSupport: Extended"
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: 'Scheme is the scheme to be used
+                                        in the value of the `Location` header in
+
+                                        the response. When empty, the scheme of the
+                                        request is used.
+
+
+                                        Scheme redirects can affect the port of the
+                                        redirect, for more information,
+
+                                        refer to the documentation for the port field
+                                        of this filter.
+
+
+                                        Note that values may be added to this enum,
+                                        implementations
+
+                                        must ensure that unknown values will not cause
+                                        a crash.
+
+
+                                        Unknown values here must result in the implementation
+                                        setting the
+
+                                        Accepted Condition for the Route to `status:
+                                        False`, with a
+
+                                        Reason of `UnsupportedValue`.
+
+
+                                        Support: Extended'
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: 'StatusCode is the HTTP status
+                                        code to be used in response.
+
+
+                                        Note that values may be added to this enum,
+                                        implementations
+
+                                        must ensure that unknown values will not cause
+                                        a crash.
+
+
+                                        Unknown values here must result in the implementation
+                                        setting the
+
+                                        Accepted Condition for the Route to `status:
+                                        False`, with a
+
+                                        Reason of `UnsupportedValue`.
+
+
+                                        Support: Core'
+                                      enum:
+                                      - 301
+                                      - 302
+                                      - 303
+                                      - 307
+                                      - 308
+                                      type: integer
+                                  type: object
+                                responseHeaderModifier:
+                                  description: 'ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response
+
+                                    headers.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,\
+                                        \ value) to the request\nbefore the action.\
+                                        \ It appends to any existing values associated\n\
+                                        with the header name.\n\nInput:\n  GET /foo\
+                                        \ HTTP/1.1\n  my-header: foo\n\nConfig:\n\
+                                        \  add:\n  - name: \"my-header\"\n    value:\
+                                        \ \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from\
+                                        \ the HTTP request before the action. The\n\
+                                        value of Remove is a list of HTTP header names.\
+                                        \ Note that the header\nnames are case-insensitive\
+                                        \ (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                        \nInput:\n  GET /foo HTTP/1.1\n  my-header1:\
+                                        \ foo\n  my-header2: bar\n  my-header3: baz\n\
+                                        \nConfig:\n  remove: [\"my-header1\", \"my-header3\"\
+                                        ]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2:\
+                                        \ bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: "Set overwrites the request with\
+                                        \ the given header (name, value)\nbefore the\
+                                        \ action.\n\nInput:\n  GET /foo HTTP/1.1\n\
+                                        \  my-header: foo\n\nConfig:\n  set:\n  -\
+                                        \ name: \"my-header\"\n    value: \"bar\"\n\
+                                        \nOutput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                        \ bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: 'Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be
+
+                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent
+                                              header names, the first entry with
+
+                                              an equivalent name MUST be considered
+                                              for a match. Subsequent entries
+
+                                              with an equivalent header name MUST
+                                              be ignored. Due to the
+
+                                              case-insensitivity of header names,
+                                              "foo" and "Foo" are considered
+
+                                              equivalent.'
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter\
+                                    \ to apply. As with other API fields,\ntypes are\
+                                    \ classified into three conformance levels:\n\n\
+                                    - Core: Filter types and their corresponding configuration\
+                                    \ defined by\n  \"Support: Core\" in this package,\
+                                    \ e.g. \"RequestHeaderModifier\". All\n  implementations\
+                                    \ must support core filters.\n\n- Extended: Filter\
+                                    \ types and their corresponding configuration\
+                                    \ defined by\n  \"Support: Extended\" in this\
+                                    \ package, e.g. \"RequestMirror\". Implementers\n\
+                                    \  are encouraged to support extended filters.\n\
+                                    \n- Implementation-specific: Filters that are\
+                                    \ defined and supported by\n  specific vendors.\n\
+                                    \  In the future, filters showing convergence\
+                                    \ in behavior across multiple\n  implementations\
+                                    \ will be considered for inclusion in extended\
+                                    \ or core\n  conformance levels. Filter-specific\
+                                    \ configuration for such filters\n  is specified\
+                                    \ using the ExtensionRef field. `Type` should\
+                                    \ be set to\n  \"ExtensionRef\" for custom filters.\n\
+                                    \nImplementers are encouraged to define custom\
+                                    \ implementation types to\nextend the core API\
+                                    \ with implementation-specific behavior.\n\nIf\
+                                    \ a reference to a custom filter type cannot be\
+                                    \ resolved, the filter\nMUST NOT be skipped. Instead,\
+                                    \ requests that would have been processed by\n\
+                                    that filter MUST receive a HTTP error response.\n\
+                                    \nNote that values may be added to this enum,\
+                                    \ implementations\nmust ensure that unknown values\
+                                    \ will not cause a crash.\n\nUnknown values here\
+                                    \ must result in the implementation setting the\n\
+                                    Accepted Condition for the Route to `status: False`,\
+                                    \ with a\nReason of `UnsupportedValue`."
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - ResponseHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - URLRewrite
+                                  - ExtensionRef
+                                  - CORS
+                                  type: string
+                                urlRewrite:
+                                  description: 'URLRewrite defines a schema for a
+                                    filter that modifies a request during forwarding.
+
+
+                                    Support: Extended'
+                                  properties:
+                                    hostname:
+                                      description: 'Hostname is the value to be used
+                                        to replace the Host header value during
+
+                                        forwarding.
+
+
+                                        Support: Extended'
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    path:
+                                      description: 'Path defines a path rewrite.
+
+
+                                        Support: Extended'
+                                      properties:
+                                        replaceFullPath:
+                                          description: 'ReplaceFullPath specifies
+                                            the value with which to replace the full
+                                            path
+
+                                            of a request during a rewrite or redirect.'
+                                          maxLength: 1024
+                                          type: string
+                                        replacePrefixMatch:
+                                          description: 'ReplacePrefixMatch specifies
+                                            the value with which to replace the prefix
+
+                                            match of a request during a rewrite or
+                                            redirect. For example, a request
+
+                                            to "/foo/bar" with a prefix match of "/foo"
+                                            and a ReplacePrefixMatch
+
+                                            of "/xyz" would be modified to "/xyz/bar".
+
+
+                                            Note that this matches the behavior of
+                                            the PathPrefix match type. This
+
+                                            matches full path elements. A path element
+                                            refers to the list of labels
+
+                                            in the path split by the `/` separator.
+                                            When specified, a trailing `/` is
+
+                                            ignored. For example, the paths `/abc`,
+                                            `/abc/`, and `/abc/def` would all
+
+                                            match the prefix `/abc`, but the path
+                                            `/abcd` would not.
+
+
+                                            ReplacePrefixMatch is only compatible
+                                            with a `PathPrefix` HTTPRouteMatch.
+
+                                            Using any other HTTPRouteMatch type on
+                                            the same HTTPRouteRule will result in
+
+                                            the implementation setting the Accepted
+                                            Condition for the Route to `status: False`.
+
+
+                                            Request Path | Prefix Match | Replace
+                                            Prefix | Modified Path'
+                                          maxLength: 1024
+                                          type: string
+                                        type:
+                                          description: 'Type defines the type of path
+                                            modifier. Additional types may be
+
+                                            added in a future release of the API.
+
+
+                                            Note that values may be added to this
+                                            enum, implementations
+
+                                            must ensure that unknown values will not
+                                            cause a crash.
+
+
+                                            Unknown values here must result in the
+                                            implementation setting the
+
+                                            Accepted Condition for the Route to `status:
+                                            False`, with a
+
+                                            Reason of `UnsupportedValue`.'
+                                          enum:
+                                          - ReplaceFullPath
+                                          - ReplacePrefixMatch
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: replaceFullPath must be specified
+                                          when type is set to 'ReplaceFullPath'
+                                        rule: 'self.type == ''ReplaceFullPath'' ?
+                                          has(self.replaceFullPath) : true'
+                                      - message: type must be 'ReplaceFullPath' when
+                                          replaceFullPath is set
+                                        rule: 'has(self.replaceFullPath) ? self.type
+                                          == ''ReplaceFullPath'' : true'
+                                      - message: replacePrefixMatch must be specified
+                                          when type is set to 'ReplacePrefixMatch'
+                                        rule: 'self.type == ''ReplacePrefixMatch''
+                                          ? has(self.replacePrefixMatch) : true'
+                                      - message: type must be 'ReplacePrefixMatch'
+                                          when replacePrefixMatch is set
+                                        rule: 'has(self.replacePrefixMatch) ? self.type
+                                          == ''ReplacePrefixMatch'' : true'
+                                  type: object
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.cors must be nil if the filter.type
+                                  is not CORS
+                                rule: '!(has(self.cors) && self.type != ''CORS'')'
+                              - message: filter.cors must be specified for CORS filter.type
+                                rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.requestRedirect must be nil if the
+                                  filter.type is not RequestRedirect
+                                rule: '!(has(self.requestRedirect) && self.type !=
+                                  ''RequestRedirect'')'
+                              - message: filter.requestRedirect must be specified
+                                  for RequestRedirect filter.type
+                                rule: '!(!has(self.requestRedirect) && self.type ==
+                                  ''RequestRedirect'')'
+                              - message: filter.urlRewrite must be nil if the filter.type
+                                  is not URLRewrite
+                                rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                              - message: filter.urlRewrite must be specified for URLRewrite
+                                  filter.type
+                                rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-type: atomic
+                            x-kubernetes-validations:
+                            - message: May specify either httpRouteFilterRequestRedirect
+                                or httpRouteFilterRequestRewrite, but not both
+                              rule: '!(self.exists(f, f.type == ''RequestRedirect'')
+                                && self.exists(f, f.type == ''URLRewrite''))'
+                            - message: CORS filter cannot be repeated
+                              rule: self.filter(f, f.type == 'CORS').size() <= 1
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                            - message: RequestRedirect filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestRedirect').size()
+                                <= 1
+                            - message: URLRewrite filter cannot be repeated
+                              rule: self.filter(f, f.type == 'URLRewrite').size()
+                                <= 1
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    filters:
+                      description: "Filters define the filters that are applied to\
+                        \ requests that match\nthis rule.\n\nWherever possible, implementations\
+                        \ SHOULD implement filters in the order\nthey are specified.\n\
+                        \nImplementations MAY choose to implement this ordering strictly,\
+                        \ rejecting\nany combination or order of filters that cannot\
+                        \ be supported. If implementations\nchoose a strict interpretation\
+                        \ of filter ordering, they MUST clearly document\nthat behavior.\n\
+                        \nTo reject an invalid combination or order of filters, implementations\
+                        \ SHOULD\nconsider the Route Rules with this configuration\
+                        \ invalid. If all Route Rules\nin a Route are invalid, the\
+                        \ entire Route would be considered invalid. If only\na portion\
+                        \ of Route Rules are invalid, implementations MUST set the\n\
+                        \"PartiallyInvalid\" condition for the Route.\n\nConformance-levels\
+                        \ at this level are defined based on the type of filter:\n\
+                        \n- ALL core filters MUST be supported by all implementations.\n\
+                        - Implementers are encouraged to support extended filters.\n\
+                        - Implementation-specific custom filters have no API guarantees\
+                        \ across\n  implementations.\n\nSpecifying the same filter\
+                        \ multiple times is not supported unless explicitly\nindicated\
+                        \ in the filter.\n\nAll filters are expected to be compatible\
+                        \ with each other except for the\nURLRewrite and RequestRedirect\
+                        \ filters, which may not be combined. If an\nimplementation\
+                        \ cannot support other combinations of filters, they must\
+                        \ clearly\ndocument that limitation. In cases where incompatible\
+                        \ or unsupported\nfilters are specified and cause the `Accepted`\
+                        \ condition to be set to status\n`False`, implementations\
+                        \ may use the `IncompatibleFilters` reason to specify\nthis\
+                        \ configuration error.\n\nSupport: Core"
+                      items:
+                        description: 'HTTPRouteFilter defines processing steps that
+                          must be completed during the
+
+                          request or response lifecycle. HTTPRouteFilters are meant
+                          as an extension
+
+                          point to express processing that may be done in Gateway
+                          implementations. Some
+
+                          examples include request or response modification, implementing
+
+                          authentication strategies, rate-limiting, and traffic shaping.
+                          API
+
+                          guarantee/conformance is defined based on the type of the
+                          filter.'
+                        properties:
+                          cors:
+                            description: 'CORS defines a schema for a filter that
+                              responds to the
+
+                              cross-origin request based on HTTP response header.
+
+
+                              Support: Extended'
+                            properties:
+                              allowCredentials:
+                                description: 'AllowCredentials indicates whether the
+                                  actual cross-origin request allows
+
+                                  to include credentials.
+
+
+                                  When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+
+                                  response header with value true (case-sensitive).
+
+
+                                  When set to false or omitted the gateway will omit
+                                  the header
+
+                                  `Access-Control-Allow-Credentials` entirely (this
+                                  is the standard CORS
+
+                                  behavior).
+
+
+                                  Support: Extended'
+                                type: boolean
+                              allowHeaders:
+                                description: 'AllowHeaders indicates which HTTP request
+                                  headers are supported for
+
+                                  accessing the requested resource.
+
+
+                                  Header names are not case-sensitive.
+
+
+                                  Multiple header names in the value of the `Access-Control-Allow-Headers`
+
+                                  response header are separated by a comma (",").
+
+
+                                  When the `AllowHeaders` field is configured with
+                                  one or more headers, the
+
+                                  gateway must return the `Access-Control-Allow-Headers`
+                                  response header
+
+                                  which value is present in the `AllowHeaders` field.
+
+
+                                  If any header name in the `Access-Control-Request-Headers`
+                                  request header
+
+                                  is not included in the list of header names specified
+                                  by the response
+
+                                  header `Access-Control-Allow-Headers`, it will present
+                                  an error on the
+
+                                  client side.
+
+
+                                  If any header name in the `Access-Control-Allow-Headers`
+                                  response header
+
+                                  does not recognize by the client, it will also occur
+                                  an error on the
+
+                                  client side.
+
+
+                                  A wildcard indicates that the requests with all
+                                  HTTP headers are allowed.
+
+                                  If config contains the wildcard "*" in allowHeaders
+                                  and the request is
+
+                                  not credentialed, the `Access-Control-Allow-Headers`
+                                  response header
+
+                                  can either use the `*` wildcard or the value of
+
+                                  Access-Control-Request-Headers from the request.
+
+
+                                  When the request is credentialed, the gateway must
+                                  not specify the `*`
+
+                                  wildcard in the `Access-Control-Allow-Headers` response
+                                  header. When
+
+                                  also the `AllowCredentials` field is true and `AllowHeaders`
+                                  field
+
+                                  is specified with the `*` wildcard, the gateway
+                                  must specify one or more
+
+                                  HTTP headers in the value of the `Access-Control-Allow-Headers`
+                                  response
+
+                                  header. The value of the header `Access-Control-Allow-Headers`
+                                  is same as
+
+                                  the `Access-Control-Request-Headers` header provided
+                                  by the client. If
+
+                                  the header `Access-Control-Request-Headers` is not
+                                  included in the
+
+                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+
+                                  response header, instead of specifying the `*` wildcard.
+
+
+                                  Support: Extended'
+                                items:
+                                  description: "HTTPHeaderName is the name of an HTTP\
+                                    \ header.\n\nValid values include:\n\n* \"Authorization\"\
+                                    \n* \"Set-Cookie\"\n\nInvalid values include:\n\
+                                    \n  - \":method\" - \":\" is an invalid character.\
+                                    \ This means that HTTP/2 pseudo\n    headers are\
+                                    \ not currently supported by this type.\n  - \"\
+                                    /invalid\" - \"/ \" is an invalid character"
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowHeaders cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowMethods:
+                                description: 'AllowMethods indicates which HTTP methods
+                                  are supported for accessing the
+
+                                  requested resource.
+
+
+                                  Valid values are any method defined by RFC9110,
+                                  along with the special
+
+                                  value `*`, which represents all HTTP methods are
+                                  allowed.
+
+
+                                  Method names are case-sensitive, so these values
+                                  are also case-sensitive.
+
+                                  (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+
+                                  Multiple method names in the value of the `Access-Control-Allow-Methods`
+
+                                  response header are separated by a comma (",").
+
+
+                                  A CORS-safelisted method is a method that is `GET`,
+                                  `HEAD`, or `POST`.
+
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-method)
+                                  The
+
+                                  CORS-safelisted methods are always allowed, regardless
+                                  of whether they
+
+                                  are specified in the `AllowMethods` field.
+
+
+                                  When the `AllowMethods` field is configured with
+                                  one or more methods, the
+
+                                  gateway must return the `Access-Control-Allow-Methods`
+                                  response header
+
+                                  which value is present in the `AllowMethods` field.
+
+
+                                  If the HTTP method of the `Access-Control-Request-Method`
+                                  request header
+
+                                  is not included in the list of methods specified
+                                  by the response header
+
+                                  `Access-Control-Allow-Methods`, it will present
+                                  an error on the client
+
+                                  side.
+
+
+                                  If config contains the wildcard "*" in allowMethods
+                                  and the request is
+
+                                  not credentialed, the `Access-Control-Allow-Methods`
+                                  response header
+
+                                  can either use the `*` wildcard or the value of
+
+                                  Access-Control-Request-Method from the request.
+
+
+                                  When the request is credentialed, the gateway must
+                                  not specify the `*`
+
+                                  wildcard in the `Access-Control-Allow-Methods` response
+                                  header. When
+
+                                  also the `AllowCredentials` field is true and `AllowMethods`
+                                  field
+
+                                  specified with the `*` wildcard, the gateway must
+                                  specify one HTTP method
+
+                                  in the value of the Access-Control-Allow-Methods
+                                  response header. The
+
+                                  value of the header `Access-Control-Allow-Methods`
+                                  is same as the
+
+                                  `Access-Control-Request-Method` header provided
+                                  by the client. If the
+
+                                  header `Access-Control-Request-Method` is not included
+                                  in the request,
+
+                                  the gateway will omit the `Access-Control-Allow-Methods`
+                                  response header,
+
+                                  instead of specifying the `*` wildcard.
+
+
+                                  Support: Extended'
+                                items:
+                                  enum:
+                                  - GET
+                                  - HEAD
+                                  - POST
+                                  - PUT
+                                  - DELETE
+                                  - CONNECT
+                                  - OPTIONS
+                                  - TRACE
+                                  - PATCH
+                                  - '*'
+                                  type: string
+                                maxItems: 9
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowMethods cannot contain '*' alongside
+                                    other methods
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              allowOrigins:
+                                description: "AllowOrigins indicates whether the response\
+                                  \ can be shared with requested\nresource from the\
+                                  \ given `Origin`.\n\nThe `Origin` consists of a\
+                                  \ scheme and a host, with an optional port, and\n\
+                                  takes the form `<scheme>://<host>(:<port>)`.\n\n\
+                                  Valid values for scheme are: `http` and `https`.\n\
+                                  \nValid values for port are any integer between\
+                                  \ 1 and 65535 (the list of\navailable TCP/UDP ports).\
+                                  \ Note that, if not included, port `80` is\nassumed\
+                                  \ for `http` scheme origins, and port `443` is assumed\
+                                  \ for `https`\norigins. This may affect origin matching.\n\
+                                  \nThe host part of the origin may contain the wildcard\
+                                  \ character `*`. These\nwildcard characters behave\
+                                  \ as follows:\n\n* `*` is a greedy match to the\
+                                  \ _left_, including any number of\n  DNS labels\
+                                  \ to the left of its position. This also means that\n\
+                                  \  `*` will include any number of period `.` characters\
+                                  \ to the\n  left of its position.\n* A wildcard\
+                                  \ by itself matches all hosts.\n\nAn origin value\
+                                  \ that includes _only_ the `*` character indicates\
+                                  \ requests\nfrom all `Origin`s are allowed.\n\n\
+                                  When the `AllowOrigins` field is configured with\
+                                  \ multiple origins, it\nmeans the server supports\
+                                  \ clients from multiple origins. If the request\n\
+                                  `Origin` matches the configured allowed origins,\
+                                  \ the gateway must return\nthe given `Origin` and\
+                                  \ sets value of the header\n`Access-Control-Allow-Origin`\
+                                  \ same as the `Origin` header provided by the\n\
+                                  client.\n\nThe status code of a successful response\
+                                  \ to a \"preflight\" request is\nalways an OK status\
+                                  \ (i.e., 204 or 200).\n\nIf the request `Origin`\
+                                  \ does not match the configured allowed origins,\n\
+                                  the gateway returns 204/200 response but doesn't\
+                                  \ set the relevant\ncross-origin response headers.\
+                                  \ Alternatively, the gateway responds with\n403\
+                                  \ status to the \"preflight\" request is denied,\
+                                  \ coupled with omitting\nthe CORS headers. The cross-origin\
+                                  \ request fails on the client side.\nTherefore,\
+                                  \ the client doesn't attempt the actual cross-origin\
+                                  \ request.\n\nConversely, if the request `Origin`\
+                                  \ matches one of the configured\nallowed origins,\
+                                  \ the gateway sets the response header\n`Access-Control-Allow-Origin`\
+                                  \ to the same value as the `Origin`\nheader provided\
+                                  \ by the client.\n\nWhen config has the wildcard\
+                                  \ (\"*\") in allowOrigins, and the request\nis not\
+                                  \ credentialed (e.g., it is a preflight request),\
+                                  \ the\n`Access-Control-Allow-Origin` response header\
+                                  \ either contains the\nwildcard as well or the Origin\
+                                  \ from the request.\n\nWhen the request is credentialed,\
+                                  \ the gateway must not specify the `*`\nwildcard\
+                                  \ in the `Access-Control-Allow-Origin` response\
+                                  \ header. When\nalso the `AllowCredentials` field\
+                                  \ is true and `AllowOrigins` field\nspecified with\
+                                  \ the `*` wildcard, the gateway must return a single\
+                                  \ origin\nin the value of the `Access-Control-Allow-Origin`\
+                                  \ response header,\ninstead of specifying the `*`\
+                                  \ wildcard. The value of the header\n`Access-Control-Allow-Origin`\
+                                  \ is same as the `Origin` header provided by\nthe\
+                                  \ client.\n\nSupport: Extended"
+                                items:
+                                  description: 'The CORSOrigin MUST NOT be a relative
+                                    URI, and it MUST follow the URI syntax and
+
+                                    encoding rules specified in RFC3986.  The CORSOrigin
+                                    MUST include both a
+
+                                    scheme ("http" or "https") and a scheme-specific-part,
+                                    or it should be a single ''*'' character.
+
+                                    URIs that include an authority MUST include a
+                                    fully qualified domain name or
+
+                                    IP address as the host.'
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: (^\*$)|(^(http(s)?):\/\/(((\*\.)?([a-zA-Z0-9\-]+\.)*[a-zA-Z0-9-]+|\*)(:([0-9]{1,5}))?)$)
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: AllowOrigins cannot contain '*' alongside
+                                    other origins
+                                  rule: '!(''*'' in self && self.size() > 1)'
+                              exposeHeaders:
+                                description: 'ExposeHeaders indicates which HTTP response
+                                  headers can be exposed
+
+                                  to client-side scripts in response to a cross-origin
+                                  request.
+
+
+                                  A CORS-safelisted response header is an HTTP header
+                                  in a CORS response
+
+                                  that it is considered safe to expose to the client
+                                  scripts.
+
+                                  The CORS-safelisted response headers include the
+                                  following headers:
+
+                                  `Cache-Control`
+
+                                  `Content-Language`
+
+                                  `Content-Length`
+
+                                  `Content-Type`
+
+                                  `Expires`
+
+                                  `Last-Modified`
+
+                                  `Pragma`
+
+                                  (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+
+                                  The CORS-safelisted response headers are exposed
+                                  to client by default.
+
+
+                                  When an HTTP header name is specified using the
+                                  `ExposeHeaders` field,
+
+                                  this additional header will be exposed as part of
+                                  the response to the
+
+                                  client.
+
+
+                                  Header names are not case-sensitive.
+
+
+                                  Multiple header names in the value of the `Access-Control-Expose-Headers`
+
+                                  response header are separated by a comma (",").
+
+
+                                  A wildcard indicates that the responses with all
+                                  HTTP headers are exposed
+
+                                  to clients. The `Access-Control-Expose-Headers`
+                                  response header can only
+
+                                  use `*` wildcard as value when the request is not
+                                  credentialed.
+
+
+                                  When the `exposeHeaders` config field contains the
+                                  "*" wildcard and
+
+                                  the request is credentialed, the gateway cannot
+                                  use the `*` wildcard in
+
+                                  the `Access-Control-Expose-Headers` response header.
+
+
+                                  Support: Extended'
+                                items:
+                                  description: "HTTPHeaderName is the name of an HTTP\
+                                    \ header.\n\nValid values include:\n\n* \"Authorization\"\
+                                    \n* \"Set-Cookie\"\n\nInvalid values include:\n\
+                                    \n  - \":method\" - \":\" is an invalid character.\
+                                    \ This means that HTTP/2 pseudo\n    headers are\
+                                    \ not currently supported by this type.\n  - \"\
+                                    /invalid\" - \"/ \" is an invalid character"
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                maxItems: 64
+                                type: array
+                                x-kubernetes-list-type: set
+                              maxAge:
+                                default: 5
+                                description: 'MaxAge indicates the duration (in seconds)
+                                  for the client to cache the
+
+                                  results of a "preflight" request.
+
+
+                                  The information provided by the `Access-Control-Allow-Methods`
+                                  and
+
+                                  `Access-Control-Allow-Headers` response headers
+                                  can be cached by the
+
+                                  client until the time specified by `Access-Control-Max-Age`
+                                  elapses.
+
+
+                                  The default value of `Access-Control-Max-Age` response
+                                  header is 5
+
+                                  (seconds).
+
+
+                                  When the `MaxAge` field is unspecified, the gateway
+                                  sets the response
+
+                                  header "Access-Control-Max-Age: 5" by default.'
+                                format: int32
+                                minimum: 1
+                                type: integer
+                            type: object
+                          extensionRef:
+                            description: 'ExtensionRef is an optional, implementation-specific
+                              extension to the
+
+                              "filter" behavior.  For example, resource "myroutefilter"
+                              in group
+
+                              "networking.example.net"). ExtensionRef MUST NOT be
+                              used for core and
+
+                              extended filters.
+
+
+                              This filter can be used multiple times within the same
+                              rule.
+
+
+                              Support: Implementation-specific'
+                            properties:
+                              group:
+                                description: 'Group is the group of the referent.
+                                  For example, "gateway.networking.k8s.io".
+
+                                  When unspecified or empty string, core API group
+                                  is inferred.'
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: 'RequestHeaderModifier defines a schema for
+                              a filter that modifies request
+
+                              headers.
+
+
+                              Support: Core'
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,\
+                                  \ value) to the request\nbefore the action. It appends\
+                                  \ to any existing values associated\nwith the header\
+                                  \ name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                  \ foo\n\nConfig:\n  add:\n  - name: \"my-header\"\
+                                  \n    value: \"bar,baz\"\n\nOutput:\n  GET /foo\
+                                  \ HTTP/1.1\n  my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the\
+                                  \ HTTP request before the action. The\nvalue of\
+                                  \ Remove is a list of HTTP header names. Note that\
+                                  \ the header\nnames are case-insensitive (see\n\
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n\
+                                  \  my-header2: bar\n  my-header3: baz\n\nConfig:\n\
+                                  \  remove: [\"my-header1\", \"my-header3\"]\n\n\
+                                  Output:\n  GET /foo HTTP/1.1\n  my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the\
+                                  \ given header (name, value)\nbefore the action.\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\
+                                  \nConfig:\n  set:\n  - name: \"my-header\"\n   \
+                                  \ value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                  \  my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: 'RequestMirror defines a schema for a filter
+                              that mirrors requests.
+
+                              Requests are sent to the specified destination, but
+                              responses from
+
+                              that destination are ignored.
+
+
+                              This filter can be used multiple times within the same
+                              rule. Note that
+
+                              not all implementations will be able to support mirroring
+                              to multiple
+
+                              backends.
+
+
+                              Support: Extended'
+                            properties:
+                              backendRef:
+                                description: 'BackendRef references a resource where
+                                  mirrored requests are sent.
+
+
+                                  Mirrored requests must be sent only to a single
+                                  destination endpoint
+
+                                  within this BackendRef, irrespective of how many
+                                  endpoints are present
+
+                                  within this BackendRef.
+
+
+                                  If the referent cannot be found, this BackendRef
+                                  is invalid and must be
+
+                                  dropped from the Gateway. The controller must ensure
+                                  the "ResolvedRefs"
+
+                                  condition on the Route status is set to `status:
+                                  False` and not configure
+
+                                  this backend in the underlying implementation.
+
+
+                                  If there is a cross-namespace reference to an *existing*
+                                  object
+
+                                  that is not allowed by a ReferenceGrant, the controller
+                                  must ensure the
+
+                                  "ResolvedRefs"  condition on the Route is set to
+                                  `status: False`,
+
+                                  with the "RefNotPermitted" reason and not configure
+                                  this backend in the
+
+                                  underlying implementation.
+
+
+                                  In either error case, the Message of the `ResolvedRefs`
+                                  Condition
+
+                                  should be used to provide more detail about the
+                                  problem.
+
+
+                                  Support: Extended for Kubernetes Service
+
+
+                                  Support: Implementation-specific for any other resource'
+                                properties:
+                                  group:
+                                    default: ''
+                                    description: 'Group is the group of the referent.
+                                      For example, "gateway.networking.k8s.io".
+
+                                      When unspecified or empty string, core API group
+                                      is inferred.'
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: 'Kind is the Kubernetes resource
+                                      kind of the referent. For example
+
+                                      "Service".
+
+
+                                      Defaults to "Service" when not specified.
+
+
+                                      ExternalName services can refer to CNAME DNS
+                                      records that may live
+
+                                      outside of the cluster and as such are difficult
+                                      to reason about in
+
+                                      terms of conformance. They also may not be safe
+                                      to forward to (see
+
+                                      CVE-2021-25740 for more information). Implementations
+                                      SHOULD NOT
+
+                                      support ExternalName Services.
+
+
+                                      Support: Core (Services with a type other than
+                                      ExternalName)
+
+
+                                      Support: Implementation-specific (Services with
+                                      type ExternalName)'
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace is the namespace of the
+                                      backend. When unspecified, the local
+
+                                      namespace is inferred.
+
+
+                                      Note that when a namespace different than the
+                                      local namespace is specified,
+
+                                      a ReferenceGrant object is required in the referent
+                                      namespace to allow that
+
+                                      namespace''s owner to accept the reference.
+                                      See the ReferenceGrant
+
+                                      documentation for details.
+
+
+                                      Support: Core'
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: 'Port specifies the destination port
+                                      number to use for this resource.
+
+                                      Port is required when the referent is a Kubernetes
+                                      Service. In this
+
+                                      case, the port number is the service port number,
+                                      not the target port.
+
+                                      For other resources, destination port might
+                                      be derived from the referent
+
+                                      resource or this field.'
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                              fraction:
+                                description: 'Fraction represents the fraction of
+                                  requests that should be
+
+                                  mirrored to BackendRef.
+
+
+                                  Only one of Fraction or Percent may be specified.
+                                  If neither field
+
+                                  is specified, 100% of requests will be mirrored.'
+                                properties:
+                                  denominator:
+                                    default: 100
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                  numerator:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                required:
+                                - numerator
+                                type: object
+                                x-kubernetes-validations:
+                                - message: numerator must be less than or equal to
+                                    denominator
+                                  rule: self.numerator <= self.denominator
+                              percent:
+                                description: 'Percent represents the percentage of
+                                  requests that should be
+
+                                  mirrored to BackendRef. Its minimum value is 0 (indicating
+                                  0% of
+
+                                  requests) and its maximum value is 100 (indicating
+                                  100% of requests).
+
+
+                                  Only one of Fraction or Percent may be specified.
+                                  If neither field
+
+                                  is specified, 100% of requests will be mirrored.'
+                                format: int32
+                                maximum: 100
+                                minimum: 0
+                                type: integer
+                            required:
+                            - backendRef
+                            type: object
+                            x-kubernetes-validations:
+                            - message: Only one of percent or fraction may be specified
+                                in HTTPRequestMirrorFilter
+                              rule: '!(has(self.percent) && has(self.fraction))'
+                          requestRedirect:
+                            description: 'RequestRedirect defines a schema for a filter
+                              that responds to the
+
+                              request with an HTTP redirection.
+
+
+                              Support: Core'
+                            properties:
+                              hostname:
+                                description: 'Hostname is the hostname to be used
+                                  in the value of the `Location`
+
+                                  header in the response.
+
+                                  When empty, the hostname in the `Host` header of
+                                  the request is used.
+
+
+                                  Support: Core'
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: 'Path defines parameters used to modify
+                                  the path of the incoming request.
+
+                                  The modified path is then used to construct the
+                                  `Location` header. When
+
+                                  empty, the request path is used as-is.
+
+
+                                  Support: Extended'
+                                properties:
+                                  replaceFullPath:
+                                    description: 'ReplaceFullPath specifies the value
+                                      with which to replace the full path
+
+                                      of a request during a rewrite or redirect.'
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: 'ReplacePrefixMatch specifies the
+                                      value with which to replace the prefix
+
+                                      match of a request during a rewrite or redirect.
+                                      For example, a request
+
+                                      to "/foo/bar" with a prefix match of "/foo"
+                                      and a ReplacePrefixMatch
+
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+
+                                      Note that this matches the behavior of the PathPrefix
+                                      match type. This
+
+                                      matches full path elements. A path element refers
+                                      to the list of labels
+
+                                      in the path split by the `/` separator. When
+                                      specified, a trailing `/` is
+
+                                      ignored. For example, the paths `/abc`, `/abc/`,
+                                      and `/abc/def` would all
+
+                                      match the prefix `/abc`, but the path `/abcd`
+                                      would not.
+
+
+                                      ReplacePrefixMatch is only compatible with a
+                                      `PathPrefix` HTTPRouteMatch.
+
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in
+
+                                      the implementation setting the Accepted Condition
+                                      for the Route to `status: False`.
+
+
+                                      Request Path | Prefix Match | Replace Prefix
+                                      | Modified Path'
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: 'Type defines the type of path modifier.
+                                      Additional types may be
+
+                                      added in a future release of the API.
+
+
+                                      Note that values may be added to this enum,
+                                      implementations
+
+                                      must ensure that unknown values will not cause
+                                      a crash.
+
+
+                                      Unknown values here must result in the implementation
+                                      setting the
+
+                                      Accepted Condition for the Route to `status:
+                                      False`, with a
+
+                                      Reason of `UnsupportedValue`.'
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                              port:
+                                description: "Port is the port to be used in the value\
+                                  \ of the `Location`\nheader in the response.\n\n\
+                                  If no port is specified, the redirect port MUST\
+                                  \ be derived using the\nfollowing rules:\n\n* If\
+                                  \ redirect scheme is not-empty, the redirect port\
+                                  \ MUST be the well-known\n  port associated with\
+                                  \ the redirect scheme. Specifically \"http\" to\
+                                  \ port 80\n  and \"https\" to port 443. If the redirect\
+                                  \ scheme does not have a\n  well-known port, the\
+                                  \ listener port of the Gateway SHOULD be used.\n\
+                                  * If redirect scheme is empty, the redirect port\
+                                  \ MUST be the Gateway\n  Listener port.\n\nImplementations\
+                                  \ SHOULD NOT add the port number in the 'Location'\n\
+                                  header in the following cases:\n\n* A Location header\
+                                  \ that will use HTTP (whether that is determined\
+                                  \ via\n  the Listener protocol or the Scheme field)\
+                                  \ _and_ use port 80.\n* A Location header that will\
+                                  \ use HTTPS (whether that is determined via\n  the\
+                                  \ Listener protocol or the Scheme field) _and_ use\
+                                  \ port 443.\n\nSupport: Extended"
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: 'Scheme is the scheme to be used in the
+                                  value of the `Location` header in
+
+                                  the response. When empty, the scheme of the request
+                                  is used.
+
+
+                                  Scheme redirects can affect the port of the redirect,
+                                  for more information,
+
+                                  refer to the documentation for the port field of
+                                  this filter.
+
+
+                                  Note that values may be added to this enum, implementations
+
+                                  must ensure that unknown values will not cause a
+                                  crash.
+
+
+                                  Unknown values here must result in the implementation
+                                  setting the
+
+                                  Accepted Condition for the Route to `status: False`,
+                                  with a
+
+                                  Reason of `UnsupportedValue`.
+
+
+                                  Support: Extended'
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: 'StatusCode is the HTTP status code to
+                                  be used in response.
+
+
+                                  Note that values may be added to this enum, implementations
+
+                                  must ensure that unknown values will not cause a
+                                  crash.
+
+
+                                  Unknown values here must result in the implementation
+                                  setting the
+
+                                  Accepted Condition for the Route to `status: False`,
+                                  with a
+
+                                  Reason of `UnsupportedValue`.
+
+
+                                  Support: Core'
+                                enum:
+                                - 301
+                                - 302
+                                - 303
+                                - 307
+                                - 308
+                                type: integer
+                            type: object
+                          responseHeaderModifier:
+                            description: 'ResponseHeaderModifier defines a schema
+                              for a filter that modifies response
+
+                              headers.
+
+
+                              Support: Extended'
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,\
+                                  \ value) to the request\nbefore the action. It appends\
+                                  \ to any existing values associated\nwith the header\
+                                  \ name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header:\
+                                  \ foo\n\nConfig:\n  add:\n  - name: \"my-header\"\
+                                  \n    value: \"bar,baz\"\n\nOutput:\n  GET /foo\
+                                  \ HTTP/1.1\n  my-header: foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the\
+                                  \ HTTP request before the action. The\nvalue of\
+                                  \ Remove is a list of HTTP header names. Note that\
+                                  \ the header\nnames are case-insensitive (see\n\
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n\
+                                  \  my-header2: bar\n  my-header3: baz\n\nConfig:\n\
+                                  \  remove: [\"my-header1\", \"my-header3\"]\n\n\
+                                  Output:\n  GET /foo HTTP/1.1\n  my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: "Set overwrites the request with the\
+                                  \ given header (name, value)\nbefore the action.\n\
+                                  \nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\
+                                  \nConfig:\n  set:\n  - name: \"my-header\"\n   \
+                                  \ value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n\
+                                  \  my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: 'Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be
+
+                                        case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header
+                                        names, the first entry with
+
+                                        an equivalent name MUST be considered for
+                                        a match. Subsequent entries
+
+                                        with an equivalent header name MUST be ignored.
+                                        Due to the
+
+                                        case-insensitivity of header names, "foo"
+                                        and "Foo" are considered
+
+                                        equivalent.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.\
+                              \ As with other API fields,\ntypes are classified into\
+                              \ three conformance levels:\n\n- Core: Filter types\
+                              \ and their corresponding configuration defined by\n\
+                              \  \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\"\
+                              . All\n  implementations must support core filters.\n\
+                              \n- Extended: Filter types and their corresponding configuration\
+                              \ defined by\n  \"Support: Extended\" in this package,\
+                              \ e.g. \"RequestMirror\". Implementers\n  are encouraged\
+                              \ to support extended filters.\n\n- Implementation-specific:\
+                              \ Filters that are defined and supported by\n  specific\
+                              \ vendors.\n  In the future, filters showing convergence\
+                              \ in behavior across multiple\n  implementations will\
+                              \ be considered for inclusion in extended or core\n\
+                              \  conformance levels. Filter-specific configuration\
+                              \ for such filters\n  is specified using the ExtensionRef\
+                              \ field. `Type` should be set to\n  \"ExtensionRef\"\
+                              \ for custom filters.\n\nImplementers are encouraged\
+                              \ to define custom implementation types to\nextend the\
+                              \ core API with implementation-specific behavior.\n\n\
+                              If a reference to a custom filter type cannot be resolved,\
+                              \ the filter\nMUST NOT be skipped. Instead, requests\
+                              \ that would have been processed by\nthat filter MUST\
+                              \ receive a HTTP error response.\n\nNote that values\
+                              \ may be added to this enum, implementations\nmust ensure\
+                              \ that unknown values will not cause a crash.\n\nUnknown\
+                              \ values here must result in the implementation setting\
+                              \ the\nAccepted Condition for the Route to `status:\
+                              \ False`, with a\nReason of `UnsupportedValue`."
+                            enum:
+                            - RequestHeaderModifier
+                            - ResponseHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - URLRewrite
+                            - ExtensionRef
+                            - CORS
+                            type: string
+                          urlRewrite:
+                            description: 'URLRewrite defines a schema for a filter
+                              that modifies a request during forwarding.
+
+
+                              Support: Extended'
+                            properties:
+                              hostname:
+                                description: 'Hostname is the value to be used to
+                                  replace the Host header value during
+
+                                  forwarding.
+
+
+                                  Support: Extended'
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              path:
+                                description: 'Path defines a path rewrite.
+
+
+                                  Support: Extended'
+                                properties:
+                                  replaceFullPath:
+                                    description: 'ReplaceFullPath specifies the value
+                                      with which to replace the full path
+
+                                      of a request during a rewrite or redirect.'
+                                    maxLength: 1024
+                                    type: string
+                                  replacePrefixMatch:
+                                    description: 'ReplacePrefixMatch specifies the
+                                      value with which to replace the prefix
+
+                                      match of a request during a rewrite or redirect.
+                                      For example, a request
+
+                                      to "/foo/bar" with a prefix match of "/foo"
+                                      and a ReplacePrefixMatch
+
+                                      of "/xyz" would be modified to "/xyz/bar".
+
+
+                                      Note that this matches the behavior of the PathPrefix
+                                      match type. This
+
+                                      matches full path elements. A path element refers
+                                      to the list of labels
+
+                                      in the path split by the `/` separator. When
+                                      specified, a trailing `/` is
+
+                                      ignored. For example, the paths `/abc`, `/abc/`,
+                                      and `/abc/def` would all
+
+                                      match the prefix `/abc`, but the path `/abcd`
+                                      would not.
+
+
+                                      ReplacePrefixMatch is only compatible with a
+                                      `PathPrefix` HTTPRouteMatch.
+
+                                      Using any other HTTPRouteMatch type on the same
+                                      HTTPRouteRule will result in
+
+                                      the implementation setting the Accepted Condition
+                                      for the Route to `status: False`.
+
+
+                                      Request Path | Prefix Match | Replace Prefix
+                                      | Modified Path'
+                                    maxLength: 1024
+                                    type: string
+                                  type:
+                                    description: 'Type defines the type of path modifier.
+                                      Additional types may be
+
+                                      added in a future release of the API.
+
+
+                                      Note that values may be added to this enum,
+                                      implementations
+
+                                      must ensure that unknown values will not cause
+                                      a crash.
+
+
+                                      Unknown values here must result in the implementation
+                                      setting the
+
+                                      Accepted Condition for the Route to `status:
+                                      False`, with a
+
+                                      Reason of `UnsupportedValue`.'
+                                    enum:
+                                    - ReplaceFullPath
+                                    - ReplacePrefixMatch
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: replaceFullPath must be specified when
+                                    type is set to 'ReplaceFullPath'
+                                  rule: 'self.type == ''ReplaceFullPath'' ? has(self.replaceFullPath)
+                                    : true'
+                                - message: type must be 'ReplaceFullPath' when replaceFullPath
+                                    is set
+                                  rule: 'has(self.replaceFullPath) ? self.type ==
+                                    ''ReplaceFullPath'' : true'
+                                - message: replacePrefixMatch must be specified when
+                                    type is set to 'ReplacePrefixMatch'
+                                  rule: 'self.type == ''ReplacePrefixMatch'' ? has(self.replacePrefixMatch)
+                                    : true'
+                                - message: type must be 'ReplacePrefixMatch' when
+                                    replacePrefixMatch is set
+                                  rule: 'has(self.replacePrefixMatch) ? self.type
+                                    == ''ReplacePrefixMatch'' : true'
+                            type: object
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.cors must be nil if the filter.type is not
+                            CORS
+                          rule: '!(has(self.cors) && self.type != ''CORS'')'
+                        - message: filter.cors must be specified for CORS filter.type
+                          rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.requestRedirect must be nil if the filter.type
+                            is not RequestRedirect
+                          rule: '!(has(self.requestRedirect) && self.type != ''RequestRedirect'')'
+                        - message: filter.requestRedirect must be specified for RequestRedirect
+                            filter.type
+                          rule: '!(!has(self.requestRedirect) && self.type == ''RequestRedirect'')'
+                        - message: filter.urlRewrite must be nil if the filter.type
+                            is not URLRewrite
+                          rule: '!(has(self.urlRewrite) && self.type != ''URLRewrite'')'
+                        - message: filter.urlRewrite must be specified for URLRewrite
+                            filter.type
+                          rule: '!(!has(self.urlRewrite) && self.type == ''URLRewrite'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: atomic
+                      x-kubernetes-validations:
+                      - message: May specify either httpRouteFilterRequestRedirect
+                          or httpRouteFilterRequestRewrite, but not both
+                        rule: '!(self.exists(f, f.type == ''RequestRedirect'') &&
+                          self.exists(f, f.type == ''URLRewrite''))'
+                      - message: CORS filter cannot be repeated
+                        rule: self.filter(f, f.type == 'CORS').size() <= 1
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                      - message: RequestRedirect filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestRedirect').size() <=
+                          1
+                      - message: URLRewrite filter cannot be repeated
+                        rule: self.filter(f, f.type == 'URLRewrite').size() <= 1
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: "Matches define conditions used for matching the\
+                        \ rule against incoming\nHTTP requests. Each match is independent,\
+                        \ i.e. this rule will be matched\nif **any** one of the matches\
+                        \ is satisfied.\n\nFor example, take the following matches\
+                        \ configuration:\n\n```\nmatches:\n- path:\n    value: \"\
+                        /foo\"\n  headers:\n  - name: \"version\"\n    value: \"v2\"\
+                        \n- path:\n    value: \"/v2/foo\"\n```\n\nFor a request to\
+                        \ match against this rule, a request must satisfy\nEITHER\
+                        \ of the two conditions:\n\n- path prefixed with `/foo` AND\
+                        \ contains the header `version: v2`\n- path prefix of `/v2/foo`\n\
+                        \nSee the documentation for HTTPRouteMatch on how to specify\
+                        \ multiple\nmatch conditions that should be ANDed together.\n\
+                        \nIf no matches are specified, the default is a prefix\npath\
+                        \ match on \"/\", which has the effect of matching every\n\
+                        HTTP request.\n\nProxy or Load Balancer routing configuration\
+                        \ generated from HTTPRoutes\nMUST prioritize matches based\
+                        \ on the following criteria, continuing on\nties. Across all\
+                        \ rules specified on applicable Routes, precedence must be\n\
+                        given to the match having:\n\n* \"Exact\" path match.\n* \"\
+                        Prefix\" path match with largest number of characters.\n*\
+                        \ Method match.\n* Largest number of header matches.\n* Largest\
+                        \ number of query param matches.\n\nNote: The precedence of\
+                        \ RegularExpression path matches are implementation-specific.\n\
+                        \nIf ties still exist across multiple Routes, matching precedence\
+                        \ MUST be\ndetermined in order of the following criteria,\
+                        \ continuing on ties:\n\n* The oldest Route based on creation\
+                        \ timestamp.\n* The Route appearing first in alphabetical\
+                        \ order by\n  \"{namespace}/{name}\".\n\nIf ties still exist\
+                        \ within an HTTPRoute, matching precedence MUST be granted\n\
+                        to the FIRST matching rule (in list order) with a match meeting\
+                        \ the above\ncriteria.\n\nWhen no rules matching a request\
+                        \ have been successfully attached to the\nparent a request\
+                        \ is coming from, a HTTP 404 status code MUST be returned."
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to\
+                          \ match requests to a given\naction. Multiple match types\
+                          \ are ANDed together, i.e. the match will\nevaluate to true\
+                          \ only if all conditions are satisfied.\n\nFor example,\
+                          \ the match below will match a HTTP request only if its\
+                          \ path\nstarts with `/foo` AND it contains the `version:\
+                          \ v1` header:\n\n```\nmatch:\n\n\tpath:\n\t  value: \"/foo\"\
+                          \n\theaders:\n\t- name: \"version\"\n\t  value \"v1\"\n\n\
+                          ```"
+                        properties:
+                          headers:
+                            description: 'Headers specifies HTTP request header matchers.
+                              Multiple match values are
+
+                              ANDed together, meaning, a request must match all the
+                              specified headers
+
+                              to select the route.'
+                            items:
+                              description: 'HTTPHeaderMatch describes how to select
+                                a HTTP route by matching HTTP request
+
+                                headers.'
+                              properties:
+                                name:
+                                  description: 'Name is the name of the HTTP Header
+                                    to be matched. Name matching MUST be
+
+                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                    If multiple entries specify equivalent header
+                                    names, only the first
+
+                                    entry with an equivalent name MUST be considered
+                                    for a match. Subsequent
+
+                                    entries with an equivalent header name MUST be
+                                    ignored. Due to the
+
+                                    case-insensitivity of header names, "foo" and
+                                    "Foo" are considered
+
+                                    equivalent.
+
+
+                                    When a header is repeated in an HTTP request,
+                                    it is
+
+                                    implementation-specific behavior as to how this
+                                    is represented.
+
+                                    Generally, proxies should follow the guidance
+                                    from the RFC:
+
+                                    https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                    regarding
+
+                                    processing a repeated header, with special handling
+                                    for "Set-Cookie".'
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: 'Type specifies how to match against
+                                    the value of the header.
+
+
+                                    Support: Core (Exact)
+
+
+                                    Support: Implementation-specific (RegularExpression)
+
+
+                                    Since RegularExpression HeaderMatchType has implementation-specific
+
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects
+
+                                    of regular expressions. Please read the implementation''s
+                                    documentation to
+
+                                    determine the supported dialect.'
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: 'Method specifies HTTP method matcher.
+
+                              When specified, this route will be matched only if the
+                              request has the
+
+                              specified method.
+
+
+                              Support: Extended'
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: 'Path specifies a HTTP request path matcher.
+                              If this field is not
+
+                              specified, a default prefix match on the "/" path is
+                              provided.'
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: 'Type specifies how to match against
+                                  the path Value.
+
+
+                                  Support: Core (Exact, PathPrefix)
+
+
+                                  Support: Implementation-specific (RegularExpression)'
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: value must be an absolute path and start with
+                                '/' when type one of ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.startsWith(''/'')
+                                : true'
+                            - message: must not contain '//' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''//'')
+                                : true'
+                            - message: must not contain '/./' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/./'')
+                                : true'
+                            - message: must not contain '/../' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''/../'')
+                                : true'
+                            - message: must not contain '%2f' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2f'')
+                                : true'
+                            - message: must not contain '%2F' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''%2F'')
+                                : true'
+                            - message: must not contain '#' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.contains(''#'')
+                                : true'
+                            - message: must not end with '/..' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/..'')
+                                : true'
+                            - message: must not end with '/.' when type one of ['Exact',
+                                'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? !self.value.endsWith(''/.'')
+                                : true'
+                            - message: type must be one of ['Exact', 'PathPrefix',
+                                'RegularExpression']
+                              rule: self.type in ['Exact','PathPrefix'] || self.type
+                                == 'RegularExpression'
+                            - message: must only contain valid characters (matching
+                                ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                for types ['Exact', 'PathPrefix']
+                              rule: '(self.type in [''Exact'',''PathPrefix'']) ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                : true'
+                          queryParams:
+                            description: 'QueryParams specifies HTTP query parameter
+                              matchers. Multiple match
+
+                              values are ANDed together, meaning, a request must match
+                              all the
+
+                              specified query parameters to select the route.
+
+
+                              Support: Extended'
+                            items:
+                              description: 'HTTPQueryParamMatch describes how to select
+                                a HTTP route by matching HTTP
+
+                                query parameters.'
+                              properties:
+                                name:
+                                  description: 'Name is the name of the HTTP query
+                                    param to be matched. This must be an
+
+                                    exact string match. (See
+
+                                    https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                    If multiple entries specify equivalent query param
+                                    names, only the first
+
+                                    entry with an equivalent name MUST be considered
+                                    for a match. Subsequent
+
+                                    entries with an equivalent query param name MUST
+                                    be ignored.
+
+
+                                    If a query param is repeated in an HTTP request,
+                                    the behavior is
+
+                                    purposely left undefined, since different data
+                                    planes have different
+
+                                    capabilities. However, it is *recommended* that
+                                    implementations should
+
+                                    match against the first value of the param if
+                                    the data plane supports it,
+
+                                    as this behavior is expected in other load balancing
+                                    contexts outside of
+
+                                    the Gateway API.
+
+
+                                    Users SHOULD NOT route traffic based on repeated
+                                    query params to guard
+
+                                    themselves against potential differences in the
+                                    implementations.'
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: 'Type specifies how to match against
+                                    the value of the query parameter.
+
+
+                                    Support: Extended (Exact)
+
+
+                                    Support: Implementation-specific (RegularExpression)
+
+
+                                    Since RegularExpression QueryParamMatchType has
+                                    Implementation-specific
+
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other
+
+                                    dialects of regular expressions. Please read the
+                                    implementation''s
+
+                                    documentation to determine the supported dialect.'
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 64
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: 'Name is the name of the route rule. This name
+                        MUST be unique within a Route if it is set.
+
+
+                        Support: Extended'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    timeouts:
+                      description: 'Timeouts defines the timeouts that can be configured
+                        for an HTTP request.
+
+
+                        Support: Extended'
+                      properties:
+                        backendRequest:
+                          description: 'BackendRequest specifies a timeout for an
+                            individual request from the gateway
+
+                            to a backend. This covers the time from when the request
+                            first starts being
+
+                            sent from the gateway to when the full response has been
+                            received from the backend.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD
+                            disable the timeout
+
+                            completely. Implementations that cannot completely disable
+                            the timeout MUST
+
+                            instead interpret the zero duration as the longest possible
+                            value to which
+
+                            the timeout can be set.
+
+
+                            An entire client HTTP transaction with a gateway, covered
+                            by the Request timeout,
+
+                            may result in more than one call from the gateway to the
+                            destination backend,
+
+                            for example, if automatic retries are supported.
+
+
+                            The value of BackendRequest must be a Gateway API Duration
+                            string as defined by
+
+                            GEP-2257.  When this field is unspecified, its behavior
+                            is implementation-specific;
+
+                            when specified, the value of BackendRequest must be no
+                            more than the value of the
+
+                            Request timeout (since the Request timeout encompasses
+                            the BackendRequest timeout).
+
+
+                            Support: Extended'
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        request:
+                          description: 'Request specifies the maximum duration for
+                            a gateway to respond to an HTTP request.
+
+                            If the gateway has not been able to respond before this
+                            deadline is met, the gateway
+
+                            MUST return a timeout error.
+
+
+                            For example, setting the `rules.timeouts.request` field
+                            to the value `10s` in an
+
+                            `HTTPRoute` will cause a timeout if a client request is
+                            taking longer than 10 seconds
+
+                            to complete.
+
+
+                            Setting a timeout to the zero duration (e.g. "0s") SHOULD
+                            disable the timeout
+
+                            completely. Implementations that cannot completely disable
+                            the timeout MUST
+
+                            instead interpret the zero duration as the longest possible
+                            value to which
+
+                            the timeout can be set.
+
+
+                            This timeout is intended to cover as close to the whole
+                            request-response transaction
+
+                            as possible although an implementation MAY choose to start
+                            the timeout after the entire
+
+                            request stream has been received instead of immediately
+                            after the transaction is
+
+                            initiated by the client.
+
+
+                            The value of Request is a Gateway API Duration string
+                            as defined by GEP-2257. When this
+
+                            field is unspecified, request timeout behavior is implementation-specific.
+
+
+                            Support: Extended'
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: backendRequest timeout cannot be longer than request
+                          timeout
+                        rule: '!(has(self.request) && has(self.backendRequest) &&
+                          duration(self.request) != duration(''0s'') && duration(self.backendRequest)
+                          > duration(self.request))'
+                  type: object
+                  x-kubernetes-validations:
+                  - message: RequestRedirect filter must not be used together with
+                      backendRefs
+                    rule: '(has(self.backendRefs) && size(self.backendRefs) > 0) ?
+                      (!has(self.filters) || self.filters.all(f, !has(f.requestRedirect))):
+                      true'
+                  - message: When using RequestRedirect filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      ? ((size(self.matches) != 1 || !has(self.matches[0].path) ||
+                      self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: When using URLRewrite filter with path.replacePrefixMatch,
+                      exactly one PathPrefix match must be specified
+                    rule: '(has(self.filters) && self.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                  - message: Within backendRefs, when using RequestRedirect filter
+                      with path.replacePrefixMatch, exactly one PathPrefix match must
+                      be specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.requestRedirect)
+                      && has(f.requestRedirect.path) && f.requestRedirect.path.type
+                      == ''ReplacePrefixMatch'' && has(f.requestRedirect.path.replacePrefixMatch)))
+                      )) ? ((size(self.matches) != 1 || !has(self.matches[0].path)
+                      || self.matches[0].path.type != ''PathPrefix'') ? false : true)
+                      : true'
+                  - message: Within backendRefs, When using URLRewrite filter with
+                      path.replacePrefixMatch, exactly one PathPrefix match must be
+                      specified
+                    rule: '(has(self.backendRefs) && self.backendRefs.exists_one(b,
+                      (has(b.filters) && b.filters.exists_one(f, has(f.urlRewrite)
+                      && has(f.urlRewrite.path) && f.urlRewrite.path.type == ''ReplacePrefixMatch''
+                      && has(f.urlRewrite.path.replacePrefixMatch))) )) ? ((size(self.matches)
+                      != 1 || !has(self.matches[0].path) || self.matches[0].path.type
+                      != ''PathPrefix'') ? false : true) : true'
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: While 16 rules and 64 matches per rule are allowed, the
+                    total number of matches across all rules in a route must be less
+                    than 128
+                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
+                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
+                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
+                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
+                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
+                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
+                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
+                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
+                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
+                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
+                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_listenersets.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_listenersets.yaml
@@ -1,0 +1,980 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: listenersets.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: ListenerSet
+    listKind: ListenerSetList
+    plural: listenersets
+    shortNames:
+    - lset
+    singular: listenerset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ListenerSet defines a set of additional listeners to attach\
+          \ to an existing Gateway.\nThis resource provides a mechanism to merge multiple\
+          \ listeners into a single Gateway.\n\nThe parent Gateway must explicitly\
+          \ allow ListenerSet attachment through its\nAllowedListeners configuration.\
+          \ By default, Gateways do not allow ListenerSet\nattachment.\n\nRoutes can\
+          \ attach to a ListenerSet by specifying it as a parentRef, and can\noptionally\
+          \ target specific listeners using the sectionName field.\n\nPolicy Attachment:\n\
+          - Policies that attach to a ListenerSet apply to all listeners defined in\
+          \ that resource\n- Policies do not impact listeners in the parent Gateway\n\
+          - Different ListenerSets attached to the same Gateway can have different\
+          \ policies\n- If an implementation cannot apply a policy to specific listeners,\
+          \ it should reject the policy\n\nReferenceGrant Semantics:\n- ReferenceGrants\
+          \ applied to a Gateway are not inherited by child ListenerSets\n- ReferenceGrants\
+          \ applied to a ListenerSet do not grant permission to the parent Gateway's\
+          \ listeners\n- A ListenerSet can reference secrets/backends in its own namespace\
+          \ without a ReferenceGrant\n\nGateway Integration:\n  - The parent Gateway's\
+          \ status will include \"AttachedListenerSets\"\n    which is the count of\
+          \ ListenerSets that have successfully attached to a Gateway\n    A ListenerSet\
+          \ is successfully attached to a Gateway when all the following conditions\
+          \ are met:\n  - The ListenerSet is selected by the Gateway's AllowedListeners\
+          \ field\n  - The ListenerSet has a valid ParentRef selecting the Gateway\n\
+          \  - The ListenerSet's status has the condition \"Accepted: true\""
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ListenerSet.
+            properties:
+              listeners:
+                description: 'Listeners associated with this ListenerSet. Listeners
+                  define
+
+                  logical endpoints that are bound on this referenced parent Gateway''s
+                  addresses.
+
+
+                  Listeners in a `Gateway` and their attached `ListenerSets` are concatenated
+
+                  as a list when programming the underlying infrastructure. Each listener
+
+                  name does not need to be unique across the Gateway and ListenerSets.
+
+                  See ListenerEntry.Name for more details.
+
+
+                  Implementations MUST treat the parent Gateway as having the merged
+
+                  list of all listeners from itself and attached ListenerSets using
+
+                  the following precedence:
+
+
+                  1. "parent" Gateway
+
+                  2. ListenerSet ordered by creation time (oldest first)
+
+                  3. ListenerSet ordered alphabetically by "{namespace}/{name}".
+
+
+                  An implementation MAY reject listeners by setting the ListenerEntryStatus
+
+                  `Accepted` condition to False with the Reason `TooManyListeners`
+
+
+                  If a listener has a conflict, this will be reported in the
+
+                  Status.ListenerEntryStatus setting the `Conflicted` condition to
+                  True.
+
+
+                  Implementations SHOULD be cautious about what information from the
+
+                  parent or siblings are reported to avoid accidentally leaking
+
+                  sensitive information that the child would not otherwise have access
+
+                  to. This can include contents of secrets etc.'
+                items:
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: "AllowedRoutes defines the types of routes that\
+                        \ MAY be attached to a\nListener and the trusted namespaces\
+                        \ where those Route resources MAY be\npresent.\n\nAlthough\
+                        \ a client request may match multiple route rules, only one\
+                        \ rule\nmay ultimately receive the request. Matching precedence\
+                        \ MUST be\ndetermined in order of the following criteria:\n\
+                        \n* The most specific match as defined by the Route type.\n\
+                        * The oldest Route based on creation timestamp. For example,\
+                        \ a Route with\n  a creation timestamp of \"2020-09-08 01:02:03\"\
+                        \ is given precedence over\n  a Route with a creation timestamp\
+                        \ of \"2020-09-08 01:02:04\".\n* If everything else is equivalent,\
+                        \ the Route appearing first in\n  alphabetical order (namespace/name)\
+                        \ should be given precedence. For\n  example, foo/bar is given\
+                        \ precedence over foo/baz.\n\nAll valid rules within a Route\
+                        \ attached to this Listener should be\nimplemented. Invalid\
+                        \ Route rules can be ignored (sometimes that will mean\nthe\
+                        \ full Route). If a Route rule transitions from valid to invalid,\n\
+                        support for that Route rule should be dropped to ensure consistency.\
+                        \ For\nexample, even if a filter specified by a Route rule\
+                        \ is invalid, the rest\nof the rules within that Route should\
+                        \ still be supported."
+                      properties:
+                        kinds:
+                          description: 'Kinds specifies the groups and kinds of Routes
+                            that are allowed to bind
+
+                            to this Gateway Listener. When unspecified or empty, the
+                            kinds of Routes
+
+                            selected are determined using the Listener protocol.
+
+
+                            A RouteGroupKind MUST correspond to kinds of Routes that
+                            are compatible
+
+                            with the application protocol specified in the Listener''s
+                            Protocol field.
+
+                            If an implementation does not support or recognize this
+                            resource type, it
+
+                            MUST set the "ResolvedRefs" condition to False for this
+                            Listener with the
+
+                            "InvalidRouteKinds" reason.
+
+
+                            Support: Core'
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        namespaces:
+                          default:
+                            from: Same
+                          description: 'Namespaces indicates namespaces from which
+                            Routes may be attached to this
+
+                            Listener. This is restricted to the namespace of this
+                            Gateway by default.
+
+
+                            Support: Core'
+                          properties:
+                            from:
+                              default: Same
+                              description: "From indicates where Routes will be selected\
+                                \ for this Gateway. Possible\nvalues are:\n\n* All:\
+                                \ Routes in all namespaces may be used by this Gateway.\n\
+                                * Selector: Routes in namespaces selected by the selector\
+                                \ may be used by\n  this Gateway.\n* Same: Only Routes\
+                                \ in the same namespace may be used by this Gateway.\n\
+                                \nSupport: Core"
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: 'Selector must be specified when From is
+                                set to "Selector". In that case,
+
+                                only Routes in Namespaces matching this Selector will
+                                be selected by this
+
+                                Gateway. This field is ignored for other values of
+                                "From".
+
+
+                                Support: Core'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: 'A label selector requirement is
+                                      a selector that contains values, a key, and
+                                      an operator that
+
+                                      relates the key and values.'
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: 'operator represents a key''s
+                                          relationship to a set of values.
+
+                                          Valid operators are In, NotIn, Exists and
+                                          DoesNotExist.'
+                                        type: string
+                                      values:
+                                        description: 'values is an array of string
+                                          values. If the operator is In or NotIn,
+
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist,
+
+                                          the values array must be empty. This array
+                                          is replaced during a strategic
+
+                                          merge patch.'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the
+
+                                    operator is "In", and the values array contains
+                                    only "value". The requirements are ANDed.'
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    hostname:
+                      description: "Hostname specifies the virtual hostname to match\
+                        \ for protocol types that\ndefine this concept. When unspecified,\
+                        \ all hostnames are matched. This\nfield is ignored for protocols\
+                        \ that don't require hostname based\nmatching.\n\nImplementations\
+                        \ MUST apply Hostname matching appropriately for each of\n\
+                        the following protocols:\n\n* TLS: The Listener Hostname MUST\
+                        \ match the SNI.\n* HTTP: The Listener Hostname MUST match\
+                        \ the Host header of the request.\n* HTTPS: The Listener Hostname\
+                        \ SHOULD match at both the TLS and HTTP\n  protocol layers\
+                        \ as described above. If an implementation does not\n  ensure\
+                        \ that both the SNI and Host header match the Listener hostname,\n\
+                        \  it MUST clearly document that.\n\nFor HTTPRoute and TLSRoute\
+                        \ resources, there is an interaction with the\n`spec.hostnames`\
+                        \ array. When both listener and route specify hostnames,\n\
+                        there MUST be an intersection between the values for a Route\
+                        \ to be\naccepted. For more information, refer to the Route\
+                        \ specific Hostnames\ndocumentation.\n\nHostnames that are\
+                        \ prefixed with a wildcard label (`*.`) are interpreted\n\
+                        as a suffix match. That means that a match for `*.example.com`\
+                        \ would match\nboth `test.example.com`, and `foo.test.example.com`,\
+                        \ but not `example.com`."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: 'Name is the name of the Listener. This name MUST
+                        be unique within a
+
+                        ListenerSet.
+
+
+                        Name is not required to be unique across a Gateway and ListenerSets.
+
+                        Routes can attach to a Listener by having a ListenerSet as
+                        a parentRef
+
+                        and setting the SectionName'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: 'Port is the network port. Multiple listeners may
+                        use the
+
+                        same port, subject to the Listener compatibility rules.'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: Protocol specifies the network protocol this listener
+                        expects to receive.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: 'TLS is the TLS configuration for the Listener.
+                        This field is required if
+
+                        the Protocol field is "HTTPS" or "TLS". It is invalid to set
+                        this field
+
+                        if the Protocol field is "HTTP", "TCP", or "UDP".
+
+
+                        The association of SNIs to Certificate defined in ListenerTLSConfig
+                        is
+
+                        defined based on the Hostname field for this listener.
+
+
+                        The GatewayClass MUST use the longest matching SNI out of
+                        all
+
+                        available certificates for any TLS handshake.'
+                      properties:
+                        certificateRefs:
+                          description: 'CertificateRefs contains a series of references
+                            to Kubernetes objects that
+
+                            contains TLS certificates and private keys. These certificates
+                            are used to
+
+                            establish a TLS handshake for requests that match the
+                            hostname of the
+
+                            associated listener.
+
+
+                            A single CertificateRef to a Kubernetes Secret has "Core"
+                            support.
+
+                            Implementations MAY choose to support attaching multiple
+                            certificates to
+
+                            a Listener, but this behavior is implementation-specific.
+
+
+                            References to a resource in different namespace are invalid
+                            UNLESS there
+
+                            is a ReferenceGrant in the target namespace that allows
+                            the certificate
+
+                            to be attached. If a ReferenceGrant does not allow this
+                            reference, the
+
+                            "ResolvedRefs" condition MUST be set to False for this
+                            listener with the
+
+                            "RefNotPermitted" reason.
+
+
+                            This field is required to have at least one element when
+                            the mode is set
+
+                            to "Terminate" (default) and is optional otherwise.
+
+
+                            CertificateRefs can reference to standard Kubernetes resources,
+                            i.e.
+
+                            Secret, or implementation-specific custom resources.
+
+
+                            Support: Core - A single reference to a Kubernetes Secret
+                            of type kubernetes.io/tls
+
+
+                            Support: Implementation-specific (More than one reference
+                            or other resource types)'
+                          items:
+                            description: 'SecretObjectReference identifies an API
+                              object including its namespace,
+
+                              defaulting to Secret.
+
+
+                              The API object must be valid in the cluster; the Group
+                              and Kind must
+
+                              be registered in the cluster for this reference to be
+                              valid.
+
+
+                              References to objects with invalid Group and Kind are
+                              not valid, and must
+
+                              be rejected by the implementation, with appropriate
+                              Conditions set
+
+                              on the containing object.'
+                            properties:
+                              group:
+                                default: ''
+                                description: 'Group is the group of the referent.
+                                  For example, "gateway.networking.k8s.io".
+
+                                  When unspecified or empty string, core API group
+                                  is inferred.'
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "Secret".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: 'Namespace is the namespace of the referenced
+                                  object. When unspecified, the local
+
+                                  namespace is inferred.
+
+
+                                  Note that when a namespace different than the local
+                                  namespace is specified,
+
+                                  a ReferenceGrant object is required in the referent
+                                  namespace to allow that
+
+                                  namespace''s owner to accept the reference. See
+                                  the ReferenceGrant
+
+                                  documentation for details.
+
+
+                                  Support: Core'
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        mode:
+                          default: Terminate
+                          description: "Mode defines the TLS behavior for the TLS\
+                            \ session initiated by the client.\nThere are two possible\
+                            \ modes:\n\n- Terminate: The TLS session between the downstream\
+                            \ client and the\n  Gateway is terminated at the Gateway.\
+                            \ This mode requires certificates\n  to be specified in\
+                            \ some way, such as populating the certificateRefs\n \
+                            \ field.\n- Passthrough: The TLS session is NOT terminated\
+                            \ by the Gateway. This\n  implies that the Gateway can't\
+                            \ decipher the TLS stream except for\n  the ClientHello\
+                            \ message of the TLS protocol. The certificateRefs field\n\
+                            \  is ignored in this mode.\n\nSupport: Core"
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: 'AnnotationValue is the value of an annotation
+                              in Gateway API. This is used
+
+                              for validation of maps such as TLS options. This roughly
+                              matches Kubernetes
+
+                              annotation validation, although the length validation
+                              in that case is based
+
+                              on the entire size of the annotations struct.'
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: 'Options are a list of key/value pairs to enable
+                            extended TLS
+
+                            configuration for each implementation. For example, configuring
+                            the
+
+                            minimum TLS version or supported cipher suites.
+
+
+                            A set of common keys MAY be defined by the API in the
+                            future. To avoid
+
+                            any ambiguity, implementation-specific definitions MUST
+                            use
+
+                            domain-prefixed names, such as `example.com/my-custom-option`.
+
+                            Un-prefixed names are reserved for key names defined by
+                            Gateway API.
+
+
+                            Support: Implementation-specific'
+                          maxProperties: 16
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                      - message: certificateRefs or options must be specified when
+                          mode is Terminate
+                        rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs)
+                          > 0 || size(self.options) > 0 : true'
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: tls must not be specified for protocols ['HTTP', 'TCP',
+                    'UDP']
+                  rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ?
+                    !has(l.tls) : true)'
+                - message: tls mode must be Terminate for protocol HTTPS
+                  rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode
+                    == '''' || l.tls.mode == ''Terminate'') : true)'
+                - message: tls mode must be set for protocol TLS
+                  rule: 'self.all(l, (l.protocol == ''TLS'' ? has(l.tls) && has(l.tls.mode)
+                    && l.tls.mode != '''' : true))'
+                - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                  rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname)
+                    || l.hostname == '''') : true)'
+                - message: Listener name must be unique within the Gateway
+                  rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                - message: Combination of port, protocol and hostname must be unique
+                    for each listener
+                  rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port)
+                    && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname)
+                    && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname)
+                    && !has(l2.hostname))))'
+              parentRef:
+                description: ParentRef references the Gateway that the listeners are
+                  attached to.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    default: Gateway
+                    description: Kind is kind of the referent. For example "Gateway".
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: 'Namespace is the namespace of the referent.  If
+                      not present,
+
+                      the namespace of the referent is assumed to be the same as
+
+                      the namespace of the referring object.'
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - listeners
+            - parentRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status defines the current state of ListenerSet.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: 'Conditions describe the current conditions of the ListenerSet.
+
+
+                  Implementations MUST express ListenerSet conditions using the
+
+                  `ListenerSetConditionType` and `ListenerSetConditionReason`
+
+                  constants so that operators and tools can converge on a common
+
+                  vocabulary to describe ListenerSet state.
+
+
+                  Known condition types are:
+
+
+                  * "Accepted"
+
+                  * "Programmed"'
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: 'AttachedRoutes represents the total number of
+                        Routes that have been
+
+                        successfully attached to this Listener.
+
+
+                        Successful attachment of a Route to a Listener is based solely
+                        on the
+
+                        combination of the AllowedRoutes field on the corresponding
+                        Listener
+
+                        and the Route''s ParentRefs field. A Route is successfully
+                        attached to
+
+                        a Listener when it is selected by the Listener''s AllowedRoutes
+                        field
+
+                        AND the Route has a valid ParentRef selecting the whole Gateway
+
+                        resource or a specific Listener as a parent resource (more
+                        detail on
+
+                        attachment semantics can be found in the documentation on
+                        the various
+
+                        Route kinds ParentRefs fields). Listener status does not impact
+
+                        successful attachment, i.e. the AttachedRoutes field count
+                        MUST be set
+
+                        for Listeners, even if the Accepted condition of an individual
+                        Listener is set
+
+                        to "False". The AttachedRoutes number represents the number
+                        of Routes with
+
+                        the Accepted condition set to "True" that have been attached
+                        to this Listener.
+
+                        Routes with any other value for the Accepted condition MUST
+                        NOT be included
+
+                        in this count.
+
+
+                        Uses for this field include troubleshooting Route attachment
+                        and
+
+                        measuring blast radius/impact of changes to a Listener.'
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: 'SupportedKinds is the list indicating the Kinds
+                        supported by this
+
+                        listener. This MUST represent the kinds supported by an implementation
+                        for
+
+                        that Listener configuration.
+
+
+                        If kinds are specified in Spec that are not supported, they
+                        MUST NOT
+
+                        appear in this list and an implementation MUST set the "ResolvedRefs"
+
+                        condition to "False" with the "InvalidRouteKinds" reason.
+                        If both valid
+
+                        and invalid Route kinds are specified, the implementation
+                        MUST
+
+                        reference the valid Route kinds that have been specified.'
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_referencegrants.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_referencegrants.yaml
@@ -1,0 +1,463 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: referencegrants.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: ReferenceGrant
+    listKind: ReferenceGrantList
+    plural: referencegrants
+    shortNames:
+    - refgrant
+    singular: referencegrant
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'ReferenceGrant identifies kinds of resources in other namespaces
+          that are
+
+          trusted to reference the specified kinds of resources in the same namespace
+
+          as the policy.
+
+
+          Each ReferenceGrant can be used to represent a unique trust relationship.
+
+          Additional Reference Grants can be used to add to the set of trusted
+
+          sources of inbound references for the namespace they are defined within.
+
+
+          All cross-namespace references in Gateway API (with the exception of cross-namespace
+
+          Gateway-route attachment) require a ReferenceGrant.
+
+
+          ReferenceGrant is a form of runtime verification allowing users to assert
+
+          which cross-namespace object references are permitted. Implementations that
+
+          support ReferenceGrant MUST NOT permit cross-namespace references which
+          have
+
+          no grant, and MUST respond to the removal of a grant by revoking the access
+
+          that the grant allowed.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: 'From describes the trusted namespaces and kinds that
+                  can reference the
+
+                  resources described in "To". Each entry in this list MUST be considered
+
+                  to be an additional place that references can be valid from, or
+                  to put
+
+                  this another way, entries MUST be combined using OR.
+
+
+                  Support: Core'
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: 'Group is the group of the referent.
+
+                        When empty, the Kubernetes core API group is inferred.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: 'Kind is the kind of the referent. Although implementations
+                        may support
+
+                        additional resources, the following types are part of the
+                        "Core"
+
+                        support level for this field.
+
+
+                        When used to permit a SecretObjectReference:
+
+
+                        * Gateway
+
+
+                        When used to permit a BackendObjectReference:
+
+
+                        * GRPCRoute
+
+                        * HTTPRoute
+
+                        * TCPRoute
+
+                        * TLSRoute
+
+                        * UDPRoute'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              to:
+                description: 'To describes the resources that may be referenced by
+                  the resources
+
+                  described in "From". Each entry in this list MUST be considered
+                  to be an
+
+                  additional place that references can be valid to, or to put this
+                  another
+
+                  way, entries MUST be combined using OR.
+
+
+                  Support: Core'
+                items:
+                  description: 'ReferenceGrantTo describes what Kinds are allowed
+                    as targets of the
+
+                    references.'
+                  properties:
+                    group:
+                      description: 'Group is the group of the referent.
+
+                        When empty, the Kubernetes core API group is inferred.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: 'Kind is the kind of the referent. Although implementations
+                        may support
+
+                        additional resources, the following types are part of the
+                        "Core"
+
+                        support level for this field:
+
+
+                        * Secret when used to permit a SecretObjectReference
+
+                        * Service when used to permit a BackendObjectReference'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent. When unspecified,
+                        this policy
+
+                        refers to all resources of the specified Group and Kind in
+                        the local
+
+                        namespace.'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: 'ReferenceGrant identifies kinds of resources in other namespaces
+          that are
+
+          trusted to reference the specified kinds of resources in the same namespace
+
+          as the policy.
+
+
+          Each ReferenceGrant can be used to represent a unique trust relationship.
+
+          Additional Reference Grants can be used to add to the set of trusted
+
+          sources of inbound references for the namespace they are defined within.
+
+
+          All cross-namespace references in Gateway API (with the exception of cross-namespace
+
+          Gateway-route attachment) require a ReferenceGrant.
+
+
+          ReferenceGrant is a form of runtime verification allowing users to assert
+
+          which cross-namespace object references are permitted. Implementations that
+
+          support ReferenceGrant MUST NOT permit cross-namespace references which
+          have
+
+          no grant, and MUST respond to the removal of a grant by revoking the access
+
+          that the grant allowed.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: 'From describes the trusted namespaces and kinds that
+                  can reference the
+
+                  resources described in "To". Each entry in this list MUST be considered
+
+                  to be an additional place that references can be valid from, or
+                  to put
+
+                  this another way, entries MUST be combined using OR.
+
+
+                  Support: Core'
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: 'Group is the group of the referent.
+
+                        When empty, the Kubernetes core API group is inferred.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: 'Kind is the kind of the referent. Although implementations
+                        may support
+
+                        additional resources, the following types are part of the
+                        "Core"
+
+                        support level for this field.
+
+
+                        When used to permit a SecretObjectReference:
+
+
+                        * Gateway
+
+
+                        When used to permit a BackendObjectReference:
+
+
+                        * GRPCRoute
+
+                        * HTTPRoute
+
+                        * TCPRoute
+
+                        * TLSRoute
+
+                        * UDPRoute'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              to:
+                description: 'To describes the resources that may be referenced by
+                  the resources
+
+                  described in "From". Each entry in this list MUST be considered
+                  to be an
+
+                  additional place that references can be valid to, or to put this
+                  another
+
+                  way, entries MUST be combined using OR.
+
+
+                  Support: Core'
+                items:
+                  description: 'ReferenceGrantTo describes what Kinds are allowed
+                    as targets of the
+
+                    references.'
+                  properties:
+                    group:
+                      description: 'Group is the group of the referent.
+
+                        When empty, the Kubernetes core API group is inferred.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: 'Kind is the kind of the referent. Although implementations
+                        may support
+
+                        additional resources, the following types are part of the
+                        "Core"
+
+                        support level for this field:
+
+
+                        * Secret when used to permit a SecretObjectReference
+
+                        * Service when used to permit a BackendObjectReference'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent. When unspecified,
+                        this policy
+
+                        refers to all resources of the specified Group and Kind in
+                        the local
+
+                        namespace.'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_tlsroutes.yaml
@@ -1,0 +1,3051 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: standard
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'The TLSRoute resource is similar to TCPRoute, but can be configured
+
+          to match against TLS-specific metadata. This allows more flexibility
+
+          in matching streams for a given TLS listener.
+
+
+          If you need to forward traffic to a single target for a TLS listener, you
+
+          could choose to use a TCPRoute with a TLS listener.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of SNI hostnames that should\
+                  \ match against the\nSNI attribute of TLS ClientHello message in\
+                  \ TLS handshake. This matches\nthe RFC 1123 definition of a hostname\
+                  \ with 2 notable exceptions:\n\n1. IPs are not allowed in SNI hostnames\
+                  \ per RFC 6066.\n2. A hostname may be prefixed with a wildcard label\
+                  \ (`*.`). The wildcard\n   label must appear by itself as the first\
+                  \ label."
+                items:
+                  description: "Hostname is the fully qualified domain name of a network\
+                    \ host. This matches\nthe RFC 1123 definition of a hostname with\
+                    \ 2 notable exceptions:\n\n 1. IPs are not allowed.\n 2. A hostname\
+                    \ may be prefixed with a wildcard label (`*.`). The wildcard\n\
+                    \    label must appear by itself as the first label.\n\nHostname\
+                    \ can be \"precise\" which is a domain name without the terminating\n\
+                    dot of a network host (e.g. \"foo.example.com\") or \"wildcard\"\
+                    , which is a\ndomain name prefixed with a single wildcard label\
+                    \ (e.g. `*.example.com`).\n\nNote that as per RFC1035 and RFC1123,\
+                    \ a *label* must consist of lower case\nalphanumeric characters\
+                    \ or '-', and must start and end with an alphanumeric\ncharacter.\
+                    \ No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Hostnames cannot contain an IP
+                  rule: self.all(h, !isIP(h))
+                - message: Hostnames must be valid based on RFC-1123
+                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                    : true)'
+                - message: Wildcards on hostnames must be the first label, and the
+                    rest of hostname must be valid based on RFC-1123
+                  rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
+                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    : true)'
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: Rules are a list of actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent. If unspecified or invalid (refers to a nonexistent resource
+                        or
+
+                        a Service with no endpoints), the rule performs no forwarding;
+                        if no
+
+                        filters are specified that would result in a response being
+                        sent, the
+
+                        underlying implementation must actively reject request attempts
+                        to this
+
+                        backend, by rejecting the connection. Request rejections must
+                        respect
+
+                        weight; if an invalid backend is requested to have 80% of
+                        requests, then
+
+                        80% of requests must be rejected instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended'
+                      items:
+                        description: 'BackendRef defines how a Route should forward
+                          a request to a Kubernetes
+
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by
+                          the implementation,
+
+                          there are some extra rules about validity to consider here.
+                          See the fields
+
+                          where this struct is used for more information about the
+                          exact behavior.'
+                        properties:
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - hostnames
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of TLSRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: 'The TLSRoute resource is similar to TCPRoute, but can be configured
+
+          to match against TLS-specific metadata. This allows more flexibility
+
+          in matching streams for a given TLS listener.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of SNI names that should match\
+                  \ against the\nSNI attribute of TLS ClientHello message in TLS handshake.\
+                  \ This matches\nthe RFC 1123 definition of a hostname with 2 notable\
+                  \ exceptions:\n\n1. IPs are not allowed in SNI names per RFC 6066.\n\
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The\
+                  \ wildcard\n   label must appear by itself as the first label.\n\
+                  \nIf a hostname is specified by both the Listener and TLSRoute,\
+                  \ there\nmust be at least one intersecting hostname for the TLSRoute\
+                  \ to be\nattached to the Listener. For example:\n\n* A Listener\
+                  \ with `test.example.com` as the hostname matches TLSRoutes\n  that\
+                  \ have either not specified any hostnames, or have specified at\n\
+                  \  least one of `test.example.com` or `*.example.com`.\n* A Listener\
+                  \ with `*.example.com` as the hostname matches TLSRoutes\n  that\
+                  \ have either not specified any hostnames or have specified at least\n\
+                  \  one hostname that matches the Listener hostname. For example,\n\
+                  \  `test.example.com` and `*.example.com` would both match. On the\
+                  \ other\n  hand, `example.com` and `test.example.net` would not\
+                  \ match.\n\nIf both the Listener and TLSRoute have specified hostnames,\
+                  \ any\nTLSRoute hostnames that do not match the Listener hostname\
+                  \ MUST be\nignored. For example, if a Listener specified `*.example.com`,\
+                  \ and the\nTLSRoute specified `test.example.com` and `test.example.net`,\n\
+                  `test.example.net` must not be considered for a match.\n\nIf both\
+                  \ the Listener and TLSRoute have specified hostnames, and none\n\
+                  match with the criteria above, then the TLSRoute is not accepted.\
+                  \ The\nimplementation must raise an 'Accepted' Condition with a\
+                  \ status of\n`False` in the corresponding RouteParentStatus.\n\n\
+                  Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network\
+                    \ host. This matches\nthe RFC 1123 definition of a hostname with\
+                    \ 2 notable exceptions:\n\n 1. IPs are not allowed.\n 2. A hostname\
+                    \ may be prefixed with a wildcard label (`*.`). The wildcard\n\
+                    \    label must appear by itself as the first label.\n\nHostname\
+                    \ can be \"precise\" which is a domain name without the terminating\n\
+                    dot of a network host (e.g. \"foo.example.com\") or \"wildcard\"\
+                    , which is a\ndomain name prefixed with a single wildcard label\
+                    \ (e.g. `*.example.com`).\n\nNote that as per RFC1035 and RFC1123,\
+                    \ a *label* must consist of lower case\nalphanumeric characters\
+                    \ or '-', and must start and end with an alphanumeric\ncharacter.\
+                    \ No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent. If unspecified or invalid (refers to a nonexistent resource
+                        or
+
+                        a Service with no endpoints), the rule performs no forwarding;
+                        if no
+
+                        filters are specified that would result in a response being
+                        sent, the
+
+                        underlying implementation must actively reject request attempts
+                        to this
+
+                        backend, by rejecting the connection. Request rejections must
+                        respect
+
+                        weight; if an invalid backend is requested to have 80% of
+                        requests, then
+
+                        80% of requests must be rejected instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended'
+                      items:
+                        description: 'BackendRef defines how a Route should forward
+                          a request to a Kubernetes
+
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by
+                          the implementation,
+
+                          there are some extra rules about validity to consider here.
+                          See the fields
+
+                          where this struct is used for more information about the
+                          exact behavior.'
+                        properties:
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha3 version of TLSRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: 'The TLSRoute resource is similar to TCPRoute, but can be configured
+
+          to match against TLS-specific metadata. This allows more flexibility
+
+          in matching streams for a given TLS listener.
+
+
+          If you need to forward traffic to a single target for a TLS listener, you
+
+          could choose to use a TCPRoute with a TLS listener.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of SNI hostnames that should\
+                  \ match against the\nSNI attribute of TLS ClientHello message in\
+                  \ TLS handshake. This matches\nthe RFC 1123 definition of a hostname\
+                  \ with 2 notable exceptions:\n\n1. IPs are not allowed in SNI hostnames\
+                  \ per RFC 6066.\n2. A hostname may be prefixed with a wildcard label\
+                  \ (`*.`). The wildcard\n   label must appear by itself as the first\
+                  \ label."
+                items:
+                  description: "Hostname is the fully qualified domain name of a network\
+                    \ host. This matches\nthe RFC 1123 definition of a hostname with\
+                    \ 2 notable exceptions:\n\n 1. IPs are not allowed.\n 2. A hostname\
+                    \ may be prefixed with a wildcard label (`*.`). The wildcard\n\
+                    \    label must appear by itself as the first label.\n\nHostname\
+                    \ can be \"precise\" which is a domain name without the terminating\n\
+                    dot of a network host (e.g. \"foo.example.com\") or \"wildcard\"\
+                    , which is a\ndomain name prefixed with a single wildcard label\
+                    \ (e.g. `*.example.com`).\n\nNote that as per RFC1035 and RFC1123,\
+                    \ a *label* must consist of lower case\nalphanumeric characters\
+                    \ or '-', and must start and end with an alphanumeric\ncharacter.\
+                    \ No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Hostnames cannot contain an IP
+                  rule: self.all(h, !isIP(h))
+                - message: Hostnames must be valid based on RFC-1123
+                  rule: 'self.all(h, !h.contains(''*'') ? h.matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$'')
+                    : true)'
+                - message: Wildcards on hostnames must be the first label, and the
+                    rest of hostname must be valid based on RFC-1123
+                  rule: 'self.all(h, h.contains(''*'') ? (h.startsWith(''*.'') &&
+                    h.substring(2).matches(''^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)$''))
+                    : true)'
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''')) : true))'
+                - message: sectionName must be unique when parentRefs includes 2 or
+                    more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName))))
+              rules:
+                description: Rules are a list of actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent. If unspecified or invalid (refers to a nonexistent resource
+                        or
+
+                        a Service with no endpoints), the rule performs no forwarding;
+                        if no
+
+                        filters are specified that would result in a response being
+                        sent, the
+
+                        underlying implementation must actively reject request attempts
+                        to this
+
+                        backend, by rejecting the connection. Request rejections must
+                        respect
+
+                        weight; if an invalid backend is requested to have 80% of
+                        requests, then
+
+                        80% of requests must be rejected instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended'
+                      items:
+                        description: 'BackendRef defines how a Route should forward
+                          a request to a Kubernetes
+
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by
+                          the implementation,
+
+                          there are some extra rules about validity to consider here.
+                          See the fields
+
+                          where this struct is used for more information about the
+                          exact behavior.'
+                        properties:
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - hostnames
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.k8s.io_tcproutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.k8s.io_tcproutes.yaml
@@ -1,0 +1,1141 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: experimental
+  name: tcproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: 'TCPRoute provides a way to route TCP requests. When combined
+          with a Gateway
+
+          listener, it can be used to forward connections on the port specified by
+          the
+
+          listener to a set of backends specified by the TCPRoute.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference.\n\n\nParentRefs from a Route\
+                  \ to a Service in the same namespace are \"producer\"\nroutes, which\
+                  \ apply default routing rules to inbound connections from\nany namespace\
+                  \ to the Service.\n\nParentRefs from a Route to a Service in a different\
+                  \ namespace are\n\"consumer\" routes, and these routing rules are\
+                  \ only applied to outbound\nconnections originating from the same\
+                  \ namespace as the Route, for which\nthe intended destination of\
+                  \ the connections are a Service targeted as a\nParentRef of the\
+                  \ Route."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace
+                        are "producer"
+
+                        routes, which apply default routing rules to inbound connections
+                        from
+
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace
+                        are
+
+                        "consumer" routes, and these routing rules are only applied
+                        to outbound
+
+                        connections originating from the same namespace as the Route,
+                        for which
+
+                        the intended destination of the connections are a Service
+                        targeted as a
+
+                        ParentRef of the Route.
+
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+
+                        When the parent resource is a Service, this targets a specific
+                        port in the
+
+                        Service spec. When both Port (experimental) and SectionName
+                        are specified,
+
+                        the name and port of the selected port must match both specified
+                        values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TCP matchers and actions.
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent. If unspecified or invalid (refers to a nonexistent resource
+                        or a
+
+                        Service with no endpoints), the underlying implementation
+                        MUST actively
+
+                        reject connection attempts to this backend. Connection rejections
+                        must
+
+                        respect weight; if an invalid backend is requested to have
+                        80% of
+
+                        connections, then 80% of connections must be rejected instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended'
+                      items:
+                        description: 'BackendRef defines how a Route should forward
+                          a request to a Kubernetes
+
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.
+
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD
+
+                          honor the appProtocol field if it is set for the target
+                          Service Port.
+
+
+                          Implementations supporting appProtocol SHOULD recognize
+                          the Kubernetes
+
+                          Standard Application Protocols defined in KEP-3726.
+
+
+                          If a Service appProtocol isn''t specified, an implementation
+                          MAY infer the
+
+                          backend protocol through its own means. Implementations
+                          MAY infer the
+
+                          protocol from the Route type referring to the backend Service.
+
+
+                          If a Route is not able to send traffic to the backend using
+                          the specified
+
+                          protocol then the backend is considered invalid. Implementations
+                          MUST set the
+
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol"
+                          reason.
+
+
+
+                          Note that when the BackendTLSPolicy object is enabled by
+                          the implementation,
+
+                          there are some extra rules about validity to consider here.
+                          See the fields
+
+                          where this struct is used for more information about the
+                          exact behavior.'
+                        properties:
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: 'Name is the name of the route rule. This name
+                        MUST be unique within a Route if it is set.
+
+
+                        Support: Extended'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+              useDefaultGateways:
+                description: 'UseDefaultGateways indicates the default Gateway scope
+                  to use for this
+
+                  Route. If unset (the default) or set to None, the Route will not
+                  be
+
+                  attached to any default Gateway; if set, it will be attached to
+                  any
+
+                  default Gateway supporting the named scope, subject to the usual
+                  rules
+
+                  about which Routes a Gateway is allowed to claim.
+
+
+                  Think carefully before using this functionality! The set of default
+
+                  Gateways supporting the requested scope can change over time without
+
+                  any notice to the Route author, and in many situations it will not
+                  be
+
+                  appropriate to request a default Gateway for a given Route -- for
+
+                  example, a Route with specific security requirements should almost
+
+                  certainly not use a default Gateway.'
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace
+                            are "producer"
+
+                            routes, which apply default routing rules to inbound connections
+                            from
+
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace
+                            are
+
+                            "consumer" routes, and these routing rules are only applied
+                            to outbound
+
+                            connections originating from the same namespace as the
+                            Route, for which
+
+                            the intended destination of the connections are a Service
+                            targeted as a
+
+                            ParentRef of the Route.
+
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a
+                            specific port in the
+
+                            Service spec. When both Port (experimental) and SectionName
+                            are specified,
+
+                            the name and port of the selected port must match both
+                            specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.k8s.io_udproutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.k8s.io_udproutes.yaml
@@ -1,0 +1,1139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: experimental
+  name: udproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: UDPRoute
+    listKind: UDPRouteList
+    plural: udproutes
+    singular: udproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: 'UDPRoute provides a way to route UDP traffic. When combined
+          with a Gateway
+
+          listener, it can be used to forward traffic on the port specified by the
+
+          listener to a set of backends specified by the UDPRoute.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)\
+                  \ that a Route wants\nto be attached to. Note that the referenced\
+                  \ parent resource needs to\nallow this for the attachment to be\
+                  \ complete. For Gateways, that means\nthe Gateway needs to allow\
+                  \ attachment from Routes of this kind and\nnamespace. For Services,\
+                  \ that means the Service must either be in the same\nnamespace for\
+                  \ a \"producer\" route, or the mesh implementation must support\n\
+                  and allow \"consumer\" routes for the referenced Service. ReferenceGrant\
+                  \ is\nnot applicable for governing ParentRefs to Services - it is\
+                  \ not possible to\ncreate a \"producer\" route for a Service in\
+                  \ a different namespace from the\nRoute.\n\nThere are two kinds\
+                  \ of parent resources with \"Core\" support:\n\n* Gateway (Gateway\
+                  \ conformance profile)\n* Service (Mesh conformance profile, ClusterIP\
+                  \ Services only)\n\nThis API may be extended in the future to support\
+                  \ additional kinds of parent\nresources.\n\nParentRefs must be _distinct_.\
+                  \ This means either that:\n\n* They select different objects.  If\
+                  \ this is the case, then parentRef\n  entries are distinct. In terms\
+                  \ of fields, this means that the\n  multi-part key defined by `group`,\
+                  \ `kind`, `namespace`, and `name` must\n  be unique across all parentRef\
+                  \ entries in the Route.\n* They do not select different objects,\
+                  \ but for each optional field used,\n  each ParentRef that selects\
+                  \ the same object must set the same set of\n  optional fields to\
+                  \ different values. If one ParentRef sets a\n  combination of optional\
+                  \ fields, all must set the same combination.\n\nSome examples:\n\
+                  \n* If one ParentRef sets `sectionName`, all ParentRefs referencing\
+                  \ the\n  same object must also set `sectionName`.\n* If one ParentRef\
+                  \ sets `port`, all ParentRefs referencing the same\n  object must\
+                  \ also set `port`.\n* If one ParentRef sets `sectionName` and `port`,\
+                  \ all ParentRefs\n  referencing the same object must also set `sectionName`\
+                  \ and `port`.\n\nIt is possible to separately reference multiple\
+                  \ distinct objects that may\nbe collapsed by an implementation.\
+                  \ For example, some implementations may\nchoose to merge compatible\
+                  \ Gateway Listeners together. If that is the\ncase, the list of\
+                  \ routes attached to those resources should also be\nmerged.\n\n\
+                  Note that for ParentRefs that cross namespace boundaries, there\
+                  \ are specific\nrules. Cross-namespace references are only valid\
+                  \ if they are explicitly\nallowed by something in the namespace\
+                  \ they are referring to. For example,\nGateway has the AllowedRoutes\
+                  \ field, and ReferenceGrant provides a\ngeneric way to enable other\
+                  \ kinds of cross-namespace reference.\n\n\nParentRefs from a Route\
+                  \ to a Service in the same namespace are \"producer\"\nroutes, which\
+                  \ apply default routing rules to inbound connections from\nany namespace\
+                  \ to the Service.\n\nParentRefs from a Route to a Service in a different\
+                  \ namespace are\n\"consumer\" routes, and these routing rules are\
+                  \ only applied to outbound\nconnections originating from the same\
+                  \ namespace as the Route, for which\nthe intended destination of\
+                  \ the connections are a Service targeted as a\nParentRef of the\
+                  \ Route."
+                items:
+                  description: 'ParentReference identifies an API object (usually
+                    a Gateway) that can be considered
+
+                    a parent of this resource (usually a route). There are two kinds
+                    of parent resources
+
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds
+                    of parent
+
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind
+                    must
+
+                    be registered in the cluster for this reference to be valid.'
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: 'Group is the group of the referent.
+
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                        To set the core API group (such as for a "Service" kind referent),
+
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core'
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: 'Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: 'Name is the name of the referent.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: 'Namespace is the namespace of the referent. When
+                        unspecified, this refers
+
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross
+                        namespace
+
+                        boundaries. Cross-namespace references are only valid if they
+                        are explicitly
+
+                        allowed by something in the namespace they are referring to.
+                        For example:
+
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides
+                        a
+
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace
+                        are "producer"
+
+                        routes, which apply default routing rules to inbound connections
+                        from
+
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace
+                        are
+
+                        "consumer" routes, and these routing rules are only applied
+                        to outbound
+
+                        connections originating from the same namespace as the Route,
+                        for which
+
+                        the intended destination of the connections are a Service
+                        targeted as a
+
+                        ParentRef of the Route.
+
+
+
+                        Support: Core'
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: 'Port is the network port this Route targets. It
+                        can be interpreted
+
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+
+                        listening on the specified port that also support this kind
+                        of Route(and
+
+                        select this Route). It''s not recommended to set `Port` unless
+                        the
+
+                        networking behaviors specified in a Route must apply to a
+                        specific port
+
+                        as opposed to a listener(s) whose port(s) may be changed.
+                        When both Port
+
+                        and SectionName are specified, the name and port of the selected
+                        listener
+
+                        must match both specified values.
+
+
+
+                        When the parent resource is a Service, this targets a specific
+                        port in the
+
+                        Service spec. When both Port (experimental) and SectionName
+                        are specified,
+
+                        the name and port of the selected port must match both specified
+                        values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+
+                        Implementations supporting other types of parent resources
+                        MUST clearly
+
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful
+                        as
+
+                        long as the parent resource accepts it partially. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment
+
+                        from the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route,
+
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: 'SectionName is the name of a section within the
+                        target resource. In the
+
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and
+                        SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+                        * Service: Port name. When both Port (experimental) and SectionName
+
+                        are specified, the name and port of the selected listener
+                        must match
+
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to
+                        other resources.
+
+                        If that is the case, they MUST clearly document how SectionName
+                        is
+
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire
+                        resource.
+
+                        For the purpose of status, an attachment is considered successful
+                        if at
+
+                        least one section in the parent resource accepts it. For example,
+                        Gateway
+
+                        listeners can restrict which Routes can attach to them by
+                        Route kind,
+
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept
+                        attachment from
+
+                        the referencing Route, the Route MUST be considered successfully
+
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the
+
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of UDP matchers and actions.
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: 'BackendRefs defines the backend(s) where matching
+                        requests should be
+
+                        sent. If unspecified or invalid (refers to a nonexistent resource
+                        or a
+
+                        Service with no endpoints), the underlying implementation
+                        MUST actively
+
+                        reject connection attempts to this backend. Packet drops must
+
+                        respect weight; if an invalid backend is requested to have
+                        80% of
+
+                        the packets, then 80% of packets must be dropped instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended'
+                      items:
+                        description: 'BackendRef defines how a Route should forward
+                          a request to a Kubernetes
+
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace
+                          is specified, a
+
+                          ReferenceGrant object is required in the referent namespace
+                          to allow that
+
+                          namespace''s owner to accept the reference. See the ReferenceGrant
+
+                          documentation for details.
+
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations
+                          SHOULD
+
+                          honor the appProtocol field if it is set for the target
+                          Service Port.
+
+
+                          Implementations supporting appProtocol SHOULD recognize
+                          the Kubernetes
+
+                          Standard Application Protocols defined in KEP-3726.
+
+
+                          If a Service appProtocol isn''t specified, an implementation
+                          MAY infer the
+
+                          backend protocol through its own means. Implementations
+                          MAY infer the
+
+                          protocol from the Route type referring to the backend Service.
+
+
+                          If a Route is not able to send traffic to the backend using
+                          the specified
+
+                          protocol then the backend is considered invalid. Implementations
+                          MUST set the
+
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol"
+                          reason.
+
+
+
+                          Note that when the BackendTLSPolicy object is enabled by
+                          the implementation,
+
+                          there are some extra rules about validity to consider here.
+                          See the fields
+
+                          where this struct is used for more information about the
+                          exact behavior.'
+                        properties:
+                          group:
+                            default: ''
+                            description: 'Group is the group of the referent. For
+                              example, "gateway.networking.k8s.io".
+
+                              When unspecified or empty string, core API group is
+                              inferred.'
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: 'Kind is the Kubernetes resource kind of
+                              the referent. For example
+
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records
+                              that may live
+
+                              outside of the cluster and as such are difficult to
+                              reason about in
+
+                              terms of conformance. They also may not be safe to forward
+                              to (see
+
+                              CVE-2021-25740 for more information). Implementations
+                              SHOULD NOT
+
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type
+                              ExternalName)'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: 'Namespace is the namespace of the backend.
+                              When unspecified, the local
+
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local
+                              namespace is specified,
+
+                              a ReferenceGrant object is required in the referent
+                              namespace to allow that
+
+                              namespace''s owner to accept the reference. See the
+                              ReferenceGrant
+
+                              documentation for details.
+
+
+                              Support: Core'
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: 'Port specifies the destination port number
+                              to use for this resource.
+
+                              Port is required when the referent is a Kubernetes Service.
+                              In this
+
+                              case, the port number is the service port number, not
+                              the target port.
+
+                              For other resources, destination port might be derived
+                              from the referent
+
+                              resource or this field.'
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: 'Weight specifies the proportion of requests
+                              forwarded to the referenced
+
+                              backend. This is computed as weight/(sum of all weights
+                              in this
+
+                              BackendRefs list). For non-zero values, there may be
+                              some epsilon from
+
+                              the exact proportion defined here depending on the precision
+                              an
+
+                              implementation supports. Weight is not a percentage
+                              and the sum of
+
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100%
+
+                              of the traffic is forwarded to that backend. If weight
+                              is set to 0, no
+
+                              traffic should be forwarded for this entry. If unspecified,
+                              weight
+
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where
+                              used.'
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: 'Name is the name of the route rule. This name
+                        MUST be unique within a Route if it is set.
+
+
+                        Support: Extended'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: Rule name must be unique within the route
+                  rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name)
+                    && l1.name == l2.name))
+              useDefaultGateways:
+                description: 'UseDefaultGateways indicates the default Gateway scope
+                  to use for this
+
+                  Route. If unset (the default) or set to None, the Route will not
+                  be
+
+                  attached to any default Gateway; if set, it will be attached to
+                  any
+
+                  default Gateway supporting the named scope, subject to the usual
+                  rules
+
+                  about which Routes a Gateway is allowed to claim.
+
+
+                  Think carefully before using this functionality! The set of default
+
+                  Gateways supporting the requested scope can change over time without
+
+                  any notice to the Route author, and in many situations it will not
+                  be
+
+                  appropriate to request a default Gateway for a given Route -- for
+
+                  example, a Route with specific security requirements should almost
+
+                  certainly not use a default Gateway.'
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources (usually Gateways)
+                  that are
+
+                  associated with the route, and the status of the route with respect
+                  to
+
+                  each parent. When this route attaches to a parent, the controller
+                  that
+
+                  manages the parent must add an entry to this list when the controller
+
+                  first sees the route and should update the entry as appropriate
+                  when the
+
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+
+                  of this API will not be added to this list. Implementations of this
+                  API
+
+                  can only populate Route status for the Gateways/parent resources
+                  they are
+
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty
+                  list
+
+                  means the route has not been attached to any Gateway.'
+                items:
+                  description: 'RouteParentStatus describes the status of a route
+                    with respect to an
+
+                    associated Parent.'
+                  properties:
+                    conditions:
+                      description: 'Conditions describes the status of the route with
+                        respect to the Gateway.
+
+                        Note that the route''s availability is also subject to the
+                        Gateway''s own
+
+                        status conditions and listener status.
+
+
+                        If the Route''s ParentRef specifies an existing Gateway that
+                        supports
+
+                        Routes of this kind AND that Gateway''s controller has sufficient
+                        access,
+
+                        then that Gateway''s controller MUST set the "Accepted" condition
+                        on the
+
+                        Route, to indicate whether the route has been accepted or
+                        rejected by the
+
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the
+                        Route''s
+
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition
+                        may not be set
+
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a nonexistent parent.
+
+                        * The Route is of a type that the controller does not support.
+
+                        * The Route is in a namespace to which the controller does
+                        not have access.'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: 'ParentRef corresponds with a ParentRef in the
+                        spec that this
+
+                        RouteParentStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace
+                            are "producer"
+
+                            routes, which apply default routing rules to inbound connections
+                            from
+
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace
+                            are
+
+                            "consumer" routes, and these routing rules are only applied
+                            to outbound
+
+                            connections originating from the same namespace as the
+                            Route, for which
+
+                            the intended destination of the connections are a Service
+                            targeted as a
+
+                            ParentRef of the Route.
+
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a
+                            specific port in the
+
+                            Service spec. When both Port (experimental) and SectionName
+                            are specified,
+
+                            the name and port of the selected port must match both
+                            specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -1,0 +1,920 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: experimental
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: xbackendtrafficpolicies.gateway.networking.x-k8s.io
+spec:
+  group: gateway.networking.x-k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: XBackendTrafficPolicy
+    listKind: XBackendTrafficPolicyList
+    plural: xbackendtrafficpolicies
+    shortNames:
+    - xbtrafficpolicy
+    singular: xbackendtrafficpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'XBackendTrafficPolicy defines the configuration for how traffic
+          to a
+
+          target backend should be handled.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTrafficPolicy.
+            properties:
+              retryConstraint:
+                description: 'RetryConstraint defines the configuration for when to
+                  allow or prevent
+
+                  further retries to a target backend, by dynamically calculating
+                  a ''retry
+
+                  budget''. This budget is calculated based on the percentage of incoming
+
+                  traffic composed of retries over a given time interval. Once the
+                  budget
+
+                  is exceeded, additional retries will be rejected.
+
+
+                  For example, if the retry budget interval is 10 seconds, there have
+                  been
+
+                  1000 active requests in the past 10 seconds, and the allowed percentage
+
+                  of requests that can be retried is 20% (the default), then 200 of
+                  those
+
+                  requests may be composed of retries. Active requests will only be
+
+                  considered for the duration of the interval when calculating the
+                  retry
+
+                  budget. Retrying the same original request multiple times within
+                  the
+
+                  retry budget interval will lead to each retry being counted towards
+
+                  calculating the budget.
+
+
+                  Configuring a RetryConstraint in BackendTrafficPolicy is compatible
+                  with
+
+                  HTTPRoute Retry settings for each HTTPRouteRule that targets the
+                  same
+
+                  backend. While the HTTPRouteRule Retry stanza can specify whether
+                  a
+
+                  request will be retried, and the number of retry attempts each client
+
+                  may perform, RetryConstraint helps prevent cascading failures such
+                  as
+
+                  retry storms during periods of consistent failures.
+
+
+                  After the retry budget has been exceeded, additional retries to
+                  the
+
+                  backend MUST return a 503 response to the client.
+
+
+                  Additional configurations for defining a constraint on retries MAY
+                  be
+
+                  defined in the future.
+
+
+                  Support: Extended'
+                properties:
+                  budget:
+                    default:
+                      interval: 10s
+                      percent: 20
+                    description: Budget holds the details of the retry budget configuration.
+                    properties:
+                      interval:
+                        default: 10s
+                        description: 'Interval defines the duration in which requests
+                          will be considered
+
+                          for calculating the budget for retries.
+
+
+                          Support: Extended'
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                        x-kubernetes-validations:
+                        - message: interval cannot be greater than one hour or less
+                            than one second
+                          rule: '!(duration(self) < duration(''1s'') || duration(self)
+                            > duration(''1h''))'
+                      percent:
+                        default: 20
+                        description: 'Percent defines the maximum percentage of active
+                          requests that may
+
+                          be made up of retries.
+
+
+                          Support: Extended'
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                    type: object
+                  minRetryRate:
+                    default:
+                      count: 10
+                      interval: 1s
+                    description: 'MinRetryRate defines the minimum rate of retries
+                      that will be allowable
+
+                      over a specified duration of time.
+
+
+                      The effective overall minimum rate of retries targeting the
+                      backend
+
+                      service may be much higher, as there can be any number of clients
+                      which
+
+                      are applying this setting locally.
+
+
+                      This ensures that requests can still be retried during periods
+                      of low
+
+                      traffic, where the budget for retries may be calculated as a
+                      very low
+
+                      value.
+
+
+                      Support: Extended'
+                    properties:
+                      count:
+                        description: 'Count specifies the number of requests per time
+                          interval.
+
+
+                          Support: Extended'
+                        maximum: 1000000
+                        minimum: 1
+                        type: integer
+                      interval:
+                        description: 'Interval specifies the divisor of the rate of
+                          requests, the amount of
+
+                          time during which the given count of requests occur.
+
+
+                          Support: Extended'
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                        x-kubernetes-validations:
+                        - message: interval cannot be greater than one hour
+                          rule: '!(duration(self) == duration(''0s'') || duration(self)
+                            > duration(''1h''))'
+                    type: object
+                type: object
+              sessionPersistence:
+                description: 'SessionPersistence defines and configures session persistence
+
+                  for the backend.
+
+
+                  Support: Extended'
+                properties:
+                  absoluteTimeout:
+                    description: 'AbsoluteTimeout defines the absolute timeout of
+                      the persistent
+
+                      session. Once the AbsoluteTimeout duration has elapsed, the
+
+                      session becomes invalid.
+
+
+                      Support: Extended'
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  cookieConfig:
+                    description: 'CookieConfig provides configuration settings that
+                      are specific
+
+                      to cookie-based session persistence.
+
+
+                      Support: Core'
+                    properties:
+                      lifetimeType:
+                        default: Session
+                        description: 'LifetimeType specifies whether the cookie has
+                          a permanent or
+
+                          session-based lifetime. A permanent cookie persists until
+                          its
+
+                          specified expiry time, defined by the Expires or Max-Age
+                          cookie
+
+                          attributes, while a session cookie is deleted when the current
+
+                          session ends.
+
+
+                          When set to "Permanent", AbsoluteTimeout indicates the
+
+                          cookie''s lifetime via the Expires or Max-Age cookie attributes
+
+                          and is required.
+
+
+                          When set to "Session", AbsoluteTimeout indicates the
+
+                          absolute lifetime of the cookie tracked by the gateway and
+
+                          is optional.
+
+
+                          Defaults to "Session".
+
+
+                          Support: Core for "Session" type
+
+
+                          Support: Extended for "Permanent" type'
+                        enum:
+                        - Permanent
+                        - Session
+                        type: string
+                    type: object
+                  idleTimeout:
+                    description: 'IdleTimeout defines the idle timeout of the persistent
+                      session.
+
+                      Once the session has been idle for more than the specified
+
+                      IdleTimeout duration, the session becomes invalid.
+
+
+                      Support: Extended'
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  sessionName:
+                    description: 'SessionName defines the name of the persistent session
+                      token
+
+                      which may be reflected in the cookie or the header. Users
+
+                      should avoid reusing session names to prevent unintended
+
+                      consequences, such as rejection or unpredictable behavior.
+
+
+                      Support: Implementation-specific'
+                    maxLength: 128
+                    type: string
+                  type:
+                    default: Cookie
+                    description: 'Type defines the type of session persistence such
+                      as through
+
+                      the use of a header or cookie. Defaults to cookie based session
+
+                      persistence.
+
+
+                      Support: Core for "Cookie" type
+
+
+                      Support: Extended for "Header" type'
+                    enum:
+                    - Cookie
+                    - Header
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                    is Permanent
+                  rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
+                    || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                - message: cookieConfig can only be set with type Cookie
+                  rule: '!has(self.cookieConfig) || self.type == ''Cookie'''
+              targetRefs:
+                description: 'TargetRefs identifies API object(s) to apply this policy
+                  to.
+
+                  Currently, Backends (A grouping of like endpoints such as Service,
+
+                  ServiceImport, or any implementation-specific backendRef) are the
+                  only
+
+                  valid API target references.
+
+
+                  Currently, a TargetRef cannot be scoped to a specific port on a
+
+                  Service.'
+                items:
+                  description: 'LocalPolicyTargetReference identifies an API object
+                    to apply a direct or
+
+                    inherited policy to. This should be used as part of Policy resources
+
+                    that can target Gateway API resources. For more information on
+                    how this
+
+                    policy attachment model works, and a sample Policy resource, refer
+                    to
+
+                    the policy attachment documentation for Gateway API.'
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - kind
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - targetRefs
+            type: object
+          status:
+            description: Status defines the current state of BackendTrafficPolicy.
+            properties:
+              ancestors:
+                description: 'Ancestors is a list of ancestor resources (usually Gateways)
+                  that are
+
+                  associated with the policy, and the status of the policy with respect
+                  to
+
+                  each ancestor. When this policy attaches to a parent, the controller
+                  that
+
+                  manages the parent and the ancestors MUST add an entry to this list
+                  when
+
+                  the controller first sees the policy and SHOULD update the entry
+                  as
+
+                  appropriate when the relevant ancestor is modified.
+
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+
+                  an important part of Policy design is designing the right object
+                  level at
+
+                  which to namespace this status.
+
+
+                  Note also that implementations MUST ONLY populate ancestor status
+                  for
+
+                  the Ancestor resources they are responsible for. Implementations
+                  MUST
+
+                  use the ControllerName field to uniquely identify the entries in
+                  this list
+
+                  that they are responsible for.
+
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+
+                  and ControllerName fields combined.
+
+
+                  A maximum of 16 ancestors will be represented in this list. An empty
+                  list
+
+                  means the Policy is not relevant for any ancestors.
+
+
+                  If this slice is full, implementations MUST NOT add further entries.
+
+                  Instead they MUST consider the policy unimplementable and signal
+                  that
+
+                  on any related resources such as the ancestor that would be referenced
+
+                  here. For example, if this list was full on BackendTLSPolicy, no
+
+                  additional Gateways would be able to reference the Service targeted
+                  by
+
+                  the BackendTLSPolicy.'
+                items:
+                  description: 'PolicyAncestorStatus describes the status of a route
+                    with respect to an
+
+                    associated Ancestor.
+
+
+                    Ancestors refer to objects that are either the Target of a policy
+                    or above it
+
+                    in terms of object hierarchy. For example, if a policy targets
+                    a Service, the
+
+                    Policy''s Ancestors are, in order, the Service, the HTTPRoute,
+                    the Gateway, and
+
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway
+                    will be the most
+
+                    useful object to place Policy status on, so we recommend that
+                    implementations
+
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the
+                    designers
+
+                    have a _very_ good reason otherwise.
+
+
+                    In the context of policy attachment, the Ancestor is used to distinguish
+                    which
+
+                    resource results in a distinct application of this policy. For
+                    example, if a policy
+
+                    targets a Service, it may have a distinct result per attached
+                    Gateway.
+
+
+                    Policies targeting the same resource may have different effects
+                    depending on the
+
+                    ancestors of those resources. For example, different Gateways
+                    targeting the same
+
+                    Service may have different capabilities, especially if they have
+                    different underlying
+
+                    implementations.
+
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service
+                    that is
+
+                    used as a backend in a HTTPRoute that is itself attached to a
+                    Gateway.
+
+                    In this case, the relevant object for status is the Gateway, and
+                    that is the
+
+                    ancestor object referred to in this status.
+
+
+                    Note that a parent is also an ancestor, so for objects where the
+                    parent is the
+
+                    relevant object for status, this struct SHOULD still be used.
+
+
+                    This struct is intended to be used in a slice that''s effectively
+                    a map,
+
+                    with a composite key made up of the AncestorRef and the ControllerName.'
+                  properties:
+                    ancestorRef:
+                      description: 'AncestorRef corresponds with a ParentRef in the
+                        spec that this
+
+                        PolicyAncestorStatus struct describes the status of.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent.
+
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+
+                            To set the core API group (such as for a "Service" kind
+                            referent),
+
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core'
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+
+                            * Service (Mesh conformance profile, ClusterIP Services
+                            only)
+
+
+                            Support for other resources is Implementation-Specific.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: 'Name is the name of the referent.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.
+                            When unspecified, this refers
+
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which
+                            cross namespace
+
+                            boundaries. Cross-namespace references are only valid
+                            if they are explicitly
+
+                            allowed by something in the namespace they are referring
+                            to. For example:
+
+                            Gateway has the AllowedRoutes field, and ReferenceGrant
+                            provides a
+
+                            generic way to enable any other kind of cross-namespace
+                            reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace
+                            are "producer"
+
+                            routes, which apply default routing rules to inbound connections
+                            from
+
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace
+                            are
+
+                            "consumer" routes, and these routing rules are only applied
+                            to outbound
+
+                            connections originating from the same namespace as the
+                            Route, for which
+
+                            the intended destination of the connections are a Service
+                            targeted as a
+
+                            ParentRef of the Route.
+
+
+
+                            Support: Core'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: 'Port is the network port this Route targets.
+                            It can be interpreted
+
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all
+                            listeners
+
+                            listening on the specified port that also support this
+                            kind of Route(and
+
+                            select this Route). It''s not recommended to set `Port`
+                            unless the
+
+                            networking behaviors specified in a Route must apply to
+                            a specific port
+
+                            as opposed to a listener(s) whose port(s) may be changed.
+                            When both Port
+
+                            and SectionName are specified, the name and port of the
+                            selected listener
+
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a
+                            specific port in the
+
+                            Service spec. When both Port (experimental) and SectionName
+                            are specified,
+
+                            the name and port of the selected port must match both
+                            specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+
+                            Implementations supporting other types of parent resources
+                            MUST clearly
+
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered
+                            successful as
+
+                            long as the parent resource accepts it partially. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment
+
+                            from the referencing Route, the Route MUST be considered
+                            successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route,
+
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended'
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: 'SectionName is the name of a section within
+                            the target resource. In the
+
+                            following resources, SectionName is interpreted as the
+                            following:
+
+
+                            * Gateway: Listener name. When both Port (experimental)
+                            and SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+                            * Service: Port name. When both Port (experimental) and
+                            SectionName
+
+                            are specified, the name and port of the selected listener
+                            must match
+
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes
+                            to other resources.
+
+                            If that is the case, they MUST clearly document how SectionName
+                            is
+
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the
+                            entire resource.
+
+                            For the purpose of status, an attachment is considered
+                            successful if at
+
+                            least one section in the parent resource accepts it. For
+                            example, Gateway
+
+                            listeners can restrict which Routes can attach to them
+                            by Route kind,
+
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept
+                            attachment from
+
+                            the referencing Route, the Route MUST be considered successfully
+
+                            attached. If no Gateway listeners accept attachment from
+                            this Route, the
+
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core'
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: 'ControllerName is a domain/path string that indicates
+                        the name of the
+
+                        controller that wrote this status. This corresponds with the
+
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN
+                        and PATH are
+
+                        valid Kubernetes names
+
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status.
+                        Controllers should ensure that
+
+                        entries to status populated with their ControllerName are
+                        cleaned up when they are no
+
+                        longer necessary.'
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - conditions
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.x-k8s.io_xmeshes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/experimentalcrds/gateway.networking.x-k8s.io_xmeshes.yaml
@@ -1,0 +1,294 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/channel: experimental
+  name: xmeshes.gateway.networking.x-k8s.io
+spec:
+  group: gateway.networking.x-k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: XMesh
+    listKind: XMeshList
+    plural: xmeshes
+    shortNames:
+    - mesh
+    singular: xmesh
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: XMesh defines mesh-wide characteristics of a GAMMA-compliant
+          service mesh.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of XMesh.
+            properties:
+              controllerName:
+                description: 'ControllerName is the name of a controller that is managing
+                  Gateway API
+
+                  resources for mesh traffic management. The value of this field MUST
+                  be a
+
+                  domain prefixed path.
+
+
+                  Example: "example.com/awesome-mesh".
+
+
+                  This field is not mutable and cannot be empty.
+
+
+                  Support: Core'
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description optionally provides a human-readable description
+                  of a Mesh.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: 'ParametersRef is an optional reference to a resource
+                  that contains
+
+                  implementation-specific configuration for this Mesh. If no
+
+                  implementation-specific parameters are needed, this field MUST be
+
+                  omitted.
+
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e.
+
+                  ConfigMap, or an implementation-specific custom resource. The resource
+
+                  can be cluster-scoped or namespace-scoped.
+
+
+                  If the referent cannot be found, refers to an unsupported kind,
+                  or when
+
+                  the data within that resource is malformed, the Mesh MUST be rejected
+
+                  with the "Accepted" status condition set to "False" and an
+
+                  "InvalidParameters" reason.
+
+
+                  Support: Implementation-specific'
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: 'Namespace is the namespace of the referent.
+
+                      This field is required when referring to a Namespace-scoped
+                      resource and
+
+                      MUST be unset when referring to a Cluster-scoped resource.'
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: '1970-01-01T00:00:00Z'
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of XMesh.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: 'Conditions is the current status from the controller
+                  for
+
+                  this Mesh.
+
+
+                  Controllers should prefer to publish conditions using values
+
+                  of MeshConditionType for the type of each Condition.'
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              supportedFeatures:
+                description: 'SupportedFeatures is the set of features the Mesh support.
+
+                  It MUST be sorted in ascending alphabetical order by the Name key.'
+                items:
+                  properties:
+                    name:
+                      description: 'FeatureName is used to describe distinct features
+                        that are covered by
+
+                        conformance tests.'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ''
+    plural: ''
+  conditions: null
+  storedVersions: null

--- a/packages/rke2-gateway-api-crd/charts/templates/experimentalcrds.yaml
+++ b/packages/rke2-gateway-api-crd/charts/templates/experimentalcrds.yaml
@@ -1,0 +1,6 @@
+{{- if eq (.Values.gatewayAPIExperimental | toString) "true" -}}
+{{- range $path, $_ := .Files.Glob "experimentalcrds/*.yaml" }}
+---
+{{ $.Files.Get $path }}
+{{- end }}
+{{- end }}

--- a/packages/rke2-gateway-api-crd/charts/templates/experimentalcrds.yaml
+++ b/packages/rke2-gateway-api-crd/charts/templates/experimentalcrds.yaml
@@ -1,4 +1,4 @@
-{{- if eq (.Values.gatewayAPIExperimental | toString) "true" -}}
+{{- if .Values.experimental.enabled -}}
 {{- range $path, $_ := .Files.Glob "experimentalcrds/*.yaml" }}
 ---
 {{ $.Files.Get $path }}

--- a/packages/rke2-gateway-api-crd/charts/templates/safe-upgrades.yaml
+++ b/packages/rke2-gateway-api-crd/charts/templates/safe-upgrades.yaml
@@ -1,0 +1,50 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/channel: standard
+  name: safe-upgrades.gateway.networking.k8s.io
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - apiextensions.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - '*'
+  validations:
+    - expression: object.spec.group != 'gateway.networking.k8s.io' || oldObject == null || ( has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && object.metadata.annotations['gateway.networking.k8s.io/channel'] == 'standard' ) || ( oldObject != null && has(oldObject.metadata.annotations) && oldObject.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/channel') && oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )
+      message: Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs.
+      reason: Invalid
+    - expression: object.spec.group != 'gateway.networking.k8s.io' || (has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version') && !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v1.[0-4].\\d+') && !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v0'))
+      message: Installing CRDs with version before v1.5.0 is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install older versions.
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  annotations:
+    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/channel: standard
+  name: safe-upgrades.gateway.networking.k8s.io
+spec:
+  policyName: safe-upgrades.gateway.networking.k8s.io
+  validationActions:
+    - Deny
+  matchResources:
+    resourceRules:
+      - apiGroups:
+          - apiextensions.k8s.io
+        apiVersions:
+          - v1
+        resources:
+          - customresourcedefinitions
+        operations:
+          - CREATE
+          - UPDATE

--- a/packages/rke2-gateway-api-crd/charts/templates/stablecrds.yaml
+++ b/packages/rke2-gateway-api-crd/charts/templates/stablecrds.yaml
@@ -1,0 +1,4 @@
+{{- range $path, $_ := .Files.Glob "crdfiles/*.yaml" }}
+---
+{{ $.Files.Get $path }}
+{{- end }}

--- a/packages/rke2-gateway-api-crd/charts/values.yaml
+++ b/packages/rke2-gateway-api-crd/charts/values.yaml
@@ -1,0 +1,1 @@
+gatewayAPIExperimental: false

--- a/packages/rke2-gateway-api-crd/charts/values.yaml
+++ b/packages/rke2-gateway-api-crd/charts/values.yaml
@@ -1,1 +1,2 @@
-gatewayAPIExperimental: false
+experimental:
+  enabled: false

--- a/packages/rke2-gateway-api-crd/package.yaml
+++ b/packages/rke2-gateway-api-crd/package.yaml
@@ -1,0 +1,2 @@
+url: local
+packageVersion: 00


### PR DESCRIPTION
Add a new rke2 chart called rke2-gateway-api-crd. yaml to bundle the lifecycle of gateway-api directly in RKE2.

This is connected to https://github.com/rancher/rke2/pull/10104.

I added a README (AI generated) that explains the design of this chart (after some extensive test/error process). It also explains how to update it in the future, as I believe it is not that obvious due to upstream releasing all CRDs under two yaml files