### PR TITLE
rke2-snapshot-controller: bump hardened image to build20260722 for grpc CVE (GHSA-hrxh-6v49-42gf)

### DIFF
--- a/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
      pullPolicy: IfNotPresent
      # Overrides the image tag whose default is the chart appVersion.
 -    tag: ""
-+    tag: "v8.6.0-build20260708"
++    tag: "v8.6.0-build20260722"
  
    imagePullSecrets: []
  

--- a/packages/rke2-snapshot-controller/package.yaml
+++ b/packages/rke2-snapshot-controller/package.yaml
@@ -1,7 +1,7 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-controller
 commit: ccc8a601db5ae518334da43ce7a5851ea349d526  # snapshot-controller-4.2.0
-packageVersion: 07
+packageVersion: 08
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Bumps `hardened-snapshot-controller` from `v8.6.0-build20260708` to `v8.6.0-build20260722` in the rke2-snapshot-controller package to pick up the `google.golang.org/grpc` fix for GHSA-hrxh-6v49-42gf (requires grpc >= v1.82.1). packageVersion 07 to 08.

## Scope

This PR originally bumped six packages (canal, coredns, flannel, metrics-server, multus, snapshot-controller). All of those except snapshot-controller are now handled by updatecli PRs, so this PR has been trimmed to snapshot-controller only to avoid duplication:

- rke2-canal: #1102 (merged)
- rke2-coredns: #1103 (merged)
- rke2-metrics-server: #1105 (merged)
- rke2-flannel: #1106 (merged)
- rke2-multus: #1107 (open)
- rke2-snapshot-controller: this PR (no updatecli coverage)

## Validation

`PACKAGE=rke2-snapshot-controller make charts` generates `rke2-snapshot-controller-4.2.008` and `rke2-snapshot-controller-crd-4.2.008` cleanly. Source-only commit per repo convention on main-source (generated assets/, charts/, index.yaml are not tracked).