### PR TITLE
Add toleration for network-unavailable

### DIFF
--- a/packages/rke2-calico-crd/package.yaml
+++ b/packages/rke2-calico-crd/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.32.0/crd.projectcalico.org.v1-v3.32.0.tgz
-packageVersion: 02
+packageVersion: 03

--- a/packages/rke2-calico/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-calico/generated-changes/patch/values.yaml.patch
@@ -23,7 +23,7 @@
  
    # Valid options: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG, Kind.
    # If empty the operator will attempt to automatically determine the current provider.
-@@ -65,7 +72,13 @@
+@@ -65,7 +72,16 @@
  
    controlPlaneNodeSelector: {}
  
@@ -35,10 +35,13 @@
 +  - key: "node-role.kubernetes.io/etcd"
 +    operator: "Exists"
 +    effect: "NoExecute"
++  - key: "node.kubernetes.io/network-unavailable"
++    operator: "Exists"
++    effect: "NoSchedule"
  
    # Run Calico in non-privileged mode (Rootless)
    nonPrivileged: "Disabled"
-@@ -85,15 +98,15 @@
+@@ -85,15 +101,15 @@
  # apiServer configures the Calico API server, needed for interacting with
  # the projectcalico.org/v3 suite of APIs.
  apiServer:
@@ -57,7 +60,7 @@
  
  defaultFelixConfiguration:
    enabled: false
-@@ -111,7 +124,7 @@
+@@ -111,7 +127,7 @@
  
  # Whether or not the tigera/operator should manange CustomResourceDefinitions
  # needed to run itself and Calico. If disabled, you must manage these resources out-of-band.
@@ -66,7 +69,7 @@
  
  # Resource requests and limits for the tigera/operator pod.
  resources: {}
-@@ -146,13 +159,32 @@
+@@ -146,13 +162,32 @@
  dnsConfig: {}
  # Image and registry configuration for the tigera/operator pod.
  tigeraOperator:

--- a/packages/rke2-calico/package.yaml
+++ b/packages/rke2-calico/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/projectcalico/calico/releases/download/v3.32.0/tigera-operator-v3.32.0.tgz
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
Fixes issue where calico-typha pods could not schedule onto a node after calico-node pod was deleted and added NetworkUnavailable condition to the nodes, which in turn prevented calico-node from coming back up again.

I'd prefer to have calico just not set that condition when it's going down, but there does not seem to be a way to do that.