### PR TITLE
Bundle ovirt csi driver

### DIFF
--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/Chart.yaml.patch
@@ -1,0 +1,12 @@
+--- charts-original/Chart.yaml
++++ charts/Chart.yaml
+@@ -1,8 +1,6 @@
+ apiVersion: v2
+-name: ovirt-csi-driver
++name: rke2-ovirt-csi-driver
+ description: Implementation of a CSI driver for oVirt.
+ type: application
+ version: 4.21.0
+ appVersion: "4.21.0"
+-icon: icons/kubernetes-logo.svg
+-kubeVersion: '>= 1.30.0 < 1.34.0'

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/Chart.yaml.patch
@@ -6,7 +6,9 @@
 +name: rke2-ovirt-csi-driver
  description: Implementation of a CSI driver for oVirt.
  type: application
- version: 4.21.0
- appVersion: "4.21.0"
+-version: 4.21.0
+-appVersion: "4.21.0"
 -icon: icons/kubernetes-logo.svg
 -kubeVersion: '>= 1.30.0 < 1.34.0'
++version: 4.15.0
++appVersion: "4.15.0"

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,0 +1,17 @@
+--- charts-original/templates/_helpers.tpl
++++ charts/templates/_helpers.tpl
+@@ -60,3 +60,14 @@
+ {{- default "default" .Values.serviceAccount.name }}
+ {{- end }}
+ {{- end }}
++
++{{/*
++Return the proper image registry
++*/}}
++{{- define "system_default_registry" -}}
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/csi_driver_controller.yaml
++++ charts/templates/csi_driver_controller.yaml
+@@ -37,7 +37,7 @@
+               apiVersion: v1
+               fieldPath: spec.nodeName
+         - name: OVIRT_CONFIG
+-          value: /tmp/config/ovirt-config.yaml
++          value: {{ quote .Values.csiController.ovirtController.env.ovirtConfig }}
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+         image: {{ .Values.csiController.ovirtController.image.repository }}:{{ .Values.csiController.ovirtController.image.tag

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
@@ -1,11 +1,8 @@
 --- charts-original/templates/csi_driver_controller.yaml
 +++ charts/templates/csi_driver_controller.yaml
-@@ -37,10 +37,10 @@
-               apiVersion: v1
-               fieldPath: spec.nodeName
+@@ -39,8 +39,8 @@
          - name: OVIRT_CONFIG
--          value: /tmp/config/ovirt-config.yaml
-+          value: {{ quote .Values.csiController.ovirtController.env.ovirtConfig }}
+           value: /tmp/config/ovirt-config.yaml
          - name: KUBERNETES_CLUSTER_DOMAIN
 -          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiController.ovirtController.image.repository }}:{{ .Values.csiController.ovirtController.image.tag

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
@@ -44,7 +44,7 @@
          volumeMounts:
          - mountPath: /csi-socket
            name: socket-dir
-+      {{- if .Values.csiController.csiResizer.enable }}
++      {{- if .Values.csiController.csiResizer.enabled }}
        - args:
          - -csi-address=/csi-socket/csi.sock
          - -v=5

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
@@ -7,35 +7,42 @@
 -          value: /tmp/config/ovirt-config.yaml
 +          value: {{ quote .Values.csiController.ovirtController.env.ovirtConfig }}
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiController.ovirtController.image.repository }}:{{ .Values.csiController.ovirtController.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiController.ovirtController.image.repository }}:{{ .Values.csiController.ovirtController.image.tag
            | default .Chart.AppVersion }}
          imagePullPolicy: {{ .Values.csiController.ovirtController.imagePullPolicy }}
          livenessProbe:
