### PR TITLE
Fix metrics-server

### DIFF
--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.13.1/metrics-server-3.13.1.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
The release on the 4th of June failed in the CI: https://github.com/kubernetes-sigs/metrics-server/actions/runs/26792099111

Probably it was released and our updateCLI picked it up: https://github.com/rancher/rke2-charts/pull/1018#issue-4584854574

Then, rke2-metrics released again with the same version 1.13.1 on the 11th https://github.com/rancher/rke2-charts/pull/1018#issue-4584854574

It's probably 99% the same but perhaps there is some metadata related to date that makes the hash not be exactly the same, hence:
time="2026-06-18T09:46:14Z" level=fatal msg="Failed to validate against main: Hash of new contents at new-assets/charts-without-rc/rke2-metrics-server/rke2-metrics-server/3.13.100 does not match that of old contents at original-assets/charts/rke2-metrics-server/rke2-metrics-server/3.13.100"

This PR creates a new chart of rke2-metrics with the current release (the one on the 11th of June)