### PR TITLE
[rke2-coredns] Add nodelocal.extraClusterDomains for extra cluster-domain zones

### DIFF
--- a/packages/rke2-coredns/generated-changes/overlay/templates/configmap-nodelocal.yaml
+++ b/packages/rke2-coredns/generated-changes/overlay/templates/configmap-nodelocal.yaml
@@ -9,7 +9,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
-    {{ coalesce .Values.global.clusterDomain "cluster.local" }}:53 {{ range .Values.nodelocal.extraClusterDomains }}{{ . }}:53 {{ end }}{
+    {{ coalesce .Values.global.clusterDomain "cluster.local" }}:53{{ range .Values.nodelocal.extraClusterDomains }} {{ . }}:53{{ end }} {
         errors
         cache {
                 success 9984 30

--- a/packages/rke2-coredns/generated-changes/overlay/templates/configmap-nodelocal.yaml
+++ b/packages/rke2-coredns/generated-changes/overlay/templates/configmap-nodelocal.yaml
@@ -9,7 +9,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
-    {{ coalesce .Values.global.clusterDomain "cluster.local" }}:53 {
+    {{ coalesce .Values.global.clusterDomain "cluster.local" }}:53 {{ range .Values.nodelocal.extraClusterDomains }}{{ . }}:53 {{ end }}{
         errors
         cache {
                 success 9984 30

--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -164,7 +164,7 @@
      failureThreshold: 3
      successThreshold: 1
  
-@@ -431,3 +453,39 @@
+@@ -431,3 +453,46 @@
  
  # Configures initcontainers for the coredns deployment.
  initContainers: []
@@ -177,6 +177,13 @@
 +  enabled: false
 +  ip_address: "169.254.20.10"
 +  ipvs: false
++
++  # Additional domains served from the same server block as the cluster domain
++  # in the node-local-dns cache. Each entry is appended to the cluster-domain
++  # block header and is therefore cached locally and forwarded to the cluster
++  # DNS over force_tcp, exactly like the cluster domain (e.g. "cluster.local").
++  # Defaults to [] (no extra domains, no change to the rendered Corefile).
++  extraClusterDomains: []
 +
 +  # set to true, if you wish to use nodelocal with cilium in kube-proxy replacement mode.
 +  # This sets up a Cilium Local Redirect Policy (LRP) to steer DNS traffic to the nodelocal dns cache.

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.46.0/coredns-1.46.0.tgz
-packageVersion: 02
+packageVersion: 03


### PR DESCRIPTION
### What this does

Adds an optional `nodelocal.extraClusterDomains` list to the `rke2-coredns` chart. Each entry is appended to the cluster-domain server block of the node-local-dns Corefile, so the domain is cached locally and forwarded to the cluster DNS over `force_tcp` — identically to the cluster domain.

The node-local-dns Corefile is rendered from a hardcoded template (`templates/configmap-nodelocal.yaml`) with four fixed zone blocks (cluster domain, `in-addr.arpa`, `ip6.arpa`, `.`). Today there is no values hook to serve an additional internal suffix the same way as the cluster domain; any other suffix falls through to the `.:53` upstream-forward block. This adds that hook.

### Changes

- `generated-changes/overlay/templates/configmap-nodelocal.yaml` — append each `nodelocal.extraClusterDomains` entry to the cluster-domain block header.
- `generated-changes/patch/values.yaml.patch` — document the new `extraClusterDomains: []` value (empty by default).
- `package.yaml` — bump `packageVersion` `02` → `03`.

Regenerated via the documented workflow: `PACKAGE=rke2-coredns make prepare` → edit working dir → `make patch` → `make clean`.

### Rendered output

`nodelocal.extraClusterDomains: []` (default) — unchanged:

```
cluster.local:53 {
    errors
    ...
}
```

`nodelocal.extraClusterDomains: [example.internal, foo.bar]`:

```
cluster.local:53 example.internal:53 foo.bar:53 {
    errors
    ...
}
```

### Compatibility

Default is `[]`, so the rendered Corefile is byte-for-byte unchanged for existing deployments.

### Related

Addresses rancher/rke2#10672.
