### PR TITLE
Split multus crd into its own sub-chart

### DIFF
--- a/packages/rke2-multus/charts/Chart.yaml
+++ b/packages/rke2-multus/charts/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 appVersion: 4.2.4
 dependencies:
 - condition: rke2-whereabouts.enabled

--- a/packages/rke2-multus/charts/crds/customResourceDefinition.yaml
+++ b/packages/rke2-multus/charts/crds/customResourceDefinition.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- if .Values.manifests.customResourceDefinition }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -38,4 +37,3 @@ spec:
               properties:
                 config:
                   type: string
-{{- end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,24 +1,23 @@
----
+{{ if (index .Values "rke2-whereabouts").enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  name: overlappingrangeipreservations.whereabouts.cni.cncf.io
+  name: ippools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
   names:
-    kind: OverlappingRangeIPReservation
-    listKind: OverlappingRangeIPReservationList
-    plural: overlappingrangeipreservations
-    singular: overlappingrangeipreservation
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OverlappingRangeIPReservation is the Schema for the OverlappingRangeIPReservations
-          API
+        description: IPPool is the Schema for the ippools API
         properties:
           apiVersion:
             description: |-
@@ -38,20 +37,36 @@ spec:
           metadata:
             type: object
           spec:
-            description: OverlappingRangeIPReservationSpec defines the desired state
-              of OverlappingRangeIPReservation
+            description: IPPoolSpec defines the desired state of IPPool
             properties:
-              containerid:
-                type: string
-              ifname:
-                type: string
-              podref:
+              allocations:
+                additionalProperties:
+                  description: IPAllocation represents metadata about the pod/container
+                    owner of a specific IP
+                  properties:
+                    id:
+                      type: string
+                    ifname:
+                      type: string
+                    podref:
+                      type: string
+                  required:
+                  - id
+                  - podref
+                  type: object
+                description: |-
+                  Allocations is the set of allocated IPs for the given range. Its` indices are a direct mapping to the
+                  IP with the same index/offset for the pool's range.
+                type: object
+              range:
+                description: Range is a RFC 4632/4291-style string that represents
+                  an IP address and prefix length in CIDR notation
                 type: string
             required:
-            - podref
+            - allocations
+            - range
             type: object
-        required:
-        - spec
         type: object
     served: true
     storage: true
+{{ end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
@@ -1,4 +1,4 @@
----
+{{ if (index .Values "rke2-whereabouts").enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -77,3 +77,4 @@ spec:
         type: object
     served: true
     storage: true
+{{ end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -1,23 +1,24 @@
----
+{{ if (index .Values "rke2-whereabouts").enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  name: ippools.whereabouts.cni.cncf.io
+  name: overlappingrangeipreservations.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
   names:
-    kind: IPPool
-    listKind: IPPoolList
-    plural: ippools
-    singular: ippool
+    kind: OverlappingRangeIPReservation
+    listKind: OverlappingRangeIPReservationList
+    plural: overlappingrangeipreservations
+    singular: overlappingrangeipreservation
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IPPool is the Schema for the ippools API
+        description: OverlappingRangeIPReservation is the Schema for the OverlappingRangeIPReservations
+          API
         properties:
           apiVersion:
             description: |-
@@ -37,35 +38,21 @@ spec:
           metadata:
             type: object
           spec:
-            description: IPPoolSpec defines the desired state of IPPool
+            description: OverlappingRangeIPReservationSpec defines the desired state
+              of OverlappingRangeIPReservation
             properties:
-              allocations:
-                additionalProperties:
-                  description: IPAllocation represents metadata about the pod/container
-                    owner of a specific IP
-                  properties:
-                    id:
-                      type: string
-                    ifname:
-                      type: string
-                    podref:
-                      type: string
-                  required:
-                  - id
-                  - podref
-                  type: object
-                description: |-
-                  Allocations is the set of allocated IPs for the given range. Its` indices are a direct mapping to the
-                  IP with the same index/offset for the pool's range.
-                type: object
-              range:
-                description: Range is a RFC 4632/4291-style string that represents
-                  an IP address and prefix length in CIDR notation
+              containerid:
+                type: string
+              ifname:
+                type: string
+              podref:
                 type: string
             required:
-            - allocations
-            - range
+            - podref
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
+{{ end }}

--- a/packages/rke2-multus/charts/requirements.yaml
+++ b/packages/rke2-multus/charts/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- condition: rke2-whereabouts.enabled
+  name: rke2-whereabouts
+  repository: file://./charts/rke2-whereabouts

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -98,12 +98,12 @@ config:
     #multusBinFile: /usr/src/multus-cni/bin/multus
     #multusCniConfDir: /host/etc/cni/multus/net.d
     # The following options can be used only when multusConfFile=auto
-    # multusAutoconfigDir is mandatory when multusConfFile=auto 
+    # multusAutoconfigDir is mandatory when multusConfFile=auto
     multusAutoconfigDir: /etc/cni/net.d #path on the host, not inside the container
     kubeconfig: /etc/cni/net.d/multus.d/multus.kubeconfig
     #masterCniFilename:
-    #overrideNetworkName: 
-    #renameConfFile: 
+    #overrideNetworkName:
+    #renameConfFile:
     #logFile: /var/log/multus.log
     #logLevel: panic
     #logToStderr: true
@@ -126,14 +126,13 @@ manifests:
   clusterRoleBinding: true
   configMap: true
   daemonSet: true
-  customResourceDefinition: true
   dhcpDaemonSet: false
 
 tolerations:
-- operator: Exists 
-  effect: NoSchedule 
-- operator: Exists 
-  effect: NoExecute 
+- operator: Exists
+  effect: NoSchedule
+- operator: Exists
+  effect: NoExecute
 
 #affinity: {}
 
@@ -158,7 +157,7 @@ global:
 
 rke2-whereabouts:
   enabled: false
-  
+
 # When using the thick plugin, manifests.configMap MUST be set to true
 thickPlugin:
   enabled: false

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,9 @@
 url: local
 workingDir: charts
-packageVersion: 07
+packageVersion: 08
+additionalCharts:
+  - workingDir: charts-crd
+    crdOptions:
+      templateDirectory: crd-template
+      crdDirectory: templates
+      addCRDValidationToMainChart: false

--- a/packages/rke2-multus/templates/crd-template/Chart.yaml
+++ b/packages/rke2-multus/templates/crd-template/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+version: 4.2.4
+description: Installs the CRDs for rke2-multus
+name: rke2-multus-crd
+type: application

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,5 +1,5 @@
 url: local
 workingDir: charts
-packageVersion: 02
+packageVersion: 03
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
and move whereabouts crds into this sub-chart.
We cannot split whereabouts crds into their own sub-chart
because whereabouts is itself a sub-chart of multus.


related issue:
- https://github.com/rancher/rke2/issues/8628