### PR TITLE
Update Calico to v3.32.0

### DIFF
--- a/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
@@ -10,6 +10,6 @@
  - https://github.com/projectcalico/calico/tree/master/charts/tigera-operator
  - https://github.com/tigera/operator
  - https://github.com/projectcalico/calico
- version: v3.31.5
+ version: v3.32.0
 +annotations:
 +  catalog.cattle.io/namespace: tigera-operator

--- a/packages/rke2-calico/generated-changes/patch/README.md.patch
+++ b/packages/rke2-calico/generated-changes/patch/README.md.patch
@@ -1,6 +1,6 @@
 --- charts-original/README.md
 +++ charts/README.md
-@@ -162,9 +162,9 @@
+@@ -166,9 +166,9 @@
  # Configuration for the tigera operator images to deploy.
  tigeraOperator:
    image: tigera/operator
@@ -10,5 +10,5 @@
 -  image: quay.io/calico/ctl
 +  image: docker.io/rancher/mirrored-calico-ctl
  
- # Configuration for the Calico CSI plugin - setting to None will disable the plugin, default: /var/lib/kubelet
- kubeletVolumePluginPath: None   
+ # Optionally configure the host and port used to access the Kubernetes API server.
+ kubernetesServiceEndpoint:

--- a/packages/rke2-calico/generated-changes/patch/templates/tigera-operator/02-tigera-operator.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/templates/tigera-operator/02-tigera-operator.yaml.patch
@@ -9,7 +9,7 @@
    labels:
      {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
  spec:
-@@ -51,7 +51,7 @@
+@@ -55,7 +55,7 @@
        {{- end }}
        containers:
          - name: tigera-operator

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -1,8 +1,8 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -6,14 +6,30 @@
- imagePullSecrets: {}
- 
+@@ -9,6 +9,13 @@
+ # on the operator.tigera.io/Installation API documented
+ # here: https://docs.tigera.io/calico/latest/reference/installation/api#installationspec
  installation:
 +  controlPlaneTolerations:
 +  - key: "node-role.kubernetes.io/control-plane"
@@ -12,7 +12,13 @@
 +    operator: "Exists"
 +    effect: "NoExecute"
    enabled: true
-   kubernetesProvider: ""
+   # Uncomment to enable prometheus metrics reporting for node and typha.
+   # nodeMetricsPort: 9090
+@@ -16,7 +23,13 @@
+   # Path to the kubelet volume plugin directory used by the Calico CSI driver.
+   # Set to "None" to disable the CSI driver. If unset, defaults to /var/lib/kubelet (CSI enabled).
+   kubeletVolumePluginPath: "None"
+-
 +  natOutgoing: "Enabled"
 +  backend: "VXLAN"
 +  calicoNetwork:
@@ -20,18 +26,18 @@
 +  imagePath: "rancher"
 +  imagePrefix: "mirrored-calico-"
 +  flexVolumePath: "/var/lib/kubelet/volumeplugins/"
-+
-   # imagePullSecrets are configured on all images deployed by the tigera-operator.
-   # secrets specified here must exist in the tigera-operator namespace; they won't be created by the operator or helm.
-   # imagePullSecrets are a slice of LocalObjectReferences, which is the same format they appear as on deployments.
+   # --- General Image Settings ---
+   # registry: <custom-registry>
+   # imagePath: <optional-path>
+@@ -28,6 +41,7 @@
    #
    # Example: --set installation.imagePullSecrets[0].name=my-existing-secret
    imagePullSecrets: []
 +  registry: "docker.io"
  
-   # Disable CSI driver by default.
-   kubeletVolumePluginPath: "None"
-@@ -21,15 +37,15 @@
+   # Valid options: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG, Kind.
+   # If empty the operator will attempt to automatically determine the current provider.
+@@ -85,15 +99,15 @@
  # apiServer configures the Calico API server, needed for interacting with
  # the projectcalico.org/v3 suite of APIs.
  apiServer:
@@ -50,7 +56,7 @@
  
  defaultFelixConfiguration:
    enabled: false
-@@ -47,7 +63,7 @@
+@@ -111,7 +125,7 @@
  
  # Whether or not the tigera/operator should manange CustomResourceDefinitions
  # needed to run itself and Calico. If disabled, you must manage these resources out-of-band.
@@ -59,19 +65,19 @@
  
  # Resource requests and limits for the tigera/operator pod.
  resources: {}
-@@ -82,13 +98,32 @@
+@@ -146,13 +160,32 @@
  dnsConfig: {}
  # Image and registry configuration for the tigera/operator pod.
  tigeraOperator:
 -  image: tigera/operator
 +  image: rancher/mirrored-calico-operator
-   version: v1.40.8
+   version: v1.42.0
 -  registry: quay.io
 +  registry: docker.io
  calicoctl:
 -  image: quay.io/calico/ctl
 +  image: rancher/mirrored-calico-ctl
-   tag: v3.31.5
+   tag: v3.32.0
  
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,8 +1,6 @@
-url: https://github.com/projectcalico/calico/releases/download/v3.31.5/tigera-operator-v3.31.5.tgz
+url: https://github.com/projectcalico/calico/releases/download/v3.32.0/tigera-operator-v3.32.0.tgz
 packageVersion: 00
 additionalCharts:
   - workingDir: charts-crd
-    crdOptions:
-      templateDirectory: crd-template
-      crdDirectory: templates
-      addCRDValidationToMainChart: true
+    upstreamOptions:
+      url: https://github.com/projectcalico/calico/releases/download/v3.32.0/crd.projectcalico.org.v1-v3.32.0.tgz

--- a/packages/rke2-calico/templates/crd-template/Chart.yaml
+++ b/packages/rke2-calico/templates/crd-template/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: v3.31.5
+version: v3.32.0
 description: Installs the CRDs for rke2-calico
 name: rke2-calico-crd
 type: application

--- a/updatecli/scripts/update-calico.sh
+++ b/updatecli/scripts/update-calico.sh
@@ -20,7 +20,8 @@ if [ -n "$CALICO_VERSION" ]; then
 		sed -i "s/   tag: .*/   tag: $CALICO_VERSION/g" packages/rke2-calico/generated-changes/patch/values.yaml.patch
 		yq -i ".version = \"$CALICO_VERSION\"" packages/rke2-calico/templates/crd-template/Chart.yaml
 		yq -i ".url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz\" |
-			.packageVersion = 00" packages/rke2-calico/package.yaml
+			.packageVersion = 00 |
+		        .additionalCharts[].upstreamOptions.url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/crd.projectcalico.org.v1-$CALICO_VERSION.tgz\"" packages/rke2-calico/package.yaml
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make prepare
 		find packages/rke2-calico/charts -name '*.orig' -delete
 		find packages/rke2-calico/charts-crd -name '*.orig' -delete


### PR DESCRIPTION
Updated Calico to v3.32.0 with the new crds url.
https://github.com/rancher/rke2/issues/10305