### PR TITLE
Fix bug. DaemonSet has a capital S

### DIFF
--- a/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
@@ -18,7 +18,7 @@
    enabled: true
    # -- Deployment or DaemonSet
 -  kind: Deployment
-+  kind: Daemonset
++  kind: DaemonSet
    # -- Number of pods of the deployment (only applies when kind == Deployment)
    replicas: 1
    # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 


### PR DESCRIPTION
The previous chart was using the value: "Daemonset" instead of "DaemonSet". As a result, no traefik daemonset was generated