### PR TITLE
fix: keep netpol defaults in rke2-flannel values to prevent nil pointer on install

### DIFF
--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -64,7 +64,7 @@
          }
        ]
      }
-@@ -98,17 +92,19 @@
+@@ -98,9 +92,17 @@
        initialDelaySeconds: 5
        periodSeconds: 10
    tolerations:
@@ -84,14 +84,6 @@
 +    effect: "NoExecute"
    nodeSelector: {}
  
--netpol:
--  enabled: false
--  args:
--  - "--hostname-override=$(MY_NODE_NAME)"
--  - "--v=2"
--  image:
--    repository: registry.k8s.io/networking/kube-network-policies
--    tag: v1.0.0
 +global:
 +  systemDefaultRegistry: ""
 +  clusterCIDRv4: ""

--- a/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-flannel/generated-changes/patch/values.yaml.patch
@@ -64,7 +64,7 @@
          }
        ]
      }
-@@ -98,9 +92,17 @@
+@@ -98,17 +92,27 @@
        initialDelaySeconds: 5
        periodSeconds: 10
    tolerations:
@@ -88,3 +88,11 @@
 +  systemDefaultRegistry: ""
 +  clusterCIDRv4: ""
 +  clusterCIDRv6: ""
+ netpol:
+   enabled: false
+   args:
+   - "--hostname-override=$(MY_NODE_NAME)"
+   - "--v=2"
+   image:
+     repository: registry.k8s.io/networking/kube-network-policies
+     tag: v1.0.0

--- a/packages/rke2-flannel/package.yaml
+++ b/packages/rke2-flannel/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/flannel-io/flannel/releases/download/v0.28.9/flannel.tgz
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
## Problem

The `packages/rke2-flannel/generated-changes/patch/values.yaml.patch` was deleting the entire `netpol` section from upstream flannel v0.28.9's `values.yaml`. However, the daemonset template still references `.Values.netpol.enabled`, causing:

```
nil pointer evaluating interface {}.enabled
```

when installing rke2-flannel v0.28.900.

## Fix

Remove the deletion lines for the `netpol` block from `values.yaml.patch`, so the upstream default (`netpol.enabled: false`) is preserved in the resulting `values.yaml`. The `global:` additions are retained and appended after `nodeSelector: {}` as before.

The resulting values.yaml will contain:
```yaml
netpol:
  enabled: false
  args:
  - "--hostname-override=$(MY_NODE_NAME)"
  - "--v=2"
  image:
    repository: registry.k8s.io/networking/kube-network-policies
    tag: v1.0.0
```

This satisfies the template reference to `.Values.netpol.enabled` and prevents the nil pointer error.