### PR TITLE
Fix deprecated `updatecli apply` command in updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Apply Updatecli
         # Never use '--debug' option, because it might leak the access tokens.
-        run: "updatecli apply --clean --config ./updatecli/updatecli.d/ --values ./updatecli/values.yaml"
+        run: "updatecli pipeline apply --clean --config ./updatecli/updatecli.d/ --values ./updatecli/values.yaml"
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The "Apply Updatecli" step in `.github/workflows/updatecli.yml` uses the deprecated `updatecli apply` command, which produces this warning in GitHub Actions logs:

```
WARNING: Deprecated command, please instead use `updatecli pipeline apply`
```

This PR updates the invocation to the new `updatecli pipeline apply` form.

## Changes

- `.github/workflows/updatecli.yml`: `updatecli apply ...` → `updatecli pipeline apply ...`

I also searched the repo for any other uses of the deprecated `updatecli apply` / `updatecli diff` commands — this was the only occurrence.

## Reference

Failing job: https://github.com/rancher/rke2-charts/actions/runs/29565952029/job/87838500740