-@@ -70,7 +70,7 @@
+@@ -69,8 +69,8 @@
+         - --health-port=9898
          env:
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiController.livenessProbe.image.repository }}:{{ .Values.csiController.livenessProbe.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiController.livenessProbe.image.repository }}:{{ .Values.csiController.livenessProbe.image.tag
            | default .Chart.AppVersion }}
          name: liveness-probe
          resources: {{- toYaml .Values.csiController.livenessProbe.resources | nindent
-@@ -84,7 +84,7 @@
+@@ -83,8 +83,8 @@
+         - --v=5
          env:
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiController.csiAttacher.image.repository }}:{{ .Values.csiController.csiAttacher.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiController.csiAttacher.image.repository }}:{{ .Values.csiController.csiAttacher.image.tag
            | default .Chart.AppVersion }}
          name: csi-attacher
          resources: {{- toYaml .Values.csiController.csiAttacher.resources | nindent 10
-@@ -101,7 +101,7 @@
+@@ -100,8 +100,8 @@
+         - -v=5
          env:
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiController.csiProvisioner.image.repository }}:{{ .Values.csiController.csiProvisioner.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiController.csiProvisioner.image.repository }}:{{ .Values.csiController.csiProvisioner.image.tag
            | default .Chart.AppVersion }}
          name: csi-provisioner
@@ -50,8 +57,9 @@
          - -v=5
          env:
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiController.csiResizer.image.repository }}:{{ .Values.csiController.csiResizer.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiController.csiResizer.image.repository }}:{{ .Values.csiController.csiResizer.image.tag
            | default .Chart.AppVersion }}
          name: csi-resizer
@@ -64,11 +72,13 @@
        initContainers:
        - command:
          - /bin/sh
-@@ -169,7 +171,7 @@
+@@ -168,8 +170,8 @@
+               name:  {{ .Values.ovirt.caConfigMapName }}
  {{ end }}
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiController.prepareOvirtConfig.image.repository }}:{{ .Values.csiController.prepareOvirtConfig.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiController.prepareOvirtConfig.image.repository }}:{{ .Values.csiController.prepareOvirtConfig.image.tag
            | default .Chart.AppVersion }}
          imagePullPolicy: {{ .Values.csiController.prepareOvirtConfig.imagePullPolicy }}

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_controller.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/csi_driver_controller.yaml
 +++ charts/templates/csi_driver_controller.yaml
-@@ -37,7 +37,7 @@
+@@ -37,10 +37,10 @@
                apiVersion: v1
                fieldPath: spec.nodeName
          - name: OVIRT_CONFIG
@@ -8,4 +8,68 @@
 +          value: {{ quote .Values.csiController.ovirtController.env.ovirtConfig }}
          - name: KUBERNETES_CLUSTER_DOMAIN
            value: {{ quote .Values.kubernetesClusterDomain }}
