### PR TITLE
Fix rke2-canal chart RBAC rendering for Calico kube-controllers

### DIFF
--- a/packages/rke2-canal/charts/templates/rbac.yaml
+++ b/packages/rke2-canal/charts/templates/rbac.yaml
@@ -241,9 +241,7 @@ rules:
     verbs:
       - get
       - list
-       - update
-
-
+      - update
       - watch
   # IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
   - apiGroups: ["crd.projectcalico.org"]
@@ -306,6 +304,15 @@ rules:
       # update status
       - update
       # watch for changes
+      - watch
+  # Needs access to get, list and watch namespaces.
+  - apiGroups:
+      - ""
+    resources:
+    - namespaces
+    verbs:
+      - get
+      - list
       - watch
 ---
 kind: ClusterRoleBinding

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
This PR fixes an issue in the `rke2-canal` chart that produces malformed RBAC rules when `calico.calicoKubeControllers=true`.

### **Issue**

When enabled, the generated ClusterRole contains an invalid verb entry (https://github.com/rancher/rke2-charts/blob/main-source/packages/rke2-canal/charts/templates/rbac.yaml#L244):

```
- get
- list - update
- watch
```

This results in `update` not being granted as a separate verb.

Additionally, the RBAC rules do not include access to `namespaces`, which is required for Calico kube-controllers to watch namespace resources (https://github.com/projectcalico/calico/blob/master/charts/calico/templates/calico-kube-controllers-rbac.yaml)

### **Impact**

Calico kube-controllers fails to watch core Kubernetes resources:

```
failed to list *v1.Namespace: namespaces is forbidden
failed to list *v1.Service: services is forbidden
```

This prevents proper reconciliation of cluster state (services, endpoints, and policies).

### **Reproduction**

Enable in HelmChartConfig:

```yaml
calico:
  calicoKubeControllers: true
```

Deploy rke2-canal chart and inspect generated ClusterRole.