### PR TITLE
rke2-cilium: wrap images with system_default_registry for airgap

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-preflight/daemonset.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-preflight/daemonset.yaml.patch
@@ -18,3 +18,12 @@
            imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
            command: ["/bin/sh"]
            args:
+@@ -117,7 +117,7 @@
+           terminationMessagePolicy: FallbackToLogsOnError
+         {{- if $envoyDS }}
+         - name: cilium-pre-flight-envoy
+-          image: {{ include "cilium.image" .Values.preflight.envoy.image | quote }}
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.preflight.envoy.image }}"
+           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
+           command: ["/bin/sh"]
+           args:

--- a/packages/rke2-cilium/generated-changes/patch/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
++++ charts/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+@@ -14,7 +14,7 @@
+           type: RuntimeDefault
+       containers:
+         - name: certgen
+-          image: {{ include "cilium.image" .Values.certgen.image | quote }}
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.certgen.image }}"
+           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
+           securityContext:
+             capabilities:

--- a/packages/rke2-cilium/generated-changes/patch/templates/clustermesh-coredns-mcsapi/job.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/clustermesh-coredns-mcsapi/job.yaml.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/clustermesh-coredns-mcsapi/job.yaml
++++ charts/templates/clustermesh-coredns-mcsapi/job.yaml
+@@ -31,7 +31,7 @@
+     spec:
+       containers:
+         - name: autoconfig
+-          image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.clustermesh.apiserver.image }}"
+           imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
+           {{- with .Values.clustermesh.mcsapi.corednsAutoConfigure.resources }}
+           resources:

--- a/packages/rke2-cilium/generated-changes/patch/templates/hubble/tls-cronjob/_job-spec.tpl.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/hubble/tls-cronjob/_job-spec.tpl.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/hubble/tls-cronjob/_job-spec.tpl
++++ charts/templates/hubble/tls-cronjob/_job-spec.tpl
+@@ -14,7 +14,7 @@
+           type: RuntimeDefault
+       containers:
+         - name: certgen
+-          image: {{ include "cilium.image" .Values.certgen.image | quote }}
++          image: "{{ template "system_default_registry" . }}{{ include "cilium.image" .Values.certgen.image }}"
+           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
+           securityContext:
+             capabilities:

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.20.0.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
Follow-up to #1115. 

Four container images in the rke2-cilium chart were never wrapped with `system_default_registry`
- `cilium-pre-flight-envoy` (`preflight.envoy.image`)
- clustermesh-apiserver certgen cronjob (`certgen.image`)
- hubble certgen cronjob (`certgen.image`)
- clustermesh-coredns-mcsapi job (`clustermesh.apiserver.image`)

These are long-standing gaps, not 1.20.0 regressions:

- **certgen (clustermesh + hubble)** and **preflight-envoy** have been unwrapped since at least **1.18.x** (`rke2-cilium-1.18.601`) and through **1.19.x** (`rke2-cilium-1.19.601`). The other three preflight images (`preflight.image`) were always wrapped.

- **clustermesh-coredns-mcsapi** didn't exist in 1.18.x (MCS-API was added in the 1.19.x line), so its gap dates from when the template was introduced.
