### PR TITLE
Support kubernetesIngressNginx temporarily

### DIFF
--- a/packages/rke2-traefik/generated-changes/overlay/templates/migrationClass.yaml
+++ b/packages/rke2-traefik/generated-changes/overlay/templates/migrationClass.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.providers.kubernetesIngressNGINX.enabled -}}
+{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+{{- if $kubernetesIngressNGINX.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:

--- a/packages/rke2-traefik/generated-changes/patch/templates/NOTES.txt.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/NOTES.txt.patch
@@ -1,0 +1,19 @@
+--- charts-original/templates/NOTES.txt
++++ charts/templates/NOTES.txt
+@@ -120,6 +120,16 @@
+   {{- end -}}
+ 
+ 
++{{/* Warn about legacy Kubernetes Ingress NGINX provider key */}}
++{{- if and (hasKey .Values.providers "kubernetesIngressNginx") (default false .Values.providers.kubernetesIngressNginx.enabled) }}
++{{- printf "\n" -}}
++⚠️ DEPRECATION WARNING: You are using providers.kubernetesIngressNginx (legacy key).
++Please migrate to providers.kubernetesIngressNGINX.
++The legacy key will be removed in a future version.
++{{- printf "\n" -}}
++{{- end -}}
++
++
+ {{/* Warn about Gateway API CRDs no longer shipped with this chart in future versions */}}
+ {{- if .Values.providers.kubernetesGateway.enabled }}
+ {{- printf "\n" -}}

--- a/packages/rke2-traefik/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/_helpers.tpl.patch
@@ -9,7 +9,44 @@
  {{- end -}}
  {{- end -}}
  
-@@ -486,3 +486,11 @@
+@@ -147,9 +147,20 @@
+ {{- print $servicePath | trimSuffix "-" -}}
+ {{- end -}}
+ 
++{{- define "providers.kubernetesIngressNGINX.values" -}}
++{{- $new := default dict .Values.providers.kubernetesIngressNGINX -}}
++{{- $old := default dict .Values.providers.kubernetesIngressNginx -}}
++{{- $provider := $new -}}
++{{- if and $old.enabled (not $new.enabled) -}}
++{{- $provider = mergeOverwrite (dict) $new $old -}}
++{{- end -}}
++{{- toYaml $provider }}
++{{- end -}}
++
+ {{- define "providers.kubernetesIngressNGINX.publishServicePath" -}}
+ {{- $defServiceName := printf "%s/%s" (include "traefik.namespace" .) (include "traefik.fullname" .) -}}
+-{{- $servicePath := default $defServiceName .Values.providers.kubernetesIngressNGINX.publishService.pathOverride }}
++{{- $provider := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
++{{- $servicePath := default $defServiceName (dig "publishService" "pathOverride" "" $provider) }}
+ {{- print $servicePath | trimSuffix "-" -}}
+ {{- end -}}
+ 
+@@ -166,7 +177,13 @@
+ {{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngress.namespaces) }}
+ {{- end -}}
+ {{- define "providers.kubernetesIngressNGINX.namespaces" -}}
+-{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngressNGINX.watchNamespace) }}
++{{- $provider := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
++{{- $watchNamespace := dig "watchNamespace" "" $provider -}}
++{{- if kindIs "slice" $watchNamespace -}}
++{{- default (include "traefik.namespace" .) (join "," $watchNamespace) }}
++{{- else -}}
++{{- default (include "traefik.namespace" .) $watchNamespace }}
++{{- end -}}
+ {{- end -}}
+ {{- define "providers.knative.namespaces" -}}
+ {{- default (include "traefik.namespace" .) (join "," .Values.providers.knative.namespaces) }}
+@@ -486,3 +503,11 @@
  {{- define "traefik.hubTokenFilePath" }}
  {{- printf "%s/%s" (.Values.hub.tokenMountPath | trimSuffix "/") "token" -}}
  {{- end -}}

--- a/packages/rke2-traefik/generated-changes/patch/templates/_podtemplate.tpl.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/_podtemplate.tpl.patch
@@ -9,3 +9,13 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          name: {{ template "traefik.fullname" . }}
          resources:
+@@ -596,7 +596,8 @@
+           {{- end }}
+           {{- end }}
+           {{- end }}
+-          {{- with .Values.providers.kubernetesIngressNGINX }}
++          {{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) }}
++          {{- with $kubernetesIngressNGINX }}
+            {{- if .enabled }}
+           - "--providers.kubernetesingressnginx"
+             {{- if or .watchNamespace (and $.Values.rbac.enabled $.Values.rbac.namespaced) }}

--- a/packages/rke2-traefik/generated-changes/patch/templates/rbac/clusterrole.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/rbac/clusterrole.yaml.patch
@@ -1,0 +1,17 @@
+--- charts-original/templates/rbac/clusterrole.yaml
++++ charts/templates/rbac/clusterrole.yaml
+@@ -1,4 +1,5 @@
+ {{- $version := include "traefik.proxyVersion" $ }}
++{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+ {{- if and .Values.rbac.enabled (not .Values.rbac.namespaced) }}
+ ---
+ kind: ClusterRole
+@@ -48,7 +49,7 @@
+       - delete
+       - deletecollection
+     {{- end }}
+-  {{- if or .Values.providers.kubernetesIngress.enabled .Values.providers.kubernetesIngressNGINX.enabled }}
++  {{- if or .Values.providers.kubernetesIngress.enabled $kubernetesIngressNGINX.enabled }}
+   - apiGroups:
+       - extensions
+       - networking.k8s.io

--- a/packages/rke2-traefik/generated-changes/patch/templates/rbac/role.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/rbac/role.yaml.patch
@@ -1,0 +1,17 @@
+--- charts-original/templates/rbac/role.yaml
++++ charts/templates/rbac/role.yaml
+@@ -1,4 +1,5 @@
+ {{- $version := include "traefik.proxyVersion" $ }}
++{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+ {{- $ingressNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
+ {{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
+ {{- $knativeNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.knative.namespaces -}}
+@@ -47,7 +48,7 @@
+       - get
+       - list
+       - watch
+-{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) ($.Values.providers.kubernetesIngressNGINX.enabled) }}
++{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) ($kubernetesIngressNGINX.enabled) }}
+   - apiGroups:
+       - extensions
+       - networking.k8s.io

--- a/packages/rke2-traefik/generated-changes/patch/templates/requirements.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/requirements.yaml.patch
@@ -1,0 +1,54 @@
+--- charts-original/templates/requirements.yaml
++++ charts/templates/requirements.yaml
+@@ -1,4 +1,5 @@
+ {{- $version := include "traefik.proxyVersion" $ }}
++{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+ {{- $proxyMinVersion := index .Chart.Annotations "traefik.io/proxy-min-version" }}
+ {{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" }}
+ {{- if (ne $version "experimental-v3.0") }}
+@@ -31,15 +32,15 @@
+   {{- end }}
+ {{- end }}
+ 
+-{{- if and (semverCompare "<v3.6.2-0" $version) (.Values.providers.kubernetesIngressNGINX).enabled}}
++{{- if and (semverCompare "<v3.6.2-0" $version) $kubernetesIngressNGINX.enabled}}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider is only available for traefik >= v3.6.2." }}
+ {{- end }}
+ 
+-{{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (not $.Values.hub.token) }}
++{{- if and ($kubernetesIngressNGINX.modsec).enabled (not $.Values.hub.token) }}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub." }}
+ {{- end }}
+ 
+-{{- with .Values.providers.kubernetesIngressNGINX }}
++{{- with $kubernetesIngressNGINX }}
+   {{- if and (semverCompare "<v3.7.0-0" $version) .enabled (or
+     (ne .proxyRequestBuffering nil)
+     (gt (.clientBodyBufferSize | int) 0)
+@@ -65,7 +66,7 @@
+   {{- end }}
+ {{- end }}
+ 
+-{{- if and (semverCompare "<v3.7.0-ea.2" $version) (ne (.Values.providers.kubernetesIngressNGINX).strictValidatePathType nil) }}
++{{- if and (semverCompare "<v3.7.0-ea.2" $version) (ne ($kubernetesIngressNGINX).strictValidatePathType nil) }}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider strictValidatePathType option requires traefik >= v3.7.0-ea.2." }}
+ {{- end }}
+ 
+@@ -73,7 +74,7 @@
+   {{- fail "ERROR: providers.precedence option requires traefik >= v3.7.0-rc.1." }}
+ {{- end }}
+ 
+-{{- if and (semverCompare "<v3.7.0-rc.1" $version) (not (empty (.Values.providers.kubernetesIngressNGINX).globalAuthUrl)) }}
++{{- if and (semverCompare "<v3.7.0-rc.1" $version) (not (empty ($kubernetesIngressNGINX).globalAuthUrl)) }}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider globalAuthUrl option requires traefik >= v3.7.0-rc.1." }}
+ {{- end }}
+ 
+@@ -159,7 +160,7 @@
+     {{- end }}
+   {{- end }}
+ 
+-  {{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (semverCompare "<v3.20.0-ea.8" $hubVersion) }}
++  {{- if and ($kubernetesIngressNGINX.modsec).enabled (semverCompare "<v3.20.0-ea.8" $hubVersion) }}
+     {{ fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub >= v3.20.0-ea.8." }}
+   {{- end }}
+ 

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
-packageVersion: 05
+packageVersion: 06
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 


### PR DESCRIPTION
Add a new function in _helpers called: "providers.kubernetesIngressNGINX.values" which coalesces .Values.providers.kubernetesIngressNGINX and .Values.providers.kubernetesIngressNginx

This way, we cover up for distracted users that are not aware of the Traefik breaking change in the new 40.x.x charts


## UPDATE ##
coalesce does not work well because the `.Values.providers.kubernetesIngressNginx` map does not include any default. As a consequence, we get errors such as:
```
Error: UPGRADE FAILED: template: rke2-traefik/templates/daemonset.yaml:58:15: executing "rke2-traefik/templates/daemonset.yaml" at <include "traefik.podTemplate" .>: error calling include: template: rke2-traefik/templates/_podtemplate.tpl:606:63: executing "traefik.podTemplate" at <.publishService.enabled>: nil pointer evaluating interface {}.enabled
```
One workaround is adding the old `kubernetesIngressNginx` map in values.yaml, so that the defaults are covered. The previous error is fixed but that is also not working beacause the new  kubernetesIngressNGINX map has new fields which are evaluated by some Traefik chart templates. As a result, when user uses the old map:
```
Error: UPGRADE FAILED: template: rke2-traefik/templates/daemonset.yaml:58:15: executing "rke2-traefik/templates/daemonset.yaml" at <include "traefik.podTemplate" .>: error calling include: template: rke2-traefik/templates/_podtemplate.tpl:609:26: executing "traefik.podTemplate" at <.modsec.enabled>: nil pointer evaluating interface {}.enabled
```
as "modsec" was not part of the old kubernetesIngressNginx.

Therefore I discarded `coalesce` and moved to `mergeOverwrite` which seems to work well. If  kubernetesIngressNginx is enabled, then we merge its values into kubernetesIngressNGINX map