### PR TITLE
rke2-multus: fix whereabouts CRD dig guard

### DIFF
--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,4 +1,4 @@
-{{ if dig "rke2-whereabouts" "enabled" false .Values }}
+{{ if (index .Values "rke2-whereabouts" | default dict).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
@@ -1,4 +1,4 @@
-{{ if dig "rke2-whereabouts" "enabled" false .Values }}
+{{ if (index .Values "rke2-whereabouts" | default dict).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -1,4 +1,4 @@
-{{ if dig "rke2-whereabouts" "enabled" false .Values }}
+{{ if (index .Values "rke2-whereabouts" | default dict).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,6 +1,6 @@
 url: local
 workingDir: charts
-packageVersion: 09
+packageVersion: 10
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Helm passes top-level .Values as a named type causing dig to panic, which breaks the `rke2-multus-crd chart install under helm-controller.

```
Error: INSTALLATION FAILED: template: rke2-multus-crd/templates/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml:1:6:
executing ... at <dig "rke2-whereabouts" "enabled" false .Values>:
error calling dig: interface conversion: interface {} is common.Values, not map[string]interface {}
```

See also: https://github.com/k3s-io/k3s/actions/runs/30974482857/job/92206440400?pr=14489

Issue: https://github.com/rancher/rke2/issues/8628

