### PR TITLE
rke2-traefik: fix .orig files in chart TGZ (packageVersion 41.1.101)

### DIFF
--- a/packages/rke2-traefik/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/Chart.yaml.patch
@@ -1,14 +1,14 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -9,6 +9,7 @@
+@@ -6,6 +6,7 @@
    traefik.io/hub-min-version: v3.19.3
-   traefik.io/proxy-max-version: v3.7.1
+   traefik.io/proxy-max-version: v3.7.9
    traefik.io/proxy-min-version: v3.6.0
 +  fleet.cattle.io/bundle-id: rke2
  apiVersion: v2
- appVersion: v3.7.1
+ appVersion: v3.7.9
  description: A Traefik based Kubernetes ingress controller
-@@ -25,7 +26,7 @@
+@@ -22,7 +23,7 @@
  - email: remi.buisson@traefik.io
    name: darkweaver87
  - name: jnoordsij

--- a/packages/rke2-traefik/generated-changes/patch/VALUES.md.patch
+++ b/packages/rke2-traefik/generated-changes/patch/VALUES.md.patch
@@ -1,15 +1,15 @@
 --- charts-original/VALUES.md
 +++ charts/VALUES.md
-@@ -59,7 +59,7 @@
- | deployment.hostUsers | string | unset (inherits cluster default) | Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
+@@ -91,7 +91,7 @@
+ | deployment.hostUsers | bool | unset (inherits cluster default) | Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
  | deployment.imagePullSecrets | list | `[]` | Pull secret for fetching traefik container image |
  | deployment.initContainers | list | `[]` | Additional initContainers (e.g. for setting file permission as shown below) |
 -| deployment.kind | string | `"Deployment"` | Deployment or DaemonSet |
 +| deployment.kind | string | `"Daemonset"` | Deployment or DaemonSet |
  | deployment.labels | object | `{}` | Additional deployment labels (e.g. for filtering deployment by custom labels) |
  | deployment.lifecycle | object | `{}` | Pod lifecycle actions |
- | deployment.livenessPath | string | `""` | Override the liveness path. Default: /ping |
-@@ -249,7 +249,7 @@
+ | deployment.livenessPath | string | `/ping` | Override the liveness path. |
+@@ -251,7 +251,7 @@
  | image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
  | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
  | image.registry | string | `nil` | Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.enabled` is true). |
@@ -19,16 +19,16 @@
  | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
  | ingressClass.isDefaultClass | bool | `true` |  |
 @@ -455,7 +455,7 @@
- | providers.kubernetesCRD.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
  | providers.kubernetesCRD.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in IngressRoute |
+ | providers.kubernetesCRD.crossProviderNamespaces | list | `[]` | List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+. |
  | providers.kubernetesCRD.enabled | bool | `true` | Load Kubernetes IngressRoute provider |
 -| providers.kubernetesCRD.ingressClass | string | `""` | When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled. |
 +| providers.kubernetesCRD.ingressClass | string | `"traefik"` | When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled. |
  | providers.kubernetesCRD.labelSelector | string | `""` | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector) |
  | providers.kubernetesCRD.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
  | providers.kubernetesCRD.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
-@@ -473,7 +473,7 @@
- | providers.kubernetesIngress.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in Ingress |
+@@ -477,7 +477,7 @@
+ | providers.kubernetesIngress.crossProviderNamespaces | list | `[]` | List of namespaces from which Ingresses or Services are allowed to declare Middlewares, TLSOptions, or ServersTransport references. Requires traefik v3.7.1+. |
  | providers.kubernetesIngress.disableIngressClassLookup | bool | `false` | Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup) |
  | providers.kubernetesIngress.enabled | bool | `true` | Load Kubernetes Ingress provider |
 -| providers.kubernetesIngress.ingressClass | string | `nil` | When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed. |

--- a/packages/rke2-traefik/generated-changes/patch/templates/NOTES.txt.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/NOTES.txt.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/NOTES.txt
 +++ charts/templates/NOTES.txt
-@@ -120,6 +120,16 @@
+@@ -160,6 +160,16 @@
    {{- end -}}
  
  

--- a/packages/rke2-traefik/generated-changes/patch/templates/_podtemplate.tpl.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/_podtemplate.tpl.patch
@@ -9,7 +9,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          name: {{ template "traefik.fullname" . }}
          resources:
-@@ -596,7 +596,8 @@
+@@ -617,7 +617,8 @@
            {{- end }}
            {{- end }}
            {{- end }}

--- a/packages/rke2-traefik/generated-changes/patch/templates/requirements.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/templates/requirements.yaml.patch
@@ -6,7 +6,7 @@
  {{- $proxyMinVersion := index .Chart.Annotations "traefik.io/proxy-min-version" }}
  {{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" }}
  {{- if (ne $version "experimental-v3.0") }}
-@@ -31,15 +32,15 @@
+@@ -45,15 +46,15 @@
    {{- end }}
  {{- end }}
  
@@ -25,7 +25,7 @@
    {{- if and (semverCompare "<v3.7.0-0" $version) .enabled (or
      (ne .proxyRequestBuffering nil)
      (gt (.clientBodyBufferSize | int) 0)
-@@ -65,7 +66,7 @@
+@@ -79,7 +80,7 @@
    {{- end }}
  {{- end }}
  
@@ -34,7 +34,7 @@
    {{- fail "ERROR: Kubernetes Ingress NGINX provider strictValidatePathType option requires traefik >= v3.7.0-ea.2." }}
  {{- end }}
  
-@@ -73,7 +74,7 @@
+@@ -87,7 +88,7 @@
    {{- fail "ERROR: providers.precedence option requires traefik >= v3.7.0-rc.1." }}
  {{- end }}
  
@@ -43,7 +43,7 @@
    {{- fail "ERROR: Kubernetes Ingress NGINX provider globalAuthUrl option requires traefik >= v3.7.0-rc.1." }}
  {{- end }}
  
-@@ -159,7 +160,7 @@
+@@ -202,7 +203,7 @@
      {{- end }}
    {{- end }}
  

--- a/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
@@ -1,7 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -5,11 +5,11 @@
- image:  # @schema additionalProperties: false
+@@ -6,10 +6,10 @@
    # -- Traefik image host registry. Defaults to `docker.io` for Traefik Proxy and `ghcr.io` for Traefik Hub (when `hub.enabled` is true).
    registry:  # @schema type:[string, null]
    # -- Traefik image repository. Defaults to `traefik` for Traefik Proxy and `traefik/traefik-hub` for Traefik Hub (when `hub.enabled` is true).
@@ -14,8 +13,7 @@
    # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
    digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
    # -- Traefik image pull policy
-@@ -21,8 +21,8 @@
- deployment:
+@@ -22,7 +22,7 @@
    # -- Enable deployment
    enabled: true
    # -- Deployment or DaemonSet
@@ -46,16 +44,16 @@
  
  readinessProbe:  # @schema additionalProperties: false
    # -- The number of consecutive failures allowed before considering the probe as failed.
-@@ -312,7 +312,7 @@
-     # -- Allows to return 503 when there are no endpoints available
-     allowEmptyServices: true
+@@ -314,7 +314,7 @@
+     # -- List of namespaces from which IngressRoute, IngressRouteTCP, IngressRouteUDP, and TraefikService are allowed to declare cross-provider references. Requires traefik v3.7.1+.
+     crossProviderNamespaces: []
      # -- When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.
 -    ingressClass: ""
 +    ingressClass: "traefik"
      # -- See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector)
      labelSelector: ""
      # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.
-@@ -854,6 +854,8 @@
+@@ -871,6 +871,8 @@
          insecureSkipVerify:  # @schema type:[boolean, null]
  
  global:
@@ -64,8 +62,8 @@
    checkNewVersion: true
    # -- Please take time to consider whether or not you wish to share anonymous data with us
    # See https://doc.traefik.io/traefik/contributing/data-collection/
-@@ -926,7 +928,7 @@
-     ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+@@ -943,7 +945,7 @@
+     # -- (bool) Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
      asDefault:  # @schema type: [boolean, null]; default: null
      port: 8000
 -    # hostPort: 8000
@@ -73,18 +71,16 @@
      # containerPort: 8000
      expose:
        default: true
-@@ -1002,8 +1004,8 @@
-   websecure:
-     ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+@@ -1002,7 +1004,7 @@
      # asDefault: true
      port: 8443
--    # -- (int) Use hostPort if set.
+     # -- (int) Use hostPort if set.
 -    hostPort:  # @schema type:[integer, null]; minimum:0
-+    # -- (int) Use hostPort if set.
 +    hostPort: 443 # @schema type:[integer, null]; minimum:0
      # -- (int) Use containerPort if set.
      containerPort:  # @schema type:[integer, null]; minimum:0
-@@ -1112,7 +1114,8 @@
+     expose:
+@@ -1133,7 +1135,8 @@
    # -- Additional entries here will be added to the Service [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core).
    # Cannot contain selector or ports entries.
    spec:
@@ -94,7 +90,7 @@
    # -- Can be used to create multiple Service.
    # See EXAMPLES.md for more details.
    additionalServices: {}
-@@ -1201,7 +1204,8 @@
+@@ -1222,7 +1225,8 @@
  #        topologyKey: kubernetes.io/hostname
  
  # -- nodeSelector is the simplest recommended form of node selection constraint.

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-41.1.1.tgz
-packageVersion: 00
+packageVersion: 01
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 


### PR DESCRIPTION
Fixes a regression introduced in #1121 where `helm install` failed with:

```
Error: INSTALLATION FAILED: YAML parse error on rke2-traefik/templates/NOTES.txt.orig
```

**Root cause:** `charts-build-scripts` v0.1.0 calls `patch -E -p1` without `--no-backup-if-mismatch`. When the upstream bumped from v40 to v41, context line numbers shifted in several patches, causing `patch(1)` to apply hunks with fuzzy matching and write `.orig` backup files alongside the patched files. The `diff` call that regenerates patches has no `-x *.orig` exclusion, so those backup files were included in the chart TGZ.

**Fix:** Regenerated all affected patches via `diff -u` between the raw upstream v41.1.1 and the fully-applied downstream, ensuring every hunk matches exactly with zero fuzz. Also removes two stale patch files (`crds/gateway-standard-install.yaml.patch`, `templates/rbac/role.yaml.patch`) that produced no diff against v41.1.1.

`make prepare` now runs with zero fuzz and no `.orig` files on both macOS and Linux.