### PR TITLE
Do not install upstream CRDs for rke2-snapshot-controller

### DIFF
--- a/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
@@ -1,5 +1,11 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
+@@ -1,4 +1,4 @@
+-installCRDs: true
++installCRDs: false
+ 
+ controller:
+    enabled: true
 @@ -16,10 +16,10 @@
      featureGates: CSIVolumeGroupSnapshot=true
  

--- a/packages/rke2-snapshot-controller/package.yaml
+++ b/packages/rke2-snapshot-controller/package.yaml
@@ -1,7 +1,7 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-controller
 commit: 5d733d8c44f666d26a7f1dd210fee876eae16c3f  # snapshot-controller-5.2.0
-packageVersion: 00
+packageVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
As noted in the upstream README, for v5.0.0+ CRDs are now deployed as a regular resoure. We would need to build a migration plan for moving from our CRDs to upstream CRDs, so for now, don't install them. 

https://github.com/piraeusdatastore/helm-charts/blob/main/charts/snapshot-controller/README.md?plain=1#L60

Signed-off-by: Derek Nola <derek.nola@suse.com>