### PR TITLE
Bump vsphere charts

### DIFF
--- a/packages/rancher-vsphere-cpi/package.yaml
+++ b/packages/rancher-vsphere-cpi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-cpi
-commit: 1f83598eee78197714d494ab0aa257f7868b056f
+commit: 05c27d239738ee1c44bc29486b15d45f1e601cd6
 packageVersion: 00

--- a/packages/rancher-vsphere-csi/package.yaml
+++ b/packages/rancher-vsphere-csi/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/rancher/vsphere-charts.git
 subdirectory: charts/rancher-vsphere-csi
-commit: 1f83598eee78197714d494ab0aa257f7868b056f
+commit: 05c27d239738ee1c44bc29486b15d45f1e601cd6
 packageVersion: 00


### PR DESCRIPTION
For Kubernetes 1.36: 
* https://github.com/rancher/vsphere-charts/pull/125