### PR TITLE
Bump HCP to 0.2.12

### DIFF
--- a/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
+++ b/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
@@ -1,3 +1,3 @@
 workingDir: ""
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.11/harvester-cloud-provider-0.2.11.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.12/harvester-cloud-provider-0.2.12.tgz
 subdirectory: dependency_charts/kube-vip

--- a/packages/harvester-cloud-provider/generated-changes/patch/Chart.yaml.patch
+++ b/packages/harvester-cloud-provider/generated-changes/patch/Chart.yaml.patch
@@ -5,7 +5,7 @@
    catalog.cattle.io/release-name: harvester-cloud-provider
    catalog.cattle.io/ui-component: harvester-cloud-provider
 -  catalog.cattle.io/upstream-version: 0.2.0
-+  catalog.cattle.io/upstream-version: 0.2.11
++  catalog.cattle.io/upstream-version: 0.2.12
  apiVersion: v2
- appVersion: v0.2.5
+ appVersion: v0.2.6
  dependencies:

--- a/packages/harvester-cloud-provider/package.yaml
+++ b/packages/harvester-cloud-provider/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.11/harvester-cloud-provider-0.2.11.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.12/harvester-cloud-provider-0.2.12.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
Harvester issue: https://github.com/harvester/harvester/issues/10068

Latest HCP 0.2.12 https://github.com/harvester/charts/releases/tag/harvester-cloud-provider-0.2.12 has been released.

Bump harvester-cloud-provider chart version to 0.2.12

HCP: chart version 0.2.12
  app image tag: 0.2.6

  dependency kube-vip: chart version: 0.9.8, image tag v1.1.2