### PR TITLE
fix(rke2-multus): correct socket path in dhcp DS init container

### DIFF
--- a/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
@@ -32,7 +32,7 @@ spec:
       initContainers:
       - name: kube-{{ .Chart.Name }}-dhcp-cleanup
         image: {{ template "system_default_registry" . }}{{ .Values.dhcpDaemonSet.image.repository }}:{{ .Values.dhcpDaemonSet.image.tag }}
-        command: ["rm", "-f", "/run/cni/dhcp.sock"]
+        command: ["rm", "-f", "/host/run/cni/dhcp.sock"]
         securityContext:
           privileged: true
         volumeMounts:

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 13
+packageVersion: 14


### PR DESCRIPTION
In `rke2-multus/charts/templates/dhcp-daemonSet.yaml`, the init container mounts `/host/run/cni`, the command arg should remove the socket in the same path.

```diff
--- a/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
+++ b/packages/rke2-multus/charts/templates/dhcp-daemonSet.yaml
@@ -32,7 +32,7 @@ spec:
       initContainers:
       - name: kube-{{ .Chart.Name }}-dhcp-cleanup
         image: {{ template "system_default_registry" . }}{{ .Values.dhcpDaemonSet.image.repository }}:{{ .Values.dhcpDaemonSet.image.tag }}
-        command: ["rm", "-f", "/run/cni/dhcp.sock"]               # <--- BUG
+        command: ["rm", "-f", "/host/run/cni/dhcp.sock"]      # <--- FIX
  volumeMounts:
  - name: socketpath
    mountPath: /host/run/cni  
```
Fixes: https://github.com/rancher/rke2/issues/10423