### PR TITLE
Bump snapshot-controller image tag to v8.5.0-build20260512

### DIFF
--- a/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
      pullPolicy: IfNotPresent
      # Overrides the image tag whose default is the chart appVersion.
 -    tag: ""
-+    tag: "v8.5.0-build20260410"
++    tag: "v8.5.0-build20260512"
  
    imagePullSecrets: []
  

--- a/packages/rke2-snapshot-controller/package.yaml
+++ b/packages/rke2-snapshot-controller/package.yaml
@@ -1,7 +1,7 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-controller
 commit: ccc8a601db5ae518334da43ce7a5851ea349d526  # snapshot-controller-4.2.0
-packageVersion: 03
+packageVersion: 04
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Bump to go 1.25.10 for CVE reasons