### PR TITLE
Bump Traefik and add helm.sh/resource-policy: keep

### DIFF
--- a/packages/rke2-traefik/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/Chart.yaml.patch
@@ -1,18 +1,14 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -1,10 +1,5 @@
+@@ -1,6 +1,5 @@
  annotations:
--  artifacthub.io/changes: |
--    - "fix: :bug: handle experimental-master and fail gracefully"
--    - "fix(nginx): add required RBAC for v3.7"
--    - "fix(gateway): setting port value for `websecure` listener can fail"
--    - "feat: upgrade traefik to version v3.6.10"
--    - "chore(release): publish v39.0.5"
+-  artifacthub.io/changes: "- \"feat(deps): update traefik docker tag to v3.6.12 (v39.0)\"\n-
+-    \"chore(release): \U0001F680 publish v39.0.7\"\n"
 +  fleet.cattle.io/bundle-id: rke2
  apiVersion: v2
- appVersion: v3.6.10
+ appVersion: v3.6.12
  description: A Traefik based Kubernetes ingress controller
-@@ -21,7 +16,7 @@
+@@ -17,7 +16,7 @@
  - email: remi.buisson@traefik.io
    name: darkweaver87
  - name: jnoordsij

--- a/packages/rke2-traefik/generated-changes/patch/crds/gateway-standard-install.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/crds/gateway-standard-install.yaml.patch
@@ -1,0 +1,50 @@
+--- charts-original/crds/gateway-standard-install.yaml
++++ charts/crds/gateway-standard-install.yaml
+@@ -26,6 +26,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+     gateway.networking.k8s.io/bundle-version: v1.4.0
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   labels:
+     gateway.networking.k8s.io/policy: Direct
+   name: backendtlspolicies.gateway.networking.k8s.io
+@@ -1348,6 +1349,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+     gateway.networking.k8s.io/bundle-version: v1.4.0
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: gatewayclasses.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -1867,6 +1869,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+     gateway.networking.k8s.io/bundle-version: v1.4.0
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: gateways.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -4124,6 +4127,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+     gateway.networking.k8s.io/bundle-version: v1.4.0
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: grpcroutes.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -6198,6 +6202,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+     gateway.networking.k8s.io/bundle-version: v1.4.0
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: httproutes.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -11845,6 +11850,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+     gateway.networking.k8s.io/bundle-version: v1.4.0
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: referencegrants.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io

--- a/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
    # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
    # When a digest is required, `versionOverride` can be used to set the version.
 -  tag:  # @schema type:[string, null]
-+  tag: v3.6.10-build20260309
++  tag: v3.6.12-build20260409
    # -- Traefik image pull policy
    pullPolicy: IfNotPresent
  

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,5 +1,5 @@
-url: https://traefik.github.io/charts/traefik/traefik-39.0.5.tgz
-packageVersion: 02
+url: https://traefik.github.io/charts/traefik/traefik-39.0.7.tgz
+packageVersion: 00
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 

--- a/packages/rke2-traefik/templates/crd-template/Chart.yaml
+++ b/packages/rke2-traefik/templates/crd-template/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 39.0.5
-appVersion: v3.6.10
+version: 39.0.7
+appVersion: v3.6.12
 description: Installs the CRDs for rke2-traefik
 name: rke2-traefik-crd
 type: application


### PR DESCRIPTION
* Bump Traefik image to v3.6.12
* Bump Traefik chart to  v39.0.7
* Add the `helm.sh/resource-policy: keep` based on https://github.com/rancher/rke2/pull/10104 (to be updated + design discussion)