### PR TITLE
Bump rke2-flannel to v0.28.9

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/Chart.yaml.patch
@@ -9,4 +9,4 @@
  sources:
 -- https://github.com/flannel-io/flannel
 +- https://github.com/rancher/rke2-charts
- version: v0.28.8
+ version: v0.28.9

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -17,7 +17,7 @@
 -    repository: ghcr.io/flannel-io/flannel
 -    tag: v0.28.8
 +    repository: rancher/hardened-flannel
-+    tag: v0.28.8-build20260722
++    tag: v0.28.9-build20260807
    flannel_cni:
      image:
 -      repository: ghcr.io/flannel-io/flannel-cni-plugin

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -15,13 +15,13 @@
    # kube-flannel image
    image:
 -    repository: ghcr.io/flannel-io/flannel
--    tag: v0.28.8
+-    tag: v0.28.9
 +    repository: rancher/hardened-flannel
 +    tag: v0.28.9-build20260807
    flannel_cni:
      image:
 -      repository: ghcr.io/flannel-io/flannel-cni-plugin
--      tag: v1.9.1-flannel2
+-      tag: v1.9.1-flannel3
 +      repository: rancher/hardened-cni-plugins
 +      tag: v1.9.1-build20260717
    # cniBinDir is the directory to which the flannel CNI binary is installed.
@@ -64,9 +64,9 @@
          }
        ]
      }
-@@ -88,17 +82,19 @@
-       cpu: 100m
-       memory: 50Mi
+@@ -98,17 +92,19 @@
+       initialDelaySeconds: 5
+       periodSeconds: 10
    tolerations:
 -  - effect: NoExecute
 -    operator: Exists

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -17,7 +17,7 @@
 -    repository: ghcr.io/flannel-io/flannel
 -    tag: v0.28.9
 +    repository: rancher/hardened-flannel
-+    tag: v0.28.9-build20260807
++    tag: v0.28.9-build20260808
    flannel_cni:
      image:
 -      repository: ghcr.io/flannel-io/flannel-cni-plugin

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/flannel-io/flannel/releases/download/v0.28.8/flannel.tgz
+url: https://github.com/flannel-io/flannel/releases/download/v0.28.9/flannel.tgz
 packageVersion: 00


### PR DESCRIPTION
Follow the upstream flannel v0.28.9 release.

**Changes:**
- `package.yaml`: update upstream tarball URL to `v0.28.9`
- `Chart.yaml.patch`: bump chart version to `v0.28.9`
- `values.yaml.patch`: update `rancher/hardened-flannel` image tag to `v0.28.9-build20260807`

fixes https://github.com/rancher/rke2/issues/11003