-         image: {{ .Values.csiController.ovirtController.image.repository }}:{{ .Values.csiController.ovirtController.image.tag
+-        image: {{ .Values.csiController.ovirtController.image.repository }}:{{ .Values.csiController.ovirtController.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiController.ovirtController.image.repository }}:{{ .Values.csiController.ovirtController.image.tag
+           | default .Chart.AppVersion }}
+         imagePullPolicy: {{ .Values.csiController.ovirtController.imagePullPolicy }}
+         livenessProbe:
+@@ -70,7 +70,7 @@
+         env:
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiController.livenessProbe.image.repository }}:{{ .Values.csiController.livenessProbe.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiController.livenessProbe.image.repository }}:{{ .Values.csiController.livenessProbe.image.tag
+           | default .Chart.AppVersion }}
+         name: liveness-probe
+         resources: {{- toYaml .Values.csiController.livenessProbe.resources | nindent
+@@ -84,7 +84,7 @@
+         env:
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiController.csiAttacher.image.repository }}:{{ .Values.csiController.csiAttacher.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiController.csiAttacher.image.repository }}:{{ .Values.csiController.csiAttacher.image.tag
+           | default .Chart.AppVersion }}
+         name: csi-attacher
+         resources: {{- toYaml .Values.csiController.csiAttacher.resources | nindent 10
+@@ -101,7 +101,7 @@
+         env:
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiController.csiProvisioner.image.repository }}:{{ .Values.csiController.csiProvisioner.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiController.csiProvisioner.image.repository }}:{{ .Values.csiController.csiProvisioner.image.tag
+           | default .Chart.AppVersion }}
+         name: csi-provisioner
+         resources: {{- toYaml .Values.csiController.csiProvisioner.resources | nindent
+@@ -111,13 +111,14 @@
+         volumeMounts:
+         - mountPath: /csi-socket
+           name: socket-dir
++      {{- if .Values.csiController.csiResizer.enable }}
+       - args:
+         - -csi-address=/csi-socket/csi.sock
+         - -v=5
+         env:
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiController.csiResizer.image.repository }}:{{ .Values.csiController.csiResizer.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiController.csiResizer.image.repository }}:{{ .Values.csiController.csiResizer.image.tag
+           | default .Chart.AppVersion }}
+         name: csi-resizer
+         resources: {{- toYaml .Values.csiController.csiResizer.resources | nindent 10
+@@ -127,6 +128,7 @@
+         volumeMounts:
+         - mountPath: /csi-socket
+           name: socket-dir
++      {{- end }}
+       initContainers:
+       - command:
+         - /bin/sh
+@@ -169,7 +171,7 @@
+ {{ end }}
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiController.prepareOvirtConfig.image.repository }}:{{ .Values.csiController.prepareOvirtConfig.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiController.prepareOvirtConfig.image.repository }}:{{ .Values.csiController.prepareOvirtConfig.image.tag
+           | default .Chart.AppVersion }}
+         imagePullPolicy: {{ .Values.csiController.prepareOvirtConfig.imagePullPolicy }}
+         name: prepare-ovirt-config

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_node.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_node.yaml.patch
@@ -1,0 +1,38 @@
+--- charts-original/templates/csi_driver_node.yaml
++++ charts/templates/csi_driver_node.yaml
+@@ -40,7 +40,7 @@
+           value: {{ quote .Values.csiNode.ovirtNode.env.ovirtConfig }}
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiNode.ovirtNode.image.repository }}:{{ .Values.csiNode.ovirtNode.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.ovirtNode.image.repository }}:{{ .Values.csiNode.ovirtNode.image.tag
+           | default .Chart.AppVersion }}
+         imagePullPolicy: {{ .Values.csiNode.ovirtNode.imagePullPolicy }}
+         livenessProbe:
+@@ -75,7 +75,7 @@
+         env:
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiNode.livenessProbe.image.repository }}:{{ .Values.csiNode.livenessProbe.image.tag
++        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.livenessProbe.image.repository }}:{{ .Values.csiNode.livenessProbe.image.tag
+           | default .Chart.AppVersion }}
+         name: liveness-probe
+         resources: {{- toYaml .Values.csiNode.livenessProbe.resources | nindent
+@@ -90,7 +90,7 @@
+         env:
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiNode.csiDriverRegistrar.image.repository }}:{{
++        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.csiDriverRegistrar.image.repository }}:{{
+           .Values.csiNode.csiDriverRegistrar.image.tag | default .Chart.AppVersion
+           }}
+         livenessProbe:
+@@ -152,7 +152,7 @@
+ {{ end }}
+         - name: KUBERNETES_CLUSTER_DOMAIN
+           value: {{ quote .Values.kubernetesClusterDomain }}
+-        image: {{ .Values.csiNode.prepareOvirtConfig.image.repository }}:{{
++        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.prepareOvirtConfig.image.repository }}:{{
+           .Values.csiNode.prepareOvirtConfig.image.tag | default .Chart.AppVersion
+           }}
+         imagePullPolicy: {{ .Values.csiNode.prepareOvirtConfig.imagePullPolicy

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_node.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/templates/csi_driver_node.yaml.patch
@@ -1,37 +1,45 @@
 --- charts-original/templates/csi_driver_node.yaml
 +++ charts/templates/csi_driver_node.yaml
-@@ -40,7 +40,7 @@
+@@ -39,8 +39,8 @@
+         - name: OVIRT_CONFIG
            value: {{ quote .Values.csiNode.ovirtNode.env.ovirtConfig }}
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiNode.ovirtNode.image.repository }}:{{ .Values.csiNode.ovirtNode.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.ovirtNode.image.repository }}:{{ .Values.csiNode.ovirtNode.image.tag
            | default .Chart.AppVersion }}
          imagePullPolicy: {{ .Values.csiNode.ovirtNode.imagePullPolicy }}
          livenessProbe:
