### PR TITLE
Adapt custom template to the new traefik chart

### DIFF
--- a/packages/rke2-traefik/generated-changes/exclude/values.schema.json
+++ b/packages/rke2-traefik/generated-changes/exclude/values.schema.json
@@ -46,6 +46,13 @@
                         "null"
                     ]
                 },
+                "disableDashboardAd": {
+                    "description": "Disable the advertisement from the dashboard.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "insecure": {
                     "description": "Enable the insecure API (HTTP)",
                     "type": [

--- a/packages/rke2-traefik/generated-changes/overlay/templates/migrationClass.yaml
+++ b/packages/rke2-traefik/generated-changes/overlay/templates/migrationClass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.providers.kubernetesIngressNginx.enabled -}}
+{{- if .Values.providers.kubernetesIngressNGINX.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:

--- a/packages/rke2-traefik/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/Chart.yaml.patch
@@ -1,14 +1,14 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -5,6 +5,7 @@
+@@ -9,6 +9,7 @@
    traefik.io/hub-min-version: v3.19.3
-   traefik.io/proxy-max-version: v3.7.0
+   traefik.io/proxy-max-version: v3.7.1
    traefik.io/proxy-min-version: v3.6.0
 +  fleet.cattle.io/bundle-id: rke2
  apiVersion: v2
- appVersion: v3.7.0
+ appVersion: v3.7.1
  description: A Traefik based Kubernetes ingress controller
-@@ -21,7 +22,7 @@
+@@ -25,7 +26,7 @@
  - email: remi.buisson@traefik.io
    name: darkweaver87
  - name: jnoordsij

--- a/packages/rke2-traefik/generated-changes/patch/VALUES.md.patch
+++ b/packages/rke2-traefik/generated-changes/patch/VALUES.md.patch
@@ -1,6 +1,6 @@
 --- charts-original/VALUES.md
 +++ charts/VALUES.md
-@@ -58,7 +58,7 @@
+@@ -59,7 +59,7 @@
  | deployment.hostUsers | string | unset (inherits cluster default) | Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
  | deployment.imagePullSecrets | list | `[]` | Pull secret for fetching traefik container image |
  | deployment.initContainers | list | `[]` | Additional initContainers (e.g. for setting file permission as shown below) |
@@ -9,7 +9,7 @@
  | deployment.labels | object | `{}` | Additional deployment labels (e.g. for filtering deployment by custom labels) |
  | deployment.lifecycle | object | `{}` | Pod lifecycle actions |
  | deployment.livenessPath | string | `""` | Override the liveness path. Default: /ping |
-@@ -216,7 +216,7 @@
+@@ -217,7 +217,7 @@
  | image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
  | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
  | image.registry | string | `"docker.io"` | Traefik image host registry |
@@ -18,7 +18,7 @@
  | image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image). |
  | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
  | ingressClass.isDefaultClass | bool | `true` |  |
-@@ -454,7 +454,7 @@
+@@ -455,7 +455,7 @@
  | providers.kubernetesCRD.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
  | providers.kubernetesCRD.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in IngressRoute |
  | providers.kubernetesCRD.enabled | bool | `true` | Load Kubernetes IngressRoute provider |
@@ -27,7 +27,7 @@
  | providers.kubernetesCRD.labelSelector | string | `""` | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector) |
  | providers.kubernetesCRD.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
  | providers.kubernetesCRD.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
-@@ -472,7 +472,7 @@
+@@ -473,7 +473,7 @@
  | providers.kubernetesIngress.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in Ingress |
  | providers.kubernetesIngress.disableIngressClassLookup | bool | `false` | Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup) |
  | providers.kubernetesIngress.enabled | bool | `true` | Load Kubernetes Ingress provider |
@@ -36,7 +36,7 @@
  | providers.kubernetesIngress.ingressEndpoint.hostname | string | `""` | Hostname used for Kubernetes Ingress endpoints |
  | providers.kubernetesIngress.ingressEndpoint.ip | string | `""` | IP used for Kubernetes Ingress endpoints |
  | providers.kubernetesIngress.labelSelector | string | `nil` |  |
-@@ -544,7 +544,7 @@
+@@ -545,7 +545,7 @@
  | service.labels | object | `{}` | Additional service labels (e.g. for filtering Service by custom labels) |
  | service.nameOverride | string | `""` | Override the default Service name. Useful for adopting an existing Service (e.g., during migration from another ingress controller). |
  | service.single | bool | `true` |  |

--- a/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
@@ -22,7 +22,7 @@
    # -- Number of pods of the deployment (only applies when kind == Deployment)
    replicas: 1
    # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
-@@ -266,8 +266,8 @@
+@@ -268,8 +268,8 @@
    # -- Customize updateStrategy of Deployment or DaemonSet
    type: RollingUpdate
    rollingUpdate:
@@ -33,7 +33,7 @@
  
  readinessProbe:  # @schema additionalProperties: false
    # -- The number of consecutive failures allowed before considering the probe as failed.
-@@ -310,7 +310,7 @@
+@@ -312,7 +312,7 @@
      # -- Allows to return 503 when there are no endpoints available
      allowEmptyServices: true
      # -- When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.
@@ -42,7 +42,7 @@
      # -- See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector)
      labelSelector: ""
      # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.
-@@ -852,6 +852,8 @@
+@@ -854,6 +854,8 @@
          insecureSkipVerify:  # @schema type:[boolean, null]
  
  global:
@@ -51,7 +51,7 @@
    checkNewVersion: true
    # -- Please take time to consider whether or not you wish to share anonymous data with us
    # See https://doc.traefik.io/traefik/contributing/data-collection/
-@@ -924,7 +926,7 @@
+@@ -926,7 +928,7 @@
      ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
      asDefault:  # @schema type: [boolean, null]; default: null
      port: 8000
@@ -60,7 +60,7 @@
      # containerPort: 8000
      expose:
        default: true
-@@ -982,7 +984,7 @@
+@@ -984,7 +986,7 @@
      ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
      # asDefault: true
      port: 8443
@@ -69,7 +69,7 @@
      containerPort:  # @schema type:[integer, null]; minimum:0
      expose:
        default: true
-@@ -1110,7 +1112,8 @@
+@@ -1112,7 +1114,8 @@
    # -- Additional entries here will be added to the Service [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core).
    # Cannot contain selector or ports entries.
    spec:
@@ -79,7 +79,7 @@
    # -- Can be used to create multiple Service.
    # See EXAMPLES.md for more details.
    additionalServices: {}
-@@ -1199,7 +1202,8 @@
+@@ -1201,7 +1204,8 @@
  #        topologyKey: kubernetes.io/hostname
  
  # -- nodeSelector is the simplest recommended form of node selection constraint.

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,5 +1,5 @@
-url: https://traefik.github.io/charts/traefik/traefik-40.0.1.tgz
-packageVersion: 01
+url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
+packageVersion: 00
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 

--- a/packages/rke2-traefik/templates/crd-template/Chart.yaml
+++ b/packages/rke2-traefik/templates/crd-template/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 40.0.1
-appVersion: v3.7.0
+version: 40.1.0
+appVersion: v3.7.1
 description: Installs the CRDs for rke2-traefik
 name: rke2-traefik-crd
 type: application


### PR DESCRIPTION
Bump chart to the 40.1.0, which still includes the Gateway API CRDs.

Adapt the var to the new name kubernetesIngressNGINX. In previous charts it was kubernetesIngressNginx