### PR TITLE
Use the up-to-date build scripts

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,20 +11,20 @@ jobs:
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-    - name: Pull scripts
-      run: sudo make pull-scripts
-
     - name: Pull in all relevant branches
       run: git fetch origin main-source main
 
     - name: Checkout live branch
-      run: git checkout main
+      run: git checkout -B main origin/main
 
     - name: Synchronize
-      run: sudo make sync
+      run: |
+        git checkout origin/main-source -- assets charts index.yaml release.yaml
       
     - name: Add assets to branch
-      run: git add . && git -c user.name="actions" -c user.email="actions@github.com" commit -m "$(git log -b main-source --oneline -n1 --pretty=format:'%B')" || true
+      run: |
+        git add assets charts index.yaml release.yaml
+        git -c user.name="actions" -c user.email="actions@github.com" commit -m "$(git log origin/main-source --oneline -n1 --pretty=format:'%B')" || true
 
     - name: Push assets
       run: git push origin main

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 pull-scripts:
 	./scripts/pull-scripts
 
-TARGETS := prepare patch charts clean sync validate rebase docs
+TARGETS := prepare patch charts clean validate
 
 $(TARGETS):
 	@ls ./bin/charts-build-scripts 1>/dev/null 2>/dev/null || ./scripts/pull-scripts
 	./bin/charts-build-scripts $@
 
-.PHONY: $(TARGETS)
+.PHONY: pull-scripts $(TARGETS)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For an example of a chart that uses systemdefaultregistry you can look at:
 
 ### Configuration
 
-This repository branch contains a `configuration.yaml` file that is used to specify how it interacts with other repository branches.
+This repository branch contains a `config/configuration.yaml` file that is used to specify how it interacts with other repository branches.
 
 #### Validate
 
@@ -101,6 +101,6 @@ If this `major.minor.patch` (e.g. `0.0.1`) version of the Chart has been release
 
 `make charts`: Runs `make prepare` and then exports your charts to `assets/` and `charts/` and generates or updates your `index.yaml`.
 
-`make validate`: Validates your current repository branch against all the repository branches indicated in your configuration.yaml
+`make validate`: Validates your current repository branch against all the repository branches indicated in your config/configuration.yaml
 
 `make docs`: Pulls in the latest docs, scripts, etc. from the charts-build-scripts repository

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,0 +1,5 @@
+template: source
+
+validate:
+  url: https://github.com/rancher/rke2-charts.git
+  branch: main

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,6 +1,0 @@
-template: source
-
-validate:
-- url: https://github.com/rancher/rke2-charts.git
-  branch: main
-  dropReleaseCandidates: true

--- a/packages/README.md
+++ b/packages/README.md
@@ -92,7 +92,7 @@ To update your working copy of the charts-build-scripts after rebasing against u
 
 To check whether the new packages you are introducing will cause any issues with upstream that you will synchronize with, run:
 
-- `make validate`: Validates your current repository branch against all the repository branches indicated in your configuration.yaml
+- `make validate`: Validates your current repository branch against all the repository branches indicated in your config/configuration.yaml
 
 #### Common Workflow
 

--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -1,23 +1,19 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
-source ./version
+CHARTS_BUILD_SCRIPT_VERSION=v1.9.25
+CHARTS_BUILD_SCRIPT_ASSET=charts-build-scripts_linux_amd64
 
 echo "Pulling in charts-build-scripts version ${CHARTS_BUILD_SCRIPT_VERSION}"
 
 rm -rf ../bin
 cd ..
 
-rm -rf charts-build-scripts
-git clone --depth 1 --branch $CHARTS_BUILD_SCRIPT_VERSION https://github.com/rancher/charts-build-scripts.git 2>/dev/null
-
-cd charts-build-scripts
-./scripts/build
-mv bin ../bin
-cd ..
-
-rm -rf charts-build-scripts
+mkdir -p ./bin
+curl -fsSL \
+	"https://github.com/rancher/charts-build-scripts/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${CHARTS_BUILD_SCRIPT_ASSET}" \
+	-o ./bin/charts-build-scripts
 chmod +x ./bin/charts-build-scripts
 ./bin/charts-build-scripts --version

--- a/scripts/version
+++ b/scripts/version
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-CHARTS_BUILD_SCRIPT_VERSION=v0.1.0


### PR DESCRIPTION
We were still using the 5 year old version of the build scripts

`v0.1.0`->`v1.9.25`