-@@ -75,7 +75,7 @@
+@@ -74,8 +74,8 @@
+         - --health-port=9898
          env:
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiNode.livenessProbe.image.repository }}:{{ .Values.csiNode.livenessProbe.image.tag
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.livenessProbe.image.repository }}:{{ .Values.csiNode.livenessProbe.image.tag
            | default .Chart.AppVersion }}
          name: liveness-probe
          resources: {{- toYaml .Values.csiNode.livenessProbe.resources | nindent
-@@ -90,7 +90,7 @@
+@@ -89,8 +89,8 @@
+         - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.ovirt.org/csi.sock
          env:
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiNode.csiDriverRegistrar.image.repository }}:{{
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.csiDriverRegistrar.image.repository }}:{{
            .Values.csiNode.csiDriverRegistrar.image.tag | default .Chart.AppVersion
            }}
          livenessProbe:
-@@ -152,7 +152,7 @@
+@@ -151,8 +151,8 @@
+               name: {{ .Values.ovirt.caConfigMapName }}
  {{ end }}
          - name: KUBERNETES_CLUSTER_DOMAIN
-           value: {{ quote .Values.kubernetesClusterDomain }}
+-          value: {{ quote .Values.kubernetesClusterDomain }}
 -        image: {{ .Values.csiNode.prepareOvirtConfig.image.repository }}:{{
++          value: {{ coalesce .Values.global.clusterDomain .Values.kubernetesClusterDomain | quote }}
 +        image: {{ template "system_default_registry" . }}{{ .Values.csiNode.prepareOvirtConfig.image.repository }}:{{
            .Values.csiNode.prepareOvirtConfig.image.tag | default .Chart.AppVersion
            }}

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
@@ -1,0 +1,100 @@
+--- charts-original/values.yaml
++++ charts/values.yaml
+@@ -3,7 +3,7 @@
+     containerSecurityContext:
+       privileged: true
+     image:
+-      repository: olcne/csi-attacher
++      repository: registry.k8s.io/sig-storage/csi-attacher
+       tag: v4.10.0
+     resources:
+       limits:
+@@ -16,7 +16,7 @@
+     containerSecurityContext:
+       privileged: true
+     image:
+-      repository: olcne/csi-provisioner
++      repository: registry.k8s.io/sig-storage/csi-provisioner
+       tag: v6.0.0
+     resources:
+       limits:
+@@ -29,7 +29,7 @@
+     containerSecurityContext:
+       privileged: true
+     image:
+-      repository: olcne/csi-resizer
++      repository: registry.k8s.io/sig-storage/csi-resizer
+       tag: v1.14.0
+     resources:
+       limits:
+@@ -40,7 +40,7 @@
+         memory: 64Mi
+   livenessProbe:
+     image:
+-      repository: olcne/livenessprobe
++      repository: registry.k8s.io/sig-storage/livenessprobe
+       tag: v2.17.0
+     resources:
+       limits:
+@@ -57,8 +57,8 @@
+       csiEndpoint: unix:///csi-socket/csi.sock
+       ovirtConfig: /tmp/config/ovirt-config.yaml
+     image:
+-      repository: olcne/ovirt-csi-driver
+-      tag: v4.21.0-2
++      repository: quay.io/ovirt/csi-driver
++      tag: latest
+     imagePullPolicy: Always
+     resources:
+       limits:
+@@ -71,8 +71,8 @@
+     env:
+       ovirtCafile: /tmp/config/ovirt-engine-ca.pem
+     image:
+-      repository: olcne/ovirt-csi-driver
+-      tag: v4.21.0-2
++      repository: quay.io/ovirt/csi-driver
++      tag: latest
+     imagePullPolicy: IfNotPresent
+     resources:
+       requests:
+@@ -82,7 +82,7 @@
+ csiNode:
+   csiDriverRegistrar:
+     image:
+-      repository: olcne/csi-node-driver-registrar
++      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+       tag: v2.15.0
+     resources:
+       limits:
+@@ -93,7 +93,7 @@
+         memory: 64Mi
+   livenessProbe:
+     image:
+-      repository: olcne/livenessprobe
++      repository: registry.k8s.io/sig-storage/livenessprobe
+       tag: v2.17.0
+     resources:
+       limits:
+@@ -110,8 +110,8 @@
+       csiEndpoint: unix:///csi-socket/csi.sock
+       ovirtConfig: /tmp/config/ovirt-config.yaml
+     image:
+-      repository: olcne/ovirt-csi-driver
+-      tag: v4.21.0-2
++      repository: quay.io/ovirt/csi-driver
++      tag: latest
+     imagePullPolicy: Always
+     resources:
+       limits:
+@@ -124,8 +124,8 @@
+     env:
+       ovirtCafile: /tmp/config/ovirt-engine-ca.pem
+     image:
+-      repository: olcne/ovirt-csi-driver
+-      tag: v4.21.0-2
++      repository: quay.io/ovirt/csi-driver
++      tag: latest
+     imagePullPolicy: IfNotPresent
+     resources:
+       requests:

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
@@ -18,7 +18,11 @@
        tag: v6.0.0
      resources:
        limits:
-@@ -29,7 +29,7 @@
+@@ -26,10 +26,11 @@
+         cpu: 80m
+         memory: 64Mi
+   csiResizer:
++    enable: true
      containerSecurityContext:
        privileged: true
      image:
@@ -27,7 +31,7 @@
        tag: v1.14.0
      resources:
        limits:
-@@ -40,7 +40,7 @@
+@@ -40,7 +41,7 @@
          memory: 64Mi
    livenessProbe:
      image:
@@ -36,7 +40,7 @@
        tag: v2.17.0
      resources:
        limits:
-@@ -57,8 +57,8 @@
+@@ -57,8 +58,8 @@
        csiEndpoint: unix:///csi-socket/csi.sock
        ovirtConfig: /tmp/config/ovirt-config.yaml
      image:
@@ -47,7 +51,7 @@
      imagePullPolicy: Always
      resources:
        limits:
-@@ -71,8 +71,8 @@
+@@ -71,8 +72,8 @@
      env:
        ovirtCafile: /tmp/config/ovirt-engine-ca.pem
      image:
@@ -58,7 +62,7 @@
      imagePullPolicy: IfNotPresent
      resources:
        requests:
-@@ -82,7 +82,7 @@
+@@ -82,7 +83,7 @@
  csiNode:
    csiDriverRegistrar:
      image:
@@ -67,7 +71,7 @@
        tag: v2.15.0
      resources:
        limits:
-@@ -93,7 +93,7 @@
+@@ -93,7 +94,7 @@
          memory: 64Mi
    livenessProbe:
      image:
@@ -76,7 +80,7 @@
        tag: v2.17.0
      resources:
        limits:
-@@ -110,8 +110,8 @@
+@@ -110,8 +111,8 @@
        csiEndpoint: unix:///csi-socket/csi.sock
        ovirtConfig: /tmp/config/ovirt-config.yaml
      image:
@@ -87,7 +91,7 @@
      imagePullPolicy: Always
      resources:
        limits:
-@@ -124,8 +124,8 @@
+@@ -124,8 +125,8 @@
      env:
        ovirtCafile: /tmp/config/ovirt-engine-ca.pem
      image:
@@ -98,3 +102,10 @@
      imagePullPolicy: IfNotPresent
      resources:
        requests:
+@@ -153,3 +154,6 @@
+ 
+ ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+ imagePullSecrets: []
++
++global:
++  systemDefaultRegistry: ""

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
@@ -5,7 +5,7 @@
        privileged: true
      image:
 -      repository: olcne/csi-attacher
-+      repository: registry.k8s.io/sig-storage/csi-attacher
++      repository: rancher/mirrored-sig-storage-csi-attacher
        tag: v4.10.0
      resources:
        limits:
@@ -14,7 +14,7 @@
        privileged: true
      image:
 -      repository: olcne/csi-provisioner
-+      repository: registry.k8s.io/sig-storage/csi-provisioner
++      repository: rancher/mirrored-sig-storage-csi-provisioner
        tag: v6.0.0
      resources:
        limits:
@@ -22,12 +22,12 @@
          cpu: 80m
          memory: 64Mi
    csiResizer:
-+    enable: true
++    enabled: false
      containerSecurityContext:
        privileged: true
      image:
 -      repository: olcne/csi-resizer
-+      repository: registry.k8s.io/sig-storage/csi-resizer
++      repository: rancher/mirrored-sig-storage-csi-resizer
        tag: v1.14.0
      resources:
        limits:
@@ -36,7 +36,7 @@
    livenessProbe:
      image:
 -      repository: olcne/livenessprobe
-+      repository: registry.k8s.io/sig-storage/livenessprobe
++      repository: rancher/mirrored-sig-storage-livenessprobe
        tag: v2.17.0
      resources:
        limits:
@@ -46,8 +46,8 @@
      image:
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
-+      repository: quay.io/ovirt/csi-driver
-+      tag: latest
++      repository: rancher/mirrored-ovirt-csi-driver
++      tag: 4.21.0
      imagePullPolicy: Always
      resources:
        limits:
@@ -57,8 +57,8 @@
      image:
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
-+      repository: quay.io/ovirt/csi-driver
-+      tag: latest
++      repository: rancher/mirrored-ovirt-csi-driver
++      tag: 4.21.0
      imagePullPolicy: IfNotPresent
      resources:
        requests:
@@ -67,7 +67,7 @@
    csiDriverRegistrar:
      image:
 -      repository: olcne/csi-node-driver-registrar
-+      repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
++      repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
        tag: v2.15.0
      resources:
        limits:
@@ -76,7 +76,7 @@
    livenessProbe:
      image:
 -      repository: olcne/livenessprobe
-+      repository: registry.k8s.io/sig-storage/livenessprobe
++      repository: rancher/mirrored-sig-storage-livenessprobe
        tag: v2.17.0
      resources:
        limits:
@@ -86,8 +86,8 @@
      image:
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
-+      repository: quay.io/ovirt/csi-driver
-+      tag: latest
++      repository: rancher/mirrored-ovirt-csi-driver
++      tag: 4.21.0
      imagePullPolicy: Always
      resources:
        limits:
@@ -97,8 +97,8 @@
      image:
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
-+      repository: quay.io/ovirt/csi-driver
-+      tag: latest
++      repository: rancher/mirrored-ovirt-csi-driver
++      tag: 4.21.0
      imagePullPolicy: IfNotPresent
      resources:
        requests:

--- a/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ovirt-csi-driver/generated-changes/patch/values.yaml.patch
@@ -47,7 +47,7 @@
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
 +      repository: rancher/mirrored-ovirt-csi-driver
-+      tag: 4.21.0
++      tag: 4.15.0
      imagePullPolicy: Always
      resources:
        limits:
@@ -58,7 +58,7 @@
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
 +      repository: rancher/mirrored-ovirt-csi-driver
-+      tag: 4.21.0
++      tag: 4.15.0
      imagePullPolicy: IfNotPresent
      resources:
        requests:
@@ -87,7 +87,7 @@
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
 +      repository: rancher/mirrored-ovirt-csi-driver
-+      tag: 4.21.0
++      tag: 4.15.0
      imagePullPolicy: Always
      resources:
        limits:
@@ -98,7 +98,7 @@
 -      repository: olcne/ovirt-csi-driver
 -      tag: v4.21.0-2
 +      repository: rancher/mirrored-ovirt-csi-driver
-+      tag: 4.21.0
++      tag: 4.15.0
      imagePullPolicy: IfNotPresent
      resources:
        requests:

--- a/packages/rke2-ovirt-csi-driver/package.yaml
+++ b/packages/rke2-ovirt-csi-driver/package.yaml
@@ -1,0 +1,4 @@
+url: https://github.com/oracle-cne/catalog.git
+subdirectory: charts/ovirt-csi-driver-4.21.0
+commit: 4eff0ec9866e3c7b2c5fce7feee97c5c1d91744e  # ovirt-csi-driver-4.21.0
+packageVersion: 00


### PR DESCRIPTION
There is two pods in the chart that is `csi-resizer` and the `liveness-probe` that were added differently from what QA did since they are from the chart itself, the `csi-resizer` if the engine does no support resize they will be in CrashLoop and giving errors. 

So the question is -> should we remove the `csi-resizer`? we will lose this feature that the csi-driver has, but it will stop the errors or should we still give the chart and let users handle this?

Besides that, everything runs very smoothly, the only thing that might happen is that the image of the csi-driver is based on the latest and oracle apparently does no give anything besides `latest` or `test`

Issue -> https://github.com/rancher/rke2/issues/10304