### PR TITLE
Split multus crd into its own sub-chart

### DIFF
--- a/packages/rke2-multus/charts/Chart.yaml
+++ b/packages/rke2-multus/charts/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 appVersion: 4.3.0
 dependencies:
 - condition: rke2-whereabouts.enabled

--- a/packages/rke2-multus/charts/Chart.yaml
+++ b/packages/rke2-multus/charts/Chart.yaml
@@ -1,9 +1,5 @@
 apiVersion: v1
 appVersion: 4.3.0
-dependencies:
-- condition: rke2-whereabouts.enabled
-  name: rke2-whereabouts
-  repository: file://./charts/rke2-whereabouts
 description: Multus Helm chart for Kubernetes
 home: https://github.com/k8snetworkplumbingwg/multus-cni
 icon: https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/doc/images/Multus.png

--- a/packages/rke2-multus/charts/crds/customResourceDefinition.yaml
+++ b/packages/rke2-multus/charts/crds/customResourceDefinition.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- if .Values.manifests.customResourceDefinition }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -40,4 +39,3 @@ spec:
               properties:
                 config:
                   type: string
-{{- end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,4 +1,4 @@
-{{ if (index .Values "rke2-whereabouts").enabled }}
+{{ if dig "rke2-whereabouts" "enabled" false .Values }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,24 +1,24 @@
----
+{{ if (index .Values "rke2-whereabouts").enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     helm.sh/resource-policy: keep
-  name: nodeslicepools.whereabouts.cni.cncf.io
+  name: ippools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
   names:
-    kind: NodeSlicePool
-    listKind: NodeSlicePoolList
-    plural: nodeslicepools
-    singular: nodeslicepool
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NodeSlicePool is the Schema for the nodesliceippools API
+        description: IPPool is the Schema for the ippools API
         properties:
           apiVersion:
             description: |-
@@ -38,43 +38,36 @@ spec:
           metadata:
             type: object
           spec:
-            description: NodeSlicePoolSpec defines the desired state of NodeSlicePool
-            properties:
-              range:
-                description: |-
-                  Range is a RFC 4632/4291-style string that represents an IP address and prefix length in CIDR notation
-                  this refers to the entire range where the node is allocated a subset
-                type: string
-              sliceSize:
-                description: SliceSize is the size of subnets or slices of the range
-                  that each node will be assigned
-                type: string
-            required:
-            - range
-            - sliceSize
-            type: object
-          status:
-            description: NodeSlicePoolStatus defines the desired state of NodeSlicePool
+            description: IPPoolSpec defines the desired state of IPPool
             properties:
               allocations:
-                description: Allocations holds the allocations of nodes to slices
-                items:
+                additionalProperties:
+                  description: IPAllocation represents metadata about the pod/container
+                    owner of a specific IP
                   properties:
-                    nodeName:
-                      description: NodeName is the name of the node assigned to this
-                        slice, empty node name is an available slice for assignment
+                    id:
                       type: string
-                    sliceRange:
-                      description: SliceRange is the subnet of this slice
+                    ifname:
+                      type: string
+                    podref:
                       type: string
                   required:
-                  - nodeName
-                  - sliceRange
+                  - id
+                  - podref
                   type: object
-                type: array
+                description: |-
+                  Allocations is the set of allocated IPs for the given range. Its` indices are a direct mapping to the
+                  IP with the same index/offset for the pool's range.
+                type: object
+              range:
+                description: Range is a RFC 4632/4291-style string that represents
+                  an IP address and prefix length in CIDR notation
+                type: string
             required:
             - allocations
+            - range
             type: object
         type: object
     served: true
     storage: true
+{{ end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
@@ -1,4 +1,4 @@
-{{ if (index .Values "rke2-whereabouts").enabled }}
+{{ if dig "rke2-whereabouts" "enabled" false .Values }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
@@ -1,24 +1,24 @@
----
+{{ if (index .Values "rke2-whereabouts").enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     helm.sh/resource-policy: keep
-  name: ippools.whereabouts.cni.cncf.io
+  name: nodeslicepools.whereabouts.cni.cncf.io
 spec:
   group: whereabouts.cni.cncf.io
   names:
-    kind: IPPool
-    listKind: IPPoolList
-    plural: ippools
-    singular: ippool
+    kind: NodeSlicePool
+    listKind: NodeSlicePoolList
+    plural: nodeslicepools
+    singular: nodeslicepool
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: IPPool is the Schema for the ippools API
+        description: NodeSlicePool is the Schema for the nodesliceippools API
         properties:
           apiVersion:
             description: |-
@@ -38,35 +38,44 @@ spec:
           metadata:
             type: object
           spec:
-            description: IPPoolSpec defines the desired state of IPPool
+            description: NodeSlicePoolSpec defines the desired state of NodeSlicePool
             properties:
-              allocations:
-                additionalProperties:
-                  description: IPAllocation represents metadata about the pod/container
-                    owner of a specific IP
-                  properties:
-                    id:
-                      type: string
-                    ifname:
-                      type: string
-                    podref:
-                      type: string
-                  required:
-                  - id
-                  - podref
-                  type: object
-                description: |-
-                  Allocations is the set of allocated IPs for the given range. Its` indices are a direct mapping to the
-                  IP with the same index/offset for the pool's range.
-                type: object
               range:
-                description: Range is a RFC 4632/4291-style string that represents
-                  an IP address and prefix length in CIDR notation
+                description: |-
+                  Range is a RFC 4632/4291-style string that represents an IP address and prefix length in CIDR notation
+                  this refers to the entire range where the node is allocated a subset
+                type: string
+              sliceSize:
+                description: SliceSize is the size of subnets or slices of the range
+                  that each node will be assigned
                 type: string
             required:
-            - allocations
             - range
+            - sliceSize
+            type: object
+          status:
+            description: NodeSlicePoolStatus defines the desired state of NodeSlicePool
+            properties:
+              allocations:
+                description: Allocations holds the allocations of nodes to slices
+                items:
+                  properties:
+                    nodeName:
+                      description: NodeName is the name of the node assigned to this
+                        slice, empty node name is an available slice for assignment
+                      type: string
+                    sliceRange:
+                      description: SliceRange is the subnet of this slice
+                      type: string
+                  required:
+                  - nodeName
+                  - sliceRange
+                  type: object
+                type: array
+            required:
+            - allocations
             type: object
         type: object
     served: true
     storage: true
+{{ end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -1,4 +1,4 @@
-{{ if (index .Values "rke2-whereabouts").enabled }}
+{{ if dig "rke2-whereabouts" "enabled" false .Values }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -1,4 +1,4 @@
----
+{{ if (index .Values "rke2-whereabouts").enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -56,3 +56,4 @@ spec:
         type: object
     served: true
     storage: true
+{{ end }}

--- a/packages/rke2-multus/charts/requirements.yaml
+++ b/packages/rke2-multus/charts/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- condition: rke2-whereabouts.enabled
+  name: rke2-whereabouts
+  repository: file://./charts/rke2-whereabouts

--- a/packages/rke2-multus/charts/templates/NOTES.txt
+++ b/packages/rke2-multus/charts/templates/NOTES.txt
@@ -9,9 +9,7 @@ Cluster Role Binding: {{ .Chart.Name }}
 {{- if .Values.manifests.configMap }}
 Config Map: {{ .Release.Name }}-{{ .Chart.Version }}-config
 {{- end }}
-{{- if .Values.manifests.customResourceDefinition }}
 Custom Resource Definition: network-attachment-definitions.k8s.cni.cncf.io
-{{- end }}
 {{- if .Values.manifests.daemonSet }}
 Daemon Set: {{ .Release.Name }}
 {{- end }}

--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -98,11 +98,11 @@ config:
     #multusBinFile: /usr/src/multus-cni/bin/multus
     #multusCniConfDir: /host/etc/cni/multus/net.d
     # The following options can be used only when multusConfFile=auto
-    # multusAutoconfigDir is mandatory when multusConfFile=auto 
+    # multusAutoconfigDir is mandatory when multusConfFile=auto
     multusAutoconfigDir: /etc/cni/net.d #path on the host, not inside the container
     kubeconfig: /etc/cni/net.d/multus.d/multus.kubeconfig
     #masterCniFilename:
-    #overrideNetworkName: 
+    #overrideNetworkName:
     #renameConfFile: 
     #logFile: /var/log/multus.log
     #logLevel: panic
@@ -126,13 +126,12 @@ manifests:
   clusterRoleBinding: true
   configMap: true
   daemonSet: true
-  customResourceDefinition: true
   dhcpDaemonSet: false
 
 tolerations:
-- operator: Exists 
-  effect: NoSchedule 
-- operator: Exists 
+- operator: Exists
+  effect: NoSchedule
+- operator: Exists
   effect: NoExecute 
 
 #affinity: {}
@@ -158,7 +157,7 @@ global:
 
 rke2-whereabouts:
   enabled: false
-  
+
 # When using the thick plugin, manifests.configMap MUST be set to true
 thickPlugin:
   enabled: false

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,9 @@
 url: local
 workingDir: charts
-packageVersion: 08
+packageVersion: 09
+additionalCharts:
+  - workingDir: charts-crd
+    crdOptions:
+      templateDirectory: crd-template
+      crdDirectory: templates
+      addCRDValidationToMainChart: false

--- a/packages/rke2-multus/templates/crd-template/Chart.yaml
+++ b/packages/rke2-multus/templates/crd-template/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+version: 4.3.0
+description: Installs the CRDs for rke2-multus
+name: rke2-multus-crd
+type: application

--- a/packages/rke2-whereabouts/package.yaml
+++ b/packages/rke2-whereabouts/package.yaml
@@ -1,5 +1,5 @@
 url: local
 workingDir: charts
-packageVersion: 05
+packageVersion: 06
 # whereabouts is only used as a dependency of multus
 doNotRelease: true


### PR DESCRIPTION
and move whereabouts crds into this sub-chart.
We cannot split whereabouts crds into their own sub-chart
because whereabouts is itself a sub-chart of multus.

The 'keep' annotation was added for the 1.36 branch so this migration should be safe to do for 1.37.

related issue:
- https://github.com/rancher/rke2/issues/8628