### PR TITLE
Bump Traefik to v3.7.3

### DIFF
--- a/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
    # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
    # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
 -  tag:  # @schema type:[string, null]
-+  tag: v3.7.1-build20260601  # @schema type:[string, null]
++  tag: v3.7.3-build20260605  # @schema type:[string, null]
    # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
    digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
    # -- Traefik image pull policy
@@ -22,6 +22,17 @@
    # -- Number of pods of the deployment (only applies when kind == Deployment)
    replicas: 1
    # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+@@ -123,8 +123,8 @@
+ ingressClass:  # @schema additionalProperties: false
+   # -- Create a default IngressClass for Traefik
+   enabled: true
+-  isDefaultClass: true
+-  name: ""
++  isDefaultClass: false
++  name: "traefik"
+ 
+ core:  # @schema additionalProperties: false
+   # -- Can be used to use globally v2 router syntax. Deprecated since v3.4 /!\.
 @@ -268,8 +268,8 @@
    # -- Customize updateStrategy of Deployment or DaemonSet
    type: RollingUpdate

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
-packageVersion: 01
+packageVersion: 02
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 


### PR DESCRIPTION
The ingressClassName change is what is needed to fix the failing rke2 test