### PR TITLE
Bump Harvester CSI Driver to 0.1.31

### DIFF
--- a/packages/harvester-csi-driver/package.yaml
+++ b/packages/harvester-csi-driver/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/harvester/charts/releases/download/harvester-csi-driver-0.1.30/harvester-csi-driver-0.1.30.tgz
+url: https://github.com/harvester/charts/releases/download/harvester-csi-driver-0.1.31/harvester-csi-driver-0.1.31.tgz
 packageVersion: 00
 releaseCandidateVersion: 00


### PR DESCRIPTION
Bump Harvester CSI Driver chart from `0.1.30` to `0.1.31`.

Related issue: https://github.com/harvester/harvester/issues/11383

- Driver release: https://github.com/harvester/harvester-csi-driver/releases/tag/v0.2.9
- Chart release: https://github.com/harvester/charts/releases/tag/harvester-csi-driver-0.1.31

The new chart adds support for `global.cattle.imagePullSecrets` on the controller Deployment and node DaemonSet.

Hi @brandond , we would like to bump Harvester CSI driver to various bug fixes and features.
Could you help review it? Thanks!
