### PR TITLE
updatecli: create-github-app-token v3.2.0 uses 'client-id'

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -41,7 +41,7 @@ jobs:
         id: get_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-            app-id: ${{ env.CREATE_ISSUE_APP_ID }}
+            client-id: ${{ env.CREATE_ISSUE_APP_ID }}
             private-key: ${{ env.CREATE_ISSUE_PRIVATE_KEY }}
             owner: rancher
             repositories: |


### PR DESCRIPTION
Input 'app-id' has been deprecated with message: Use 'client-id' instead

Fixes: https://github.com/rancher/rke2-charts/actions/runs/32306869548