### PR TITLE
Restore CRD validation to rke2-calico

### DIFF
--- a/packages/rke2-calico-crd/package.yaml
+++ b/packages/rke2-calico-crd/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.32.0/crd.projectcalico.org.v1-v3.32.0.tgz
-packageVersion: 00
+packageVersion: 01

--- a/packages/rke2-calico/generated-changes/overlay/templates/validate-install-crd.yaml
+++ b/packages/rke2-calico/generated-changes/overlay/templates/validate-install-crd.yaml
@@ -1,0 +1,45 @@
+#{{- if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 -}}
+# {{- $found := dict -}}
+# {{- set $found "crd.projectcalico.org/v1/BGPConfiguration" false -}}
+# {{- set $found "crd.projectcalico.org/v1/BGPFilter" false -}}
+# {{- set $found "crd.projectcalico.org/v1/BGPPeer" false -}}
+# {{- set $found "crd.projectcalico.org/v1/BlockAffinity" false -}}
+# {{- set $found "crd.projectcalico.org/v1/CalicoNodeStatus" false -}}
+# {{- set $found "crd.projectcalico.org/v1/ClusterInformation" false -}}
+# {{- set $found "crd.projectcalico.org/v1/FelixConfiguration" false -}}
+# {{- set $found "crd.projectcalico.org/v1/GlobalNetworkPolicy" false -}}
+# {{- set $found "crd.projectcalico.org/v1/GlobalNetworkSet" false -}}
+# {{- set $found "crd.projectcalico.org/v1/HostEndpoint" false -}}
+# {{- set $found "crd.projectcalico.org/v1/IPAMBlock" false -}}
+# {{- set $found "crd.projectcalico.org/v1/IPAMConfig" false -}}
+# {{- set $found "crd.projectcalico.org/v1/IPAMHandle" false -}}
+# {{- set $found "crd.projectcalico.org/v1/IPPool" false -}}
+# {{- set $found "crd.projectcalico.org/v1/IPReservation" false -}}
+# {{- set $found "crd.projectcalico.org/v1/KubeControllersConfiguration" false -}}
+# {{- set $found "crd.projectcalico.org/v1/NetworkPolicy" false -}}
+# {{- set $found "crd.projectcalico.org/v1/NetworkSet" false -}}
+# {{- set $found "crd.projectcalico.org/v1/StagedGlobalNetworkPolicy" false -}}
+# {{- set $found "crd.projectcalico.org/v1/StagedKubernetesNetworkPolicy" false -}}
+# {{- set $found "crd.projectcalico.org/v1/StagedNetworkPolicy" false -}}
+# {{- set $found "crd.projectcalico.org/v1/Tier" false -}}
+# {{- set $found "policy.networking.k8s.io/v1alpha2/ClusterNetworkPolicy" false -}}
+# {{- set $found "operator.tigera.io/v1/APIServer" false -}}
+# {{- set $found "operator.tigera.io/v1/GatewayAPI" false -}}
+# {{- set $found "operator.tigera.io/v1/Goldmane" false -}}
+# {{- set $found "operator.tigera.io/v1/ImageSet" false -}}
+# {{- set $found "operator.tigera.io/v1/Installation" false -}}
+# {{- set $found "operator.tigera.io/v1/Istio" false -}}
+# {{- set $found "operator.tigera.io/v1/ManagementClusterConnection" false -}}
+# {{- set $found "operator.tigera.io/v1/TigeraStatus" false -}}
+# {{- set $found "operator.tigera.io/v1/Whisker" false -}}
+# {{- range .Capabilities.APIVersions -}}
+# {{- if hasKey $found (toString .) -}}
+# 	{{- set $found (toString .) true -}}
+# {{- end -}}
+# {{- end -}}
+# {{- range $_, $exists := $found -}}
+# {{- if (eq $exists false) -}}
+# 	{{- required "Required CRDs are missing. Please install the corresponding CRD chart before installing this chart." "" -}}
+# {{- end -}}
+# {{- end -}}
+#{{- end -}}

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.32.0/tigera-operator-v3.32.0.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
We'll need to manually keep this in sync with rke2-calico-crd contents.