### PR TITLE
Bump hardened-dns-node-cache to 1.26.8-build20260716

### DIFF
--- a/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-coredns/generated-changes/patch/values.yaml.patch
@@ -192,11 +192,11 @@
 +
 +  image:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.26.8-build20260709"
++    tag: "1.26.8-build20260716"
 +
 +  initimage:
 +    repository: rancher/hardened-dns-node-cache
-+    tag: "1.26.8-build20260709"
++    tag: "1.26.8-build20260716"
 +
 +  # Node labels for pod assignment
 +  # Ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/packages/rke2-coredns/package.yaml
+++ b/packages/rke2-coredns/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/coredns/helm/releases/download/coredns-1.46.0/coredns-1.46.0.tgz
-packageVersion: 05
+packageVersion: 06


### PR DESCRIPTION
This bumps the nodelocal dns-node-cache image and initimage in the rke2-coredns chart to the new release https://github.com/rancher/image-build-dns-nodecache/releases/tag/1.26.8-build20260716

It also bumps the rke2-coredns packageVersion to 04.

Changes:
- packages/rke2-coredns/generated-changes/patch/values.yaml.patch: update both nodelocal tags (image and initimage) to 1.26.8-build20260716
- packages/rke2-coredns/package.yaml: packageVersion 03 -> 04