### PR TITLE
add helm.sh/resource-policy: keep annotation to whereabouts crds

### DIFF
--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 07
+packageVersion: 08

--- a/packages/rke2-whereabouts/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-whereabouts/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   name: ippools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io

--- a/packages/rke2-whereabouts/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
+++ b/packages/rke2-whereabouts/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   name: nodeslicepools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io

--- a/packages/rke2-whereabouts/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-whereabouts/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
   name: overlappingrangeipreservations.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,5 +1,5 @@
 url: local
 workingDir: charts
-packageVersion: 02
+packageVersion: 03
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
As a first step before moving whereabouts CRDs to a dedicated sub-chart with multus CRD, we need to add the
`helm.sh/resource-policy: keep` annotation so that they are not deleted accidentally during an upgrade.

Related issue:

- https://github.com/rancher/rke2/issues/8628