### PR TITLE
rke2-ingress-nginx: Allow custom image to bypass system-default-registry when overriding backend ingress

### DIFF
--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,21 +1,6 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -70,11 +70,11 @@
- {{/*
- Get specific image
- */}}
--{{- define "ingress-nginx.image" -}}
-+{{- define "ingress-nginx.repository" -}}
- {{- if .chroot -}}
--{{- printf "%s-chroot" .image -}}
-+{{- printf "%s-chroot" .repository -}}
- {{- else -}}
--{{- printf "%s" .image -}}
-+{{- printf "%s" .repository -}}
- {{- end }}
- {{- end -}}
- 
-@@ -261,3 +261,15 @@
+@@ -261,3 +261,28 @@
      - name: modules
        mountPath: /modules_mount
  {{- end -}}
@@ -25,6 +10,19 @@
 +{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
 +{{- else -}}
 +{{- "" -}}
++{{- end -}}
++{{- end -}}
++
++{{/*
++If the repository value is not hostname or IP with at least one dot, or host:port, use the systemDefaultRegistry if defined.
++*/}}
++{{- define "registry_domain_prefix" -}}
++{{- $repository := .repository | default "" -}}
++{{- $firstComponent := (splitList "/" $repository | first) -}}
++{{- if or (eq $firstComponent "localhost") (contains "." $firstComponent) (contains ":" $firstComponent) -}}
++{{- "" -}}
++{{- else -}}
++{{- template "system_default_registry" . -}}
 +{{- end -}}
 +{{- end -}}
 +

--- a/packages/rke2-ingress-nginx/generated-changes/patch/templates/default-backend-deployment.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/templates/default-backend-deployment.yaml.patch
@@ -7,7 +7,7 @@
 -          {{- with (merge .Values.defaultBackend.image .Values.global.image) }}
 -          image: {{ if .repository }}{{ .repository }}{{ else }}{{ .registry }}/{{ .image }}{{ end }}:{{ .tag }}{{ if .digest }}@{{ .digest }}{{ end }}
 -          {{- end }}
-+          image: "{{ template "system_default_registry" . }}{{ template "repository_or_registry_and_image" .Values.defaultBackend.image }}"
++          image: "{{ template "registry_domain_prefix" (dict "repository" .Values.defaultBackend.image.repository "Values" .Values) }}{{ template "repository_or_registry_and_image" .Values.defaultBackend.image }}"
            imagePullPolicy: {{ .Values.defaultBackend.image.pullPolicy }}
          {{- if .Values.defaultBackend.extraArgs }}
            args:

--- a/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-ingress-nginx/generated-changes/patch/values.yaml.patch
@@ -117,7 +117,7 @@
      ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
 -    ## repository:
 -    tag: "1.5"
-+    repository: rancher/nginx-ingress-controller-defaultbackend
++    repository: rancher/mirrored-nginx-ingress-controller-defaultbackend
 +    tag: "1.5-rancher1"
      pullPolicy: IfNotPresent
      runAsNonRoot: true

--- a/packages/rke2-ingress-nginx/package.yaml
+++ b/packages/rke2-ingress-nginx/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.15.1/ingress-nginx-4.15.1.tgz
-packageVersion: 05
+packageVersion: 06
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00


### PR DESCRIPTION
https://github.com/rancher/rke2/issues/10832

Also fix the default backend image to one that available on both DockerHub and PRIME registries. 
Signed-off-by: Derek Nola <derek.nola@suse.com>