### PR TITLE
rke2-canal: add liveness and readiness probes for flannel

### DIFF
--- a/packages/rke2-canal/charts/templates/daemonset.yaml
+++ b/packages/rke2-canal/charts/templates/daemonset.yaml
@@ -239,8 +239,31 @@ spec:
           {{- range .Values.flannel.args }}
           - {{ . | quote }}
           {{- end }}
+          {{- if .Values.flannel.healthz.port }}
+          - {{ printf "--healthz-port=%d" (int .Values.flannel.healthz.port) | quote }}
+          {{- end }}
           securityContext:
             privileged: true
+          {{- if .Values.flannel.healthz.port }}
+          ports:
+          - name: healthz
+            containerPort: {{ int .Values.flannel.healthz.port }}
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            {{- with .Values.flannel.healthz.livenessProbe }}
+            {{- toYaml . | trim | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+            {{- with .Values.flannel.healthz.readinessProbe }}
+            {{- toYaml . | trim | nindent 12 }}
+            {{- end }}
+          {{- end }}
           {{- if .Values.flannel.resources }}
           resources: {{- toYaml .Values.flannel.resources | nindent 12 }}
           {{- end }}

--- a/packages/rke2-canal/charts/values.yaml
+++ b/packages/rke2-canal/charts/values.yaml
@@ -53,6 +53,16 @@ flannel:
   #tunnelMode: "separate"
   # Persistent keep interval to use
   keepaliveInterval: 0
+  # Health check server configuration. Set port to a non-zero value to enable.
+  # /healthz is the liveness endpoint; /readyz is the readiness endpoint.
+  healthz:
+    port: 8081
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
   # Resource bounds for the kube-flannel daemon container
   resources: ~
   # requests:

--- a/packages/rke2-canal/package.yaml
+++ b/packages/rke2-canal/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
The `kube-flannel` container in the canal DaemonSet had no health probes, making it harder for Kubernetes to detect and recover from a broken flannel process. This ports the healthz-based probe pattern introduced in the upstream flannel chart v0.28.9.

## What changed

- **`values.yaml`**: added a `flannel.healthz` block with `port: 8081` (matching upstream defaults) and probe timing values for liveness and readiness.
- **`daemonset.yaml`**: when `flannel.healthz.port` is non-zero, the template now:
  - passes `--healthz-port=<port>` to `flanneld`
  - declares a named `healthz` container port
  - adds a `livenessProbe` (HTTP GET `/healthz`)
  - adds a `readinessProbe` (HTTP GET `/readyz`)

The feature can be disabled by setting `flannel.healthz.port: 0` in values, keeping backward compatibility.