### PR TITLE
Bump HCP to 0.2.14

### DIFF
--- a/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
+++ b/packages/harvester-cloud-provider/generated-changes/dependencies/kube-vip/dependency.yaml
@@ -1,3 +1,3 @@
 workingDir: ""
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.13/harvester-cloud-provider-0.2.13.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.14/harvester-cloud-provider-0.2.14.tgz
 subdirectory: dependency_charts/kube-vip

--- a/packages/harvester-cloud-provider/generated-changes/patch/Chart.yaml.patch
+++ b/packages/harvester-cloud-provider/generated-changes/patch/Chart.yaml.patch
@@ -5,7 +5,7 @@
    catalog.cattle.io/release-name: harvester-cloud-provider
    catalog.cattle.io/ui-component: harvester-cloud-provider
 -  catalog.cattle.io/upstream-version: 0.2.0
-+  catalog.cattle.io/upstream-version: 0.2.13
++  catalog.cattle.io/upstream-version: 0.2.14
  apiVersion: v2
  appVersion: v0.2.7
  dependencies:

--- a/packages/harvester-cloud-provider/package.yaml
+++ b/packages/harvester-cloud-provider/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.13/harvester-cloud-provider-0.2.13.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-cloud-provider-0.2.14/harvester-cloud-provider-0.2.14.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
I forgot to bump version in values.yaml of our harvester/charts

After opening another PR to re-trigger release https://github.com/harvester/charts/pull/575, we found that rancher rke2-charts stores our chart under https://rke2-charts.rancher.io/assets/harvester-cloud-provider/harvester-cloud-provider-0.2.1300.tgz. It's cached.

So we'd like to release it again https://github.com/harvester/charts/pull/576 with only changing the chart version.