### PR TITLE
Create package rke2-traefik-1.34-1.36

### DIFF
--- a/packages/rke2-traefik-1.34-1.36/generated-changes/exclude/values.schema.json
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/exclude/values.schema.json
@@ -1,0 +1,3238 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://traefik.io/traefik-helm-chart.schema.json",
+    "title": "Traefik Proxy Helm Chart",
+    "description": "The Cloud Native Application Proxy",
+    "type": "object",
+    "properties": {
+        "additionalArguments": {
+            "description": "Additional arguments to be passed at Traefik's binary See [CLI Reference](https://docs.traefik.io/reference/static-configuration/cli/)",
+            "type": "array"
+        },
+        "additionalVolumeMounts": {
+            "description": "Additional volumeMounts to add to the Traefik container",
+            "type": "array"
+        },
+        "affinity": {
+            "description": "This example pod anti-affinity forces the scheduler to put traefik pods It should be used when hostNetwork: true to prevent port conflicts",
+            "type": "object"
+        },
+        "api": {
+            "type": "object",
+            "properties": {
+                "basePath": {
+                    "description": "Configure API basePath",
+                    "default": "/",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dashboard": {
+                    "description": "Enable the dashboard",
+                    "type": "boolean"
+                },
+                "dashboardName": {
+                    "description": "Custom name for the dashboard (v3.7+).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "debug": {
+                    "description": "Enable the debug API",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "disableDashboardAd": {
+                    "description": "Disable the advertisement from the dashboard.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "insecure": {
+                    "description": "Enable the insecure API (HTTP)",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "behavior": {
+                    "description": "behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).",
+                    "type": "object"
+                },
+                "enabled": {
+                    "description": "Create HorizontalPodAutoscaler object. See EXAMPLES.md for more details.",
+                    "type": "boolean"
+                },
+                "maxReplicas": {
+                    "description": "maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
+                },
+                "metrics": {
+                    "description": "metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).",
+                    "type": "array"
+                },
+                "minReplicas": {
+                    "description": "minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down. It defaults to 1 pod.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
+                },
+                "scaleTargetRef": {
+                    "description": "scaleTargetRef points to the target resource to scale, and is used for the pods for which metrics should be collected, as well as to actually change the replica count.",
+                    "type": "object",
+                    "properties": {
+                        "apiVersion": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "certificatesResolvers": {
+            "description": "Certificates resolvers configuration. Ref: https://doc.traefik.io/traefik/reference/install-configuration/tls/certificate-resolvers/acme/ See EXAMPLES.md for more details.",
+            "type": "object"
+        },
+        "commonLabels": {
+            "description": "Add additional label to all resources",
+            "type": "object"
+        },
+        "core": {
+            "type": "object",
+            "properties": {
+                "defaultRuleSyntax": {
+                    "description": "Can be used to use globally v2 router syntax. Deprecated since v3.4 /!\\. See https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3/#new-v3-syntax-notable-changes",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "deployment": {
+            "type": "object",
+            "properties": {
+                "additionalContainers": {
+                    "description": "Additional containers (e.g. for metric offloading sidecars)",
+                    "type": "array"
+                },
+                "additionalVolumes": {
+                    "description": "Additional volumes available for use with initContainers and additionalContainers",
+                    "type": "array"
+                },
+                "annotations": {
+                    "description": "Additional deployment annotations (e.g. for jaeger-operator sidecar injection)",
+                    "type": "object"
+                },
+                "dnsConfig": {
+                    "description": "Custom pod [DNS config](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#poddnsconfig-v1-core)",
+                    "type": "object"
+                },
+                "dnsPolicy": {
+                    "description": "Custom pod DNS policy. Apply if `hostNetwork: true`",
+                    "type": "string"
+                },
+                "enabled": {
+                    "description": "Enable deployment",
+                    "type": "boolean"
+                },
+                "goMemLimitPercentage": {
+                    "description": "Percentage of memory limit to set for GOMEMLIMIT, set as decimal (0.9 = 90%, 0.95 = 95% etc). Only takes effect when resources.limits.memory is set. Set to 0 to disable (e.g. when using VPA or setting it via env)",
+                    "type": "number"
+                },
+                "healthchecksHost": {
+                    "type": "string"
+                },
+                "healthchecksPort": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
+                },
+                "healthchecksScheme": {
+                    "default": "HTTP",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "HTTP",
+                        "HTTPS",
+                        null
+                    ]
+                },
+                "hostAliases": {
+                    "description": "Custom [host aliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)",
+                    "type": "array"
+                },
+                "hostUsers": {
+                    "description": "Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "imagePullSecrets": {
+                    "description": "Pull secret for fetching traefik container image",
+                    "type": "array"
+                },
+                "initContainers": {
+                    "description": "Additional initContainers (e.g. for setting file permission as shown below)",
+                    "type": "array"
+                },
+                "kind": {
+                    "description": "Deployment or DaemonSet",
+                    "type": "string"
+                },
+                "labels": {
+                    "description": "Additional deployment labels (e.g. for filtering deployment by custom labels)",
+                    "type": "object"
+                },
+                "lifecycle": {
+                    "description": "Pod lifecycle actions",
+                    "type": "object"
+                },
+                "livenessPath": {
+                    "description": "Override the liveness path. Default: /ping",
+                    "type": "string"
+                },
+                "minReadySeconds": {
+                    "description": "The minimum number of seconds Traefik needs to be up and running before the DaemonSet/Deployment controller considers it available",
+                    "type": "integer"
+                },
+                "podAnnotations": {
+                    "description": "Additional pod annotations (e.g. for mesh injection or prometheus scraping) It supports templating. One can set it with values like traefik/name: '{{ template \"traefik.name\" . }}'",
+                    "type": "object"
+                },
+                "podLabels": {
+                    "description": "Additional Pod labels (e.g. for filtering Pod by custom labels) It supports templating. One can set it with values like traefik/name: '{{ template \"traefik.name\" . }}'",
+                    "type": "object"
+                },
+                "readinessPath": {
+                    "type": "string"
+                },
+                "replicas": {
+                    "description": "Number of pods of the deployment (only applies when kind == Deployment)",
+                    "type": "integer"
+                },
+                "revisionHistoryLimit": {
+                    "description": "Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
+                },
+                "runtimeClassName": {
+                    "description": "Set a runtimeClassName on pod",
+                    "type": "string"
+                },
+                "shareProcessNamespace": {
+                    "description": "Use process namespace sharing",
+                    "type": "boolean"
+                },
+                "terminationGracePeriodSeconds": {
+                    "description": "Amount of time (in seconds) before Kubernetes will send the SIGKILL signal if Traefik does not shut down",
+                    "type": "integer"
+                }
+            }
+        },
+        "enabled": {
+            "description": "Allow the Helm chart to be used as optional subchart.",
+            "const": true
+        },
+        "env": {
+            "description": "Additional Environment variables to be passed to Traefik's binary",
+            "type": "array"
+        },
+        "envFrom": {
+            "description": "Environment variables to be passed to Traefik's binary from configMaps or secrets",
+            "type": "array"
+        },
+        "experimental": {
+            "type": "object",
+            "properties": {
+                "abortOnPluginFailure": {
+                    "description": "Defines whether all plugins must be loaded successfully for Traefik to start",
+                    "type": "boolean"
+                },
+                "fastProxy": {
+                    "type": "object",
+                    "properties": {
+                        "debug": {
+                            "description": "Enable debug mode for the FastProxy implementation.",
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "description": "Enables the FastProxy implementation.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "knative": {
+                    "description": "Enable Knative provider experimental feature.",
+                    "type": "boolean"
+                },
+                "kubernetesGateway": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable traefik experimental GatewayClass CRD",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "localPlugins": {
+                    "description": "Enable experimental local plugins",
+                    "type": "object"
+                },
+                "otlpLogs": {
+                    "description": "Enable OTLP logging experimental feature.",
+                    "type": "boolean"
+                },
+                "plugins": {
+                    "description": "Enable experimental plugins",
+                    "type": "object"
+                }
+            }
+        },
+        "extraObjects": {
+            "description": "Extra objects to deploy (value evaluated as a template)  In some cases, it can avoid the need for additional, extended or adhoc deployments. See #595 for more details and traefik/tests/values/extra.yaml for example.",
+            "type": "array"
+        },
+        "fullnameOverride": {
+            "description": "Overrides the resource name for templates (i.e deployment, service, etc..)",
+            "type": "string"
+        },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "description": "Additional gateway annotations (e.g. for cert-manager.io/issuer)",
+                    "type": "object"
+                },
+                "defaultScope": {
+                    "description": "Configure this Gateway as a [Default Gateway](https://kubernetes.io/blog/2025/11/06/gateway-api-v1-4/#introducing-default-gateways) by setting the `defaultScope` field (e.g. `All` or `Namespace`).",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "All",
+                        "None",
+                        null
+                    ]
+                },
+                "enabled": {
+                    "description": "When providers.kubernetesGateway.enabled, deploy a default gateway",
+                    "type": "boolean"
+                },
+                "infrastructure": {
+                    "description": "[Infrastructure](https://kubernetes.io/blog/2023/11/28/gateway-api-ga/#gateway-infrastructure-labels)",
+                    "type": "object"
+                },
+                "listeners": {
+                    "type": "object",
+                    "properties": {
+                        "web": {
+                            "type": "object",
+                            "properties": {
+                                "hostname": {
+                                    "description": "Optional hostname. See [Hostname](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Hostname)",
+                                    "type": "string"
+                                },
+                                "namespacePolicy": {
+                                    "description": "Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces",
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ]
+                                },
+                                "port": {
+                                    "description": "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules. The port must match a port declared in ports section.",
+                                    "type": "integer"
+                                },
+                                "protocol": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "name": {
+                    "description": "Set a custom name to gateway",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "By default, Gateway is created in the same `Namespace` as Traefik.",
+                    "type": "string"
+                }
+            }
+        },
+        "gatewayClass": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "When providers.kubernetesGateway.enabled and gateway.enabled, deploy a default gatewayClass",
+                    "type": "boolean"
+                },
+                "labels": {
+                    "description": "Additional gatewayClass labels (e.g. for filtering gateway objects by custom labels)",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "Set a custom name to GatewayClass",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "azure": {
+                    "description": "Required for Azure Marketplace integration. See https://learn.microsoft.com/en-us/partner-center/marketplace-offers/azure-container-technical-assets-kubernetes?tabs=linux,linux2#update-the-helm-chart",
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "images": {
+                            "type": "object",
+                            "properties": {
+                                "hub": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "proxy": {
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "type": "string"
+                                        },
+                                        "registry": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "checkNewVersion": {
+                    "type": "boolean"
+                },
+                "notAppendXForwardedFor": {
+                    "description": "Disable appending RemoteAddr to X-Forwarded-For header globally (v3.7+).",
+                    "type": "boolean"
+                },
+                "sendAnonymousUsage": {
+                    "description": "Please take time to consider whether or not you wish to share anonymous data with us See https://doc.traefik.io/traefik/contributing/data-collection/",
+                    "type": "boolean"
+                }
+            }
+        },
+        "hostNetwork": {
+            "description": "If hostNetwork is true, runs traefik in the host network namespace To prevent unschedulable pods due to port collisions, if hostNetwork=true and replicas\u003e1, a pod anti-affinity is recommended and will be set if the affinity is left as default.",
+            "type": "boolean"
+        },
+        "hub": {
+            "type": "object",
+            "required": [
+                "namespaces"
+            ],
+            "properties": {
+                "aigateway": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Set to true in order to enable AI Gateway. Requires a valid license token.",
+                            "type": "boolean"
+                        },
+                        "maxRequestBodySize": {
+                            "description": "Hard limit for the size of request bodies inspected by the gateway. Accepts a plain integer representing **bytes**. The default value is `1048576` (1 MiB).",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "minimum": 0
+                        }
+                    }
+                },
+                "apimanagement": {
+                    "type": "object",
+                    "properties": {
+                        "admission": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "description": "Set custom annotations.",
+                                    "type": "object"
+                                },
+                                "customWebhookCertificate": {
+                                    "description": "Set custom certificate for the WebHook admission server. The certificate should be specified with _tls.crt_ and _tls.key_ in base64 encoding.",
+                                    "type": "object"
+                                },
+                                "listenAddr": {
+                                    "description": "WebHook admission server listen address. Default: \"0.0.0.0:9943\".",
+                                    "type": "string"
+                                },
+                                "restartOnCertificateChange": {
+                                    "description": "Set it to false if you need to disable Traefik Hub pod restart when mutating webhook certificate is updated. It's done with a label update.",
+                                    "type": "boolean"
+                                },
+                                "secretName": {
+                                    "description": "Certificate name of the WebHook admission server. Default: \"hub-agent-cert\".",
+                                    "type": "string"
+                                },
+                                "selfManagedCertificate": {
+                                    "description": "By default, this chart handles directly the tls certificate required for the admission webhook. It's possible to disable this behavior and handle it outside of the chart. See EXAMPLES.md for more details.",
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "description": "Set to true in order to enable API Management. Requires a valid license token.",
+                            "type": "boolean"
+                        },
+                        "openApi": {
+                            "type": "object",
+                            "properties": {
+                                "validateRequestMethodAndPath": {
+                                    "description": "When set to true, it will only accept paths and methods that are explicitly defined in its OpenAPI specification",
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
+                "mcpgateway": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Set to true in order to enable AI MCP Gateway. Requires a valid license token.",
+                            "type": "boolean"
+                        },
+                        "maxRequestBodySize": {
+                            "description": "Hard limit for the size of request bodies inspected by the gateway. Accepts a plain integer representing **bytes**. The default value is `1048576` (1 MiB).",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "minimum": 0
+                        }
+                    }
+                },
+                "namespaces": {
+                    "description": "By default, Traefik Hub provider watches all namespaces. When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.",
+                    "type": "array"
+                },
+                "offline": {
+                    "description": "Disables all external network connections.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "pluginRegistry": {
+                    "type": "object",
+                    "properties": {
+                        "sources": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "providers": {
+                    "type": "object",
+                    "properties": {
+                        "consulCatalogEnterprise": {
+                            "type": "object",
+                            "properties": {
+                                "cache": {
+                                    "description": "Use local agent caching for catalog reads.",
+                                    "type": "boolean"
+                                },
+                                "connectAware": {
+                                    "description": "Enable Consul Connect support.",
+                                    "type": "boolean"
+                                },
+                                "connectByDefault": {
+                                    "description": "Consider every service as Connect capable by default.",
+                                    "type": "boolean"
+                                },
+                                "constraints": {
+                                    "description": "Constraints is an expression that Traefik matches against the container's labels",
+                                    "type": "string"
+                                },
+                                "defaultRule": {
+                                    "description": "Default rule.",
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "description": "Enable Consul Catalog Enterprise backend with default settings.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "type": "object",
+                                    "properties": {
+                                        "address": {
+                                            "description": "The address of the Consul server",
+                                            "type": "string"
+                                        },
+                                        "datacenter": {
+                                            "description": "Data center to use. If not provided, the default agent data center is used",
+                                            "type": "string"
+                                        },
+                                        "endpointWaitTime": {
+                                            "description": "WaitTime limits how long a Watch will block. If not provided, the agent default",
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        },
+                                        "httpauth": {
+                                            "type": "object",
+                                            "properties": {
+                                                "password": {
+                                                    "description": "Basic Auth password",
+                                                    "type": "string"
+                                                },
+                                                "username": {
+                                                    "description": "Basic Auth username",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "scheme": {
+                                            "description": "The URI scheme for the Consul server",
+                                            "type": "string"
+                                        },
+                                        "tls": {
+                                            "type": "object",
+                                            "properties": {
+                                                "ca": {
+                                                    "description": "TLS CA",
+                                                    "type": "string"
+                                                },
+                                                "cert": {
+                                                    "description": "TLS cert",
+                                                    "type": "string"
+                                                },
+                                                "insecureSkipVerify": {
+                                                    "description": "TLS insecure skip verify",
+                                                    "type": "boolean"
+                                                },
+                                                "key": {
+                                                    "description": "TLS key",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "token": {
+                                            "description": "Token is used to provide a per-request ACL token which overrides the agent's",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "exposedByDefault": {
+                                    "description": "Expose containers by default.",
+                                    "type": "boolean"
+                                },
+                                "namespaces": {
+                                    "description": "Sets the namespaces used to discover services (Consul Enterprise only).",
+                                    "type": "string"
+                                },
+                                "partition": {
+                                    "description": "Sets the partition used to discover services (Consul Enterprise only).",
+                                    "type": "string"
+                                },
+                                "prefix": {
+                                    "description": "Prefix for consul service tags.",
+                                    "type": "string"
+                                },
+                                "refreshInterval": {
+                                    "description": "Interval for checking Consul API.",
+                                    "type": "integer"
+                                },
+                                "requireConsistent": {
+                                    "description": "Forces the read to be fully consistent.",
+                                    "type": "boolean"
+                                },
+                                "serviceName": {
+                                    "description": "Name of the Traefik service in Consul Catalog (needs to be registered via the",
+                                    "type": "string"
+                                },
+                                "stale": {
+                                    "description": "Use stale consistency for catalog reads.",
+                                    "type": "boolean"
+                                },
+                                "strictChecks": {
+                                    "description": "A list of service health statuses to allow taking traffic.",
+                                    "type": "string"
+                                },
+                                "watch": {
+                                    "description": "Watch Consul API events.",
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "microcks": {
+                            "type": "object",
+                            "properties": {
+                                "auth": {
+                                    "type": "object",
+                                    "properties": {
+                                        "clientId": {
+                                            "description": "Microcks API client ID.",
+                                            "type": "string"
+                                        },
+                                        "clientSecret": {
+                                            "description": "Microcks API client secret.",
+                                            "type": "string"
+                                        },
+                                        "endpoint": {
+                                            "description": "Microcks API endpoint.",
+                                            "type": "string"
+                                        },
+                                        "token": {
+                                            "description": "Microcks API token.",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "enabled": {
+                                    "description": "Enable Microcks provider.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Microcks API endpoint.",
+                                    "type": "string"
+                                },
+                                "pollInterval": {
+                                    "description": "Polling interval for Microcks API.",
+                                    "type": "integer"
+                                },
+                                "pollTimeout": {
+                                    "description": "Polling timeout for Microcks API.",
+                                    "type": "integer"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "TLS CA",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "TLS cert",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "TLS insecure skip verify",
+                                            "type": "boolean"
+                                        },
+                                        "key": {
+                                            "description": "TLS key",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "multicluster": {
+                            "type": "object",
+                            "properties": {
+                                "children": {
+                                    "description": "Child cluster configurations, keyed by a unique name.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object",
+                                        "properties": {
+                                            "address": {
+                                                "description": "URL of the child cluster's uplink entrypoint.",
+                                                "type": "string"
+                                            },
+                                            "serversTransport": {
+                                                "description": "TLS and transport configuration for connecting to this child.",
+                                                "type": "object",
+                                                "properties": {
+                                                    "certificates": {
+                                                        "type": "array"
+                                                    },
+                                                    "cipherSuites": {
+                                                        "description": "List of supported cipher suites for TLS versions up to 1.2.",
+                                                        "type": "array"
+                                                    },
+                                                    "disableHTTP2": {
+                                                        "description": "Disable HTTP/2 for connections to this child.",
+                                                        "type": [
+                                                            "boolean",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "forwardingTimeouts": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "dialTimeout": {
+                                                                "description": "Timeout for establishing connections.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "idleConnTimeout": {
+                                                                "description": "Timeout for idle connections.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "pingTimeout": {
+                                                                "description": "Timeout for HTTP/2 server ping frames.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "readIdleTimeout": {
+                                                                "description": "Timeout for HTTP/2 connection idle reads.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "readTimeout": {
+                                                                "description": "Timeout for reading the request body.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "responseHeaderTimeout": {
+                                                                "description": "Timeout for reading response headers.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "writeTimeout": {
+                                                                "description": "Timeout for writing the response.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    "insecureSkipVerify": {
+                                                        "description": "Disable TLS certificate verification. **Not recommended for production.**",
+                                                        "type": [
+                                                            "boolean",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "maxIdleConnsPerHost": {
+                                                        "description": "Maximum idle connections per host.",
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "maxVersion": {
+                                                        "description": "Maximum TLS version (e.g. `VersionTLS12`, `VersionTLS13`).",
+                                                        "type": "string"
+                                                    },
+                                                    "minVersion": {
+                                                        "description": "Minimum TLS version (e.g. `VersionTLS12`, `VersionTLS13`).",
+                                                        "type": "string"
+                                                    },
+                                                    "peerCertURI": {
+                                                        "description": "URI used to match against SAN URIs during the server's certificate verification.",
+                                                        "type": "string"
+                                                    },
+                                                    "rootCAs": {
+                                                        "type": "array"
+                                                    },
+                                                    "serverName": {
+                                                        "description": "Server name used for SNI and certificate verification.",
+                                                        "type": "string"
+                                                    },
+                                                    "spiffe": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "ids": {
+                                                                "type": "array"
+                                                            },
+                                                            "trustDomain": {
+                                                                "description": "SPIFFE trust domain.",
+                                                                "type": [
+                                                                    "string",
+                                                                    "integer",
+                                                                    "null"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "enabled": {
+                                    "description": "Enable Multi-cluster provider.",
+                                    "type": "boolean"
+                                },
+                                "pollInterval": {
+                                    "description": "Polling interval for Multi-cluster.",
+                                    "type": "integer"
+                                },
+                                "pollTimeout": {
+                                    "description": "Polling timeout for Multi-cluster.",
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "nutanixPrismCentral": {
+                            "type": "object",
+                            "properties": {
+                                "allowedVpcs": {
+                                    "description": "Filter VMs by VPCs. List of `{ uuid: \"\u003cvpc-uuid\u003e\" }` entries.",
+                                    "type": "array"
+                                },
+                                "apiKey": {
+                                    "description": "Prism Central API key.",
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "description": "Enable Nutanix Prism Central provider.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Prism Central endpoint.",
+                                    "type": "string"
+                                },
+                                "filename": {
+                                    "description": "Base configuration file path.",
+                                    "type": "string"
+                                },
+                                "password": {
+                                    "description": "Prism Central password.",
+                                    "type": "string"
+                                },
+                                "pollInterval": {
+                                    "description": "Polling interval for Nutanix Prism Central API.",
+                                    "type": "integer"
+                                },
+                                "pollTimeout": {
+                                    "description": "Polling timeout for Nutanix Prism Central API.",
+                                    "type": "integer"
+                                },
+                                "serviceNameCategoryKey": {
+                                    "description": "Category key used to derive the service name.",
+                                    "type": "string"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "TLS CA",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "TLS cert",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "TLS insecure skip verify",
+                                            "type": "boolean"
+                                        },
+                                        "key": {
+                                            "description": "TLS key",
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "username": {
+                                    "description": "Prism Central username.",
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "redis": {
+                    "type": "object",
+                    "properties": {
+                        "cluster": {
+                            "description": "Enable Redis Cluster. Default: true.",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "database": {
+                            "description": "Database used to store information. Default: \"0\".",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "endpoints": {
+                            "description": "Endpoints of the Redis instances to connect to. Default: \"\".",
+                            "type": "string"
+                        },
+                        "password": {
+                            "description": "The password to use when connecting to Redis endpoints. Default: \"\".",
+                            "type": "string"
+                        },
+                        "sentinel": {
+                            "type": "object",
+                            "properties": {
+                                "masterset": {
+                                    "description": "Name of the set of main nodes to use for main selection. Required when using Sentinel. Default: \"\".",
+                                    "type": "string"
+                                },
+                                "password": {
+                                    "description": "Password to use for sentinel authentication (can be different from endpoint password). Default: \"\".",
+                                    "type": "string"
+                                },
+                                "username": {
+                                    "description": "Username to use for sentinel authentication (can be different from endpoint username). Default: \"\".",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "timeout": {
+                            "description": "Timeout applied on connection with redis. Default: \"0s\".",
+                            "type": "string"
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "ca": {
+                                    "description": "Path to the certificate authority used for the secured connection.",
+                                    "type": "string"
+                                },
+                                "cert": {
+                                    "description": "Path to the public certificate used for the secure connection.",
+                                    "type": "string"
+                                },
+                                "insecureSkipVerify": {
+                                    "description": "When insecureSkipVerify is set to true, the TLS connection accepts any certificate presented by the server. Default: false.",
+                                    "type": "boolean"
+                                },
+                                "key": {
+                                    "description": "Path to the private key used for the secure connection.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "username": {
+                            "description": "The username to use when connecting to Redis endpoints. Default: \"\".",
+                            "type": "string"
+                        }
+                    }
+                },
+                "sendlogs": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "token": {
+                    "description": "Name of `Secret` with key 'token' set to a valid license token. It enables API Gateway.",
+                    "type": "string"
+                },
+                "tokenMountPath": {
+                    "description": "Mount path for token secret.",
+                    "type": "string"
+                },
+                "tracing": {
+                    "type": "object",
+                    "properties": {
+                        "additionalTraceHeaders": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Tracing headers to duplicate. To configure the following, tracing.otlp.enabled needs to be set to true.",
+                                    "type": "boolean"
+                                },
+                                "traceContext": {
+                                    "type": "object",
+                                    "properties": {
+                                        "parentId": {
+                                            "description": "Name of the header that will contain the parent-id header copy.",
+                                            "type": "string"
+                                        },
+                                        "traceId": {
+                                            "description": "Name of the header that will contain the trace-id copy.",
+                                            "type": "string"
+                                        },
+                                        "traceParent": {
+                                            "description": "Name of the header that will contain the traceparent copy.",
+                                            "type": "string"
+                                        },
+                                        "traceState": {
+                                            "description": "Name of the header that will contain the tracestate copy.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "digest": {
+                    "description": "Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "pattern": "^sha256:[a-f0-9]{64}$"
+                },
+                "pullPolicy": {
+                    "description": "Traefik image pull policy",
+                    "type": "string"
+                },
+                "registry": {
+                    "description": "Traefik image host registry",
+                    "type": "string"
+                },
+                "repository": {
+                    "description": "Traefik image repository",
+                    "type": "string"
+                },
+                "tag": {
+                    "description": "defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `\u003cversion\u003e@\u003cdigest\u003e` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "ingressClass": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Create a default IngressClass for Traefik",
+                    "type": "boolean"
+                },
+                "isDefaultClass": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ingressRoute": {
+            "description": "Only dashboard \u0026 healthcheck IngressRoute are supported. It's recommended to create workloads CR outside of this Chart.",
+            "type": "object",
+            "properties": {
+                "dashboard": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "description": "Additional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)",
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "description": "Create an IngressRoute for the dashboard",
+                            "type": "boolean"
+                        },
+                        "entryPoints": {
+                            "description": "Specify the allowed entrypoints to use for the dashboard ingress route, (e.g. traefik, web, websecure). By default, it's using traefik entrypoint, which is not exposed. /!\\ Do not expose your dashboard without any protection over the internet /!\\",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "labels": {
+                            "description": "Additional ingressRoute labels (e.g. for filtering IngressRoute by custom labels)",
+                            "type": "object"
+                        },
+                        "matchRule": {
+                            "description": "The router match rule used for the dashboard ingressRoute",
+                            "type": "string"
+                        },
+                        "middlewares": {
+                            "description": "Additional ingressRoute middlewares (e.g. for authentication)",
+                            "type": "array"
+                        },
+                        "services": {
+                            "description": "The internal service used for the dashboard ingressRoute",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "tls": {
+                            "description": "TLS options (e.g. secret containing certificate)",
+                            "type": "object"
+                        }
+                    }
+                },
+                "healthcheck": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "description": "Additional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)",
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "description": "Create an IngressRoute for the healthcheck probe",
+                            "type": "boolean"
+                        },
+                        "entryPoints": {
+                            "description": "Specify the allowed entrypoints to use for the healthcheck ingress route, (e.g. traefik, web, websecure). By default, it's using traefik entrypoint, which is not exposed.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "labels": {
+                            "description": "Additional ingressRoute labels (e.g. for filtering IngressRoute by custom labels)",
+                            "type": "object"
+                        },
+                        "matchRule": {
+                            "description": "The router match rule used for the healthcheck ingressRoute",
+                            "type": "string"
+                        },
+                        "middlewares": {
+                            "description": "Additional ingressRoute middlewares (e.g. for authentication)",
+                            "type": "array"
+                        },
+                        "services": {
+                            "description": "The internal service used for the healthcheck ingressRoute",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "tls": {
+                            "description": "TLS options (e.g. secret containing certificate)",
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "instanceLabelOverride": {
+            "description": "This field overrides the default app.kubernetes.io/instance label for all Objects.",
+            "type": "string"
+        },
+        "livenessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "description": "The number of consecutive failures allowed before considering the probe as failed.",
+                    "type": "integer"
+                },
+                "initialDelaySeconds": {
+                    "description": "The number of seconds to wait before starting the first probe.",
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "description": "The number of seconds to wait between consecutive probes.",
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "description": "The minimum consecutive successes required to consider the probe successful.",
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "description": "The number of seconds to wait for a probe response before considering it as failed.",
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "logs": {
+            "type": "object",
+            "properties": {
+                "access": {
+                    "type": "object",
+                    "properties": {
+                        "addInternals": {
+                            "description": "Enables accessLogs for internal resources. Default: false.",
+                            "type": "boolean"
+                        },
+                        "bufferingSize": {
+                            "description": "Set [bufferingSize](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-bufferingSize)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "dualOutput": {
+                            "description": "Enables access log output alongside OTLP (v3.7+).",
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "description": "To enable access logs",
+                            "type": "boolean"
+                        },
+                        "fields": {
+                            "type": "object",
+                            "properties": {
+                                "general": {
+                                    "type": "object",
+                                    "properties": {
+                                        "defaultmode": {
+                                            "description": "Set default mode for fields.names",
+                                            "default": "keep",
+                                            "type": "string",
+                                            "enum": [
+                                                "keep",
+                                                "drop",
+                                                "redact"
+                                            ]
+                                        },
+                                        "names": {
+                                            "description": "Names of the fields to limit.",
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "headers": {
+                                    "type": "object",
+                                    "properties": {
+                                        "defaultmode": {
+                                            "description": "[Limit logged fields or headers](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#log-fields-customization)",
+                                            "default": "drop",
+                                            "type": "string",
+                                            "enum": [
+                                                "keep",
+                                                "drop",
+                                                "redact"
+                                            ]
+                                        },
+                                        "names": {
+                                            "type": "object"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "filters": {
+                            "description": "Set [filtering](https://doc.traefik.io/traefik/observe/logs-and-access-logs/#access-log-filters)",
+                            "type": "object",
+                            "properties": {
+                                "minduration": {
+                                    "description": "Set minDuration, to keep access logs when requests take longer than the specified duration",
+                                    "type": "string"
+                                },
+                                "retryattempts": {
+                                    "description": "Set retryAttempts, to keep the access logs when at least one retry has happened",
+                                    "type": "boolean"
+                                },
+                                "statuscodes": {
+                                    "description": "Set statusCodes, to limit the access logs to requests with a status codes in the specified range",
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "format": {
+                            "description": "Set [access log format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-accesslog-format)",
+                            "default": "common",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "common",
+                                "genericCLF",
+                                "json",
+                                null
+                            ]
+                        },
+                        "otlp": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to enable OpenTelemetry on access logs. Note that experimental.otlpLogs needs to be enabled.",
+                                    "type": "boolean"
+                                },
+                                "grpc": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "description": "Set to true in order to send access logs to the OpenTelemetry Collector using gRPC",
+                                            "type": "boolean"
+                                        },
+                                        "endpoint": {
+                                            "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
+                                            "type": "string"
+                                        },
+                                        "insecure": {
+                                            "description": "Allows reporter to send access logs to the OpenTelemetry Collector without using a secured protocol.",
+                                            "type": "boolean"
+                                        },
+                                        "tls": {
+                                            "type": "object",
+                                            "properties": {
+                                                "ca": {
+                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                                    "type": "string"
+                                                },
+                                                "cert": {
+                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                                    "type": "string"
+                                                },
+                                                "insecureSkipVerify": {
+                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                                    "type": [
+                                                        "boolean",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "key": {
+                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "http": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "description": "Set to true in order to send access logs to the OpenTelemetry Collector using HTTP.",
+                                            "type": "boolean"
+                                        },
+                                        "endpoint": {
+                                            "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/logs",
+                                            "type": "string"
+                                        },
+                                        "headers": {
+                                            "description": "Additional headers sent with access logs by the reporter to the OpenTelemetry Collector.",
+                                            "type": "object"
+                                        },
+                                        "tls": {
+                                            "type": "object",
+                                            "properties": {
+                                                "ca": {
+                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                                    "type": "string"
+                                                },
+                                                "cert": {
+                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                                    "type": "string"
+                                                },
+                                                "insecureSkipVerify": {
+                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                                    "type": [
+                                                        "boolean",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "key": {
+                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "resourceAttributes": {
+                                    "description": "Defines additional resource attributes to be sent to the collector.",
+                                    "type": "object"
+                                },
+                                "serviceName": {
+                                    "description": "Service name used in OTLP backend. Default: traefik.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "timezone": {
+                            "description": "Set [timezone](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#time-zones)",
+                            "type": "string"
+                        }
+                    }
+                },
+                "general": {
+                    "type": "object",
+                    "properties": {
+                        "filePath": {
+                            "description": "To write the logs into a log file, use the filePath option.",
+                            "type": "string"
+                        },
+                        "format": {
+                            "description": "Set [logs format](https://doc.traefik.io/traefik/reference/install-configuration/observability/logs-and-accesslogs/#opt-log-format)",
+                            "default": "common",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "common",
+                                "json",
+                                null
+                            ]
+                        },
+                        "level": {
+                            "description": "Alternative logging levels are TRACE, DEBUG, INFO, WARN, ERROR, FATAL, and PANIC.",
+                            "default": "INFO",
+                            "type": "string",
+                            "enum": [
+                                "TRACE",
+                                "DEBUG",
+                                "INFO",
+                                "WARN",
+                                "ERROR",
+                                "FATAL",
+                                "PANIC"
+                            ]
+                        },
+                        "noColor": {
+                            "description": "When set to true and format is common, it disables the colorized output.",
+                            "type": "boolean"
+                        },
+                        "otlp": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to enable OpenTelemetry on logs. Note that experimental.otlpLogs needs to be enabled.",
+                                    "type": "boolean"
+                                },
+                                "grpc": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "description": "Set to true in order to send logs  to the OpenTelemetry Collector using gRPC",
+                                            "type": "boolean"
+                                        },
+                                        "endpoint": {
+                                            "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
+                                            "type": "string"
+                                        },
+                                        "insecure": {
+                                            "description": "Allows reporter to send logs to the OpenTelemetry Collector without using a secured protocol.",
+                                            "type": "boolean"
+                                        },
+                                        "tls": {
+                                            "type": "object",
+                                            "properties": {
+                                                "ca": {
+                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                                    "type": "string"
+                                                },
+                                                "cert": {
+                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                                    "type": "string"
+                                                },
+                                                "insecureSkipVerify": {
+                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                                    "type": [
+                                                        "boolean",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "key": {
+                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "http": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "description": "Set to true in order to send logs to the OpenTelemetry Collector using HTTP.",
+                                            "type": "boolean"
+                                        },
+                                        "endpoint": {
+                                            "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/logs",
+                                            "type": "string"
+                                        },
+                                        "headers": {
+                                            "description": "Additional headers sent with logs by the reporter to the OpenTelemetry Collector.",
+                                            "type": "object"
+                                        },
+                                        "tls": {
+                                            "type": "object",
+                                            "properties": {
+                                                "ca": {
+                                                    "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                                    "type": "string"
+                                                },
+                                                "cert": {
+                                                    "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                                    "type": "string"
+                                                },
+                                                "insecureSkipVerify": {
+                                                    "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                                    "type": [
+                                                        "boolean",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "key": {
+                                                    "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "resourceAttributes": {
+                                    "description": "Defines additional resource attributes to be sent to the collector.",
+                                    "type": "object"
+                                },
+                                "serviceName": {
+                                    "description": "Service name used in OTLP backend. Default: traefik.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "addInternals": {
+                    "description": "Enable metrics for internal resources. Default: false",
+                    "type": "boolean"
+                },
+                "otlp": {
+                    "type": "object",
+                    "properties": {
+                        "addEntryPointsLabels": {
+                            "description": "Enable metrics on entry points. Default: true",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "addRoutersLabels": {
+                            "description": "Enable metrics on routers. Default: false",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "addServicesLabels": {
+                            "description": "Enable metrics on services. Default: true",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "enabled": {
+                            "description": "Set to true in order to enable the OpenTelemetry metrics",
+                            "type": "boolean"
+                        },
+                        "explicitBoundaries": {
+                            "description": "Explicit boundaries for Histogram data points. Default: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]",
+                            "type": "array"
+                        },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to send metrics to the OpenTelemetry Collector using gRPC",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
+                                    "type": "string"
+                                },
+                                "insecure": {
+                                    "description": "Allows reporter to send metrics to the OpenTelemetry Collector without using a secured protocol.",
+                                    "type": "boolean"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                            "type": [
+                                                "boolean",
+                                                "null"
+                                            ]
+                                        },
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "http": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to send metrics to the OpenTelemetry Collector using HTTP.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/metrics",
+                                    "type": "string"
+                                },
+                                "headers": {
+                                    "description": "Additional headers sent with metrics by the reporter to the OpenTelemetry Collector.",
+                                    "type": "object"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                            "type": [
+                                                "boolean",
+                                                "null"
+                                            ]
+                                        },
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "pushInterval": {
+                            "description": "Interval at which metrics are sent to the OpenTelemetry Collector. Default: 10s",
+                            "type": "string"
+                        },
+                        "resourceAttributes": {
+                            "description": "Defines additional resource attributes to be sent to the collector.",
+                            "type": "object"
+                        },
+                        "serviceName": {
+                            "description": "Service name used in OTLP backend. Default: traefik.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "prometheus": {
+                    "type": "object",
+                    "properties": {
+                        "addEntryPointsLabels": {
+                            "description": "Enable metrics on entry points. Default: true",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "addRoutersLabels": {
+                            "description": "Enable metrics on routers. Default: false",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "addServicesLabels": {
+                            "description": "Enable metrics on services. Default: true",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "buckets": {
+                            "description": "Buckets for latency metrics. Default=\"0.1,0.3,1.2,5.0\"",
+                            "type": "string"
+                        },
+                        "disableAPICheck": {
+                            "description": "When set to true, it won't check if Prometheus Operator CRDs are deployed",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "entryPoint": {
+                            "description": "Entry point used to expose metrics.",
+                            "type": "string"
+                        },
+                        "headerLabels": {
+                            "description": "Add HTTP header labels to metrics. See EXAMPLES.md or upstream doc for usage.",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "manualRouting": {
+                            "description": "When manualRouting is true, it disables the default internal router in # order to allow creating a custom router for prometheus@internal service.",
+                            "type": "boolean"
+                        },
+                        "prometheusRule": {
+                            "type": "object",
+                            "properties": {
+                                "additionalLabels": {
+                                    "type": "object"
+                                },
+                                "apiVersion": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "description": "Enable optional CR for Prometheus Operator. See EXAMPLES.md for more details.",
+                                    "type": "boolean"
+                                },
+                                "namespace": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "enabled": {
+                                    "description": "Create a dedicated metrics service to use with ServiceMonitor",
+                                    "type": "boolean"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "serviceMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "additionalLabels": {
+                                    "type": "object"
+                                },
+                                "apiVersion": {
+                                    "type": "string"
+                                },
+                                "enableHttp2": {
+                                    "type": "boolean"
+                                },
+                                "enabled": {
+                                    "description": "Enable optional CR for Prometheus Operator. See EXAMPLES.md for more details.",
+                                    "type": "boolean"
+                                },
+                                "followRedirects": {
+                                    "type": "boolean"
+                                },
+                                "honorLabels": {
+                                    "type": "boolean"
+                                },
+                                "honorTimestamps": {
+                                    "type": "boolean"
+                                },
+                                "interval": {
+                                    "type": "string"
+                                },
+                                "jobLabel": {
+                                    "type": "string"
+                                },
+                                "metricRelabelings": {
+                                    "type": "array"
+                                },
+                                "namespace": {
+                                    "type": "string"
+                                },
+                                "namespaceSelector": {
+                                    "type": "object"
+                                },
+                                "relabelings": {
+                                    "type": "array"
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "nameOverride": {
+            "description": "overrides the app.kubernetes.io/name label",
+            "type": "string"
+        },
+        "namespaceOverride": {
+            "description": "This field overrides the default Release Namespace for Helm. It will not affect optional CRDs such as `ServiceMonitor` and `PrometheusRules`",
+            "type": "string"
+        },
+        "nodeSelector": {
+            "description": "nodeSelector is the simplest recommended form of node selection constraint.",
+            "type": "object"
+        },
+        "oci_meta": {
+            "description": "Required for OCI Marketplace integration. See https://docs.public.content.oci.oraclecloud.com/en-us/iaas/Content/Marketplace/understanding-helm-charts.htm",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enable specific values for Oracle Cloud Infrastructure",
+                    "type": "boolean"
+                },
+                "images": {
+                    "type": "object",
+                    "properties": {
+                        "hub": {
+                            "type": "object",
+                            "properties": {
+                                "image": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "proxy": {
+                            "type": "object",
+                            "properties": {
+                                "image": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "repo": {
+                    "description": "It needs to be an ocir repo",
+                    "type": "string"
+                }
+            }
+        },
+        "ocsp": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enable OCSP stapling support. See https://doc.traefik.io/traefik/reference/install-configuration/tls/ocsp/",
+                    "type": "boolean"
+                },
+                "responderOverrides": {
+                    "description": "Defines the OCSP responder URLs to use instead of the one provided by the certificate.",
+                    "type": "object"
+                }
+            }
+        },
+        "offering_version": {
+            "description": "Required for IBM Cloud Marketplace integration. Injected by IBM Cloud Catalog when deploying via IBM Cloud Schematics. This value is not used by the chart.",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "persistence": {
+            "type": "object",
+            "properties": {
+                "accessMode": {
+                    "type": "string"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "description": "Enable persistence using Persistent Volume Claims ref: http://kubernetes.io/docs/user-guide/persistent-volumes/. It can be used to store TLS certificates along with `certificatesResolvers.\u003cname\u003e.acme.storage`  option",
+                    "type": "boolean"
+                },
+                "existingClaim": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "string"
+                },
+                "storageClass": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "subPath": {
+                    "description": "Only mount a subpath of the Volume into the pod",
+                    "type": "string"
+                },
+                "volumeName": {
+                    "type": "string"
+                }
+            }
+        },
+        "podDisruptionBudget": {
+            "description": "[Pod Disruption Budget](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/pod-disruption-budget-v1/)",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxUnavailable": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
+                },
+                "minAvailable": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
+                }
+            },
+            "additionalProperties": false
+        },
+        "podSecurityContext": {
+            "description": "[Pod Security Context](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context)",
+            "type": "object",
+            "properties": {
+                "runAsGroup": {
+                    "type": "integer"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "ports": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "allowACMEByPass": {
+                        "description": "See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#allowacmebypass)",
+                        "type": "boolean"
+                    },
+                    "appProtocol": {
+                        "description": "See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol)",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "asDefault": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "containerPort": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "expose": {
+                        "description": "You may not want to expose the metrics port on production deployments. If you want to access it from outside your cluster, use `kubectl port-forward` or create a secure ingress",
+                        "type": "object",
+                        "properties": {
+                            "default": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "exposedPort": {
+                        "description": "The exposed port for this service",
+                        "type": "integer"
+                    },
+                    "forwardedHeaders": {
+                        "type": "object",
+                        "properties": {
+                            "insecure": {
+                                "type": "boolean"
+                            },
+                            "notAppendXForwardedFor": {
+                                "description": "Disable appending RemoteAddr to X-Forwarded-For header (v3.7+).",
+                                "type": "boolean"
+                            },
+                            "trustedIPs": {
+                                "description": "Trust forwarded headers information (X-Forwarded-*).",
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "hostIP": {
+                        "description": "Use hostIP if set. If not set, Kubernetes will default to 0.0.0.0, which means it's listening on all your interfaces and all your IPs. You may want to set this value if you need traefik to listen on specific interface only.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "hostPort": {
+                        "description": "Use hostPort if set.",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "http": {
+                        "type": "object",
+                        "properties": {
+                            "encodedCharacters": {
+                                "description": "See [upstream documentation](https://doc.traefik.io/traefik/security/request-path/#encoded-character-filtering)",
+                                "type": "object",
+                                "properties": {
+                                    "allowEncodedBackSlash": {
+                                        "type": [
+                                            "boolean",
+                                            "null"
+                                        ]
+                                    },
+                                    "allowEncodedHash": {
+                                        "type": [
+                                            "boolean",
+                                            "null"
+                                        ]
+                                    },
+                                    "allowEncodedNullCharacter": {
+                                        "type": [
+                                            "boolean",
+                                            "null"
+                                        ]
+                                    },
+                                    "allowEncodedPercent": {
+                                        "type": [
+                                            "boolean",
+                                            "null"
+                                        ]
+                                    },
+                                    "allowEncodedQuestionMark": {
+                                        "type": [
+                                            "boolean",
+                                            "null"
+                                        ]
+                                    },
+                                    "allowEncodedSemicolon": {
+                                        "type": [
+                                            "boolean",
+                                            "null"
+                                        ]
+                                    },
+                                    "allowEncodedSlash": {
+                                        "type": [
+                                            "boolean",
+                                            "null"
+                                        ]
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "maxHeaderBytes": {
+                                "description": "Maximum size of request headers in bytes. Default: 1048576 (1 MB)",
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "minimum": 0
+                            },
+                            "middlewares": {
+                                "description": "See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#httpmiddlewares)",
+                                "type": [
+                                    "array",
+                                    "null"
+                                ]
+                            },
+                            "redirections": {
+                                "type": "object",
+                                "properties": {
+                                    "entryPoint": {
+                                        "description": "Port Redirections Added in 2.2, one can make permanent redirects via entrypoints. Same sets of parameters: to, scheme, permanent and priority. https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#configuration-example",
+                                        "type": "object"
+                                    }
+                                }
+                            },
+                            "sanitizePath": {
+                                "description": "See [upstream documentation](https://doc.traefik.io/traefik/security/request-path/#path-sanitization)",
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            },
+                            "tls": {
+                                "type": "object",
+                                "properties": {
+                                    "certResolver": {
+                                        "type": "string"
+                                    },
+                                    "domains": {
+                                        "type": "array"
+                                    },
+                                    "enabled": {
+                                        "description": "See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#opt-http-tls)",
+                                        "type": "boolean"
+                                    },
+                                    "options": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "http3": {
+                        "type": "object",
+                        "properties": {
+                            "advertisedPort": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "minimum": 0
+                            },
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "nodePort": {
+                        "description": "See [upstream documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)",
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "observability": {
+                        "type": "object",
+                        "properties": {
+                            "accessLogs": {
+                                "description": "Enables access-logs for this entryPoint.",
+                                "default": true,
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            },
+                            "metrics": {
+                                "description": "Enables metrics for this entryPoint.",
+                                "default": true,
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            },
+                            "traceVerbosity": {
+                                "description": "Defines the tracing verbosity level for this entryPoint.",
+                                "default": "minimal",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "minimal",
+                                    "detailed",
+                                    null
+                                ]
+                            },
+                            "tracing": {
+                                "description": "Enables tracing for this entryPoint.",
+                                "default": true,
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "port": {
+                        "description": "When using hostNetwork, use another port to avoid conflict with node exporter: https://github.com/prometheus/prometheus/wiki/Default-port-allocations",
+                        "type": "integer"
+                    },
+                    "protocol": {
+                        "description": "The port protocol (TCP/UDP)",
+                        "type": "string"
+                    },
+                    "proxyProtocol": {
+                        "type": "object",
+                        "properties": {
+                            "insecure": {
+                                "type": "boolean"
+                            },
+                            "trustedIPs": {
+                                "description": "Enable the Proxy Protocol header parsing for the entry point",
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "targetPort": {
+                        "type": [
+                            "string",
+                            "integer",
+                            "null"
+                        ],
+                        "minimum": 0
+                    },
+                    "transport": {
+                        "description": "Set transport settings for the entrypoint",
+                        "type": "object",
+                        "properties": {
+                            "keepAliveMaxRequests": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "minimum": 0
+                            },
+                            "keepAliveMaxTime": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            },
+                            "lifeCycle": {
+                                "type": "object",
+                                "properties": {
+                                    "graceTimeOut": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    },
+                                    "requestAcceptGraceTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "respondingTimeouts": {
+                                "type": "object",
+                                "properties": {
+                                    "idleTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    },
+                                    "readTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    },
+                                    "writeTimeout": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "uplink": {
+                        "description": "Enable this port as an uplink for multi cluster. ⚠️ This feature is experimental and requires Traefik Hub with a specific subscription.",
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "priorityClassName": {
+            "description": "[Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)",
+            "type": "string"
+        },
+        "providers": {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "description": "File content (YAML format, go template supported) (see https://doc.traefik.io/traefik/reference/install-configuration/providers/others/file/)",
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "description": "Create a file provider",
+                            "type": "boolean"
+                        },
+                        "watch": {
+                            "description": "Allows Traefik to automatically watch for file changes",
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "knative": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable Knative provider",
+                            "type": "boolean"
+                        },
+                        "labelSelector": {
+                            "description": "Allow filtering Knative Ingress objects",
+                            "type": "string"
+                        },
+                        "namespaces": {
+                            "description": "Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.",
+                            "type": "array"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "kubernetesCRD": {
+                    "type": "object",
+                    "properties": {
+                        "allowCrossNamespace": {
+                            "description": "Allows IngressRoute to reference resources in namespace other than theirs",
+                            "type": "boolean"
+                        },
+                        "allowEmptyServices": {
+                            "description": "Allows to return 503 when there are no endpoints available",
+                            "type": "boolean"
+                        },
+                        "allowExternalNameServices": {
+                            "description": "Allows to reference ExternalName services in IngressRoute",
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "description": "Load Kubernetes IngressRoute provider",
+                            "type": "boolean"
+                        },
+                        "ingressClass": {
+                            "description": "When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.",
+                            "type": "string"
+                        },
+                        "labelSelector": {
+                            "description": "See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector)",
+                            "type": "string"
+                        },
+                        "namespaces": {
+                            "description": "Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.",
+                            "type": "array"
+                        },
+                        "nativeLBByDefault": {
+                            "description": "Defines whether to use Native Kubernetes load-balancing mode by default.",
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "kubernetesGateway": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable Traefik Gateway provider for Gateway API",
+                            "type": "boolean"
+                        },
+                        "experimentalChannel": {
+                            "description": "Toggles support for the Experimental Channel resources (Gateway API release channels documentation). This option currently enables support for TCPRoute and TLSRoute.",
+                            "type": "boolean"
+                        },
+                        "labelSelector": {
+                            "description": "A label selector can be defined to filter on specific GatewayClass objects only.",
+                            "type": "string"
+                        },
+                        "namespaces": {
+                            "description": "Array of namespaces to watch. If left empty, Traefik watches all namespaces. kubernetesGateway provider requires ClusterRole and as a consequence `rbac.namespaced` is not supported.",
+                            "type": "array"
+                        },
+                        "nativeLBByDefault": {
+                            "description": "Defines whether to use Native Kubernetes load-balancing mode by default.",
+                            "type": "boolean"
+                        },
+                        "statusAddress": {
+                            "type": "object",
+                            "properties": {
+                                "hostname": {
+                                    "description": "This Hostname will get copied to the Gateway status.addresses.",
+                                    "type": "string"
+                                },
+                                "ip": {
+                                    "description": "This IP will get copied to the Gateway status.addresses, and currently only supports one IP value (IPv4 or IPv6).",
+                                    "type": "string"
+                                },
+                                "service": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enabled": {
+                                            "description": "The Kubernetes service to copy status addresses from. When using third parties tools like External-DNS, this option can be used to copy the service loadbalancer.status (containing the service's endpoints IPs) to the gateways. Default to Service of this Chart.",
+                                            "type": "boolean"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "kubernetesIngress": {
+                    "type": "object",
+                    "properties": {
+                        "allowEmptyServices": {
+                            "description": "Allows to return 503 when there are no endpoints available",
+                            "type": "boolean"
+                        },
+                        "allowExternalNameServices": {
+                            "description": "Allows to reference ExternalName services in Ingress",
+                            "type": "boolean"
+                        },
+                        "disableIngressClassLookup": {
+                            "description": "Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup)",
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "description": "Load Kubernetes Ingress provider",
+                            "type": "boolean"
+                        },
+                        "ingressClass": {
+                            "description": "When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "ingressEndpoint": {
+                            "type": "object",
+                            "properties": {
+                                "hostname": {
+                                    "description": "Hostname used for Kubernetes Ingress endpoints",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "ip": {
+                                    "description": "IP used for Kubernetes Ingress endpoints",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "labelSelector": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "namespaces": {
+                            "description": "Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.",
+                            "type": "array"
+                        },
+                        "nativeLBByDefault": {
+                            "description": "Defines whether to use Native Kubernetes load-balancing mode by default.",
+                            "type": "boolean"
+                        },
+                        "publishedService": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable [publishedService](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#ingressendpointpublishedservice), usually with the Service provided by this Chart. It's possible to use it with an external Service using pathOverride.",
+                                    "type": "boolean"
+                                },
+                                "pathOverride": {
+                                    "description": "Override path of Kubernetes Service used to copy status from. Format: namespace/servicename. Default to Service deployed with this Chart.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "strictPrefixMatching": {
+                            "description": "Defines whether to make prefix matching strictly comply with the Kubernetes Ingress specification.",
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "kubernetesIngressNGINX": {
+                    "type": "object",
+                    "properties": {
+                        "allowCrossNamespaceResources": {
+                            "description": "Allow Ingress to reference resources (e.g. ConfigMaps, Secrets) in different namespaces (default: false)",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "allowSnippetAnnotations": {
+                            "description": "Enables parsing and adding -snippet annotations/directives (default: false)",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "certAuthFilePath": {
+                            "description": "Kubernetes certificate authority file path (not needed for in-cluster client)",
+                            "type": "string"
+                        },
+                        "clientBodyBufferSize": {
+                            "description": "Default buffer size for reading client request body in bytes (default: 16384)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "controllerClass": {
+                            "description": "Ingress Class Controller value this controller satisfies",
+                            "type": "string"
+                        },
+                        "customHTTPErrors": {
+                            "description": "Defines which HTTP status codes should result in calling the default backend to return an error page",
+                            "type": "array"
+                        },
+                        "defaultBackendService": {
+                            "description": "Service used to serve HTTP requests not matching any known server name (catch-all). Takes the form 'namespace/name'",
+                            "type": "string"
+                        },
+                        "disableSvcExternalName": {
+                            "description": "Disable support for Services of type ExternalName",
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "description": "Enable Kubernetes Ingress NGINX provider",
+                            "type": "boolean"
+                        },
+                        "endpoint": {
+                            "description": "Kubernetes server endpoint (required for external cluster client)",
+                            "type": "string"
+                        },
+                        "globalAllowedResponseHeaders": {
+                            "description": "List of allowed response headers inside the custom headers annotations",
+                            "type": "array"
+                        },
+                        "globalAuthUrl": {
+                            "description": "URL to the service that provides authentication for all the locations. Per ingress auth-url annotation has precedence over this option.",
+                            "type": "string"
+                        },
+                        "httpEntryPoint": {
+                            "description": "Defines the EntryPoint to use for HTTP requests",
+                            "type": "string"
+                        },
+                        "httpsEntryPoint": {
+                            "description": "Defines the EntryPoint to use for HTTPS requests",
+                            "type": "string"
+                        },
+                        "ingressClass": {
+                            "description": "Name of the ingress class this controller satisfies",
+                            "type": "string"
+                        },
+                        "ingressClassByName": {
+                            "description": "Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class",
+                            "type": "boolean"
+                        },
+                        "ipAllowListStrategy": {
+                            "description": "When set, the strategy is applied to every generated IPAllowList middleware.",
+                            "type": "object",
+                            "properties": {
+                                "depth": {
+                                    "description": "Number of trusted proxy hops to skip when extracting the client IP from the X-Forwarded-For header. 0 disables depth-based extraction. (default: 0)",
+                                    "type": "integer"
+                                },
+                                "excludedIPS": {
+                                    "description": "List of IPs to exclude when scanning the X-Forwarded-For header to find the client IP.",
+                                    "type": "array"
+                                },
+                                "ipv6Subnet": {
+                                    "description": "IPv6 subnet size used to group IPv6 addresses when checking the allow list. 0 disables subnet grouping.",
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "modsec": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable ModSec engine. Requires Traefik Hub \u003e= v3.20.0-ea.8.",
+                                    "type": "boolean"
+                                },
+                                "owaspCoreRules": {
+                                    "description": "Enable OWASP Core Rules.",
+                                    "type": "boolean"
+                                },
+                                "snippet": {
+                                    "description": "Custom ModSec rules snippet.",
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "proxyBodySize": {
+                            "description": "Default maximum size of a client request body in bytes (default: 1048576)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "proxyBufferSize": {
+                            "description": "Default buffer size for reading the response body in bytes (default: 8192)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "proxyBuffering": {
+                            "description": "Defines whether to enable response buffering (default: false)",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "proxyBuffersNumber": {
+                            "description": "Default number of buffers for reading a response (default: 4)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "proxyConnectTimeout": {
+                            "description": "Amount of time to wait until a connection to a server can be established. Unitless, in seconds (default: 60)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "proxyNextUpstream": {
+                            "description": "Defines in which cases a request should be retried (default: \"error timeout\")",
+                            "type": "string"
+                        },
+                        "proxyNextUpstreamTimeout": {
+                            "description": "Limits the total elapsed time to retry the request. Unitless, in seconds (default: 0)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "proxyNextUpstreamTries": {
+                            "description": "Limits the number of possible tries if the backend server does not reply (default: 3)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "proxyReadTimeout": {
+                            "description": "Amount of time between two successive read operations. Unitless, in seconds (default: 60)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "proxyRequestBuffering": {
+                            "description": "Defines whether to enable request buffering (default: false)",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "proxySendTimeout": {
+                            "description": "Amount of time between two successive write operations. Unitless, in seconds (default: 60)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "publishService": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Service fronting the Ingress controller. Takes the form 'namespace/name'",
+                                    "type": "boolean"
+                                },
+                                "pathOverride": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "publishStatusAddress": {
+                            "description": "Customized address (or addresses, separated by comma) to set as the load-balancer status of Ingress objects this controller satisfies",
+                            "type": "string"
+                        },
+                        "strictValidatePathType": {
+                            "description": "Defines whether to reject the entire ingress when any path contains regex characters and pathType is Prefix or Exact (default: true)",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ]
+                        },
+                        "throttleDuration": {
+                            "description": "Ingress refresh throttle duration",
+                            "type": "string"
+                        },
+                        "token": {
+                            "description": "Kubernetes bearer token (not needed for in-cluster client). It accepts either a token value or a file path to the token",
+                            "type": "string"
+                        },
+                        "upstreamKeepaliveTimeout": {
+                            "description": "Defines the idle timeout for keep-alive connections to upstream servers. Unitless, in seconds (default: 60)",
+                            "type": [
+                                "integer",
+                                "null"
+                            ]
+                        },
+                        "watchIngressWithoutClass": {
+                            "description": "Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified",
+                            "type": "boolean"
+                        },
+                        "watchNamespace": {
+                            "description": "Single namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector.",
+                            "type": "string"
+                        },
+                        "watchNamespaceSelector": {
+                            "description": "Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace.",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "precedence": {
+                    "description": "Defines the routing precedence between providers. See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/overview/#routing-precedence) for the default order.",
+                    "type": "array"
+                }
+            },
+            "additionalProperties": false
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "aggregateTo": {
+                    "description": "Enable user-facing roles https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
+                    "type": "array"
+                },
+                "enabled": {
+                    "description": "Whether Role Based Access Control objects like roles and rolebindings should be created",
+                    "type": "boolean"
+                },
+                "namespaced": {
+                    "description": "When set to true: \u003cbr /\u003e 1. It switches respectively the use of `ClusterRole` and `ClusterRoleBinding` to `Role` and `RoleBinding`.\u003cbr /\u003e 2. It adds `disableClusterScopeResources` on Ingress and CRD (Kubernetes) providers\u003cbr /\u003e **NOTE**: `IngressClass`, `NodePortLB` and **Gateway** provider cannot be used with namespaced RBAC. \u003cbr /\u003e See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-disableClusterScopeResources) for more details.",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "readinessProbe": {
+            "type": "object",
+            "properties": {
+                "failureThreshold": {
+                    "description": "The number of consecutive failures allowed before considering the probe as failed.",
+                    "type": "integer"
+                },
+                "initialDelaySeconds": {
+                    "description": "The number of seconds to wait before starting the first probe.",
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "description": "The number of seconds to wait between consecutive probes.",
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "description": "The minimum consecutive successes required to consider the probe successful.",
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "description": "The number of seconds to wait for a probe response before considering it as failed.",
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "resources": {
+            "description": "[Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for `traefik` container.",
+            "type": "object"
+        },
+        "securityContext": {
+            "description": "[SecurityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)",
+            "type": "object",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "additionalServices": {
+                    "description": "Can be used to create multiple Service. See EXAMPLES.md for more details.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "description": "Additional annotations applied to both TCP and UDP services (e.g. for cloud provider specific config)",
+                    "type": "object"
+                },
+                "annotationsTCP": {
+                    "description": "Additional annotations for TCP service only",
+                    "type": "object"
+                },
+                "annotationsUDP": {
+                    "description": "Additional annotations for UDP service only",
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "description": "Additional service labels (e.g. for filtering Service by custom labels)",
+                    "type": "object"
+                },
+                "nameOverride": {
+                    "description": "Override the default Service name. Useful for adopting an existing Service (e.g., during migration from another ingress controller).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "single": {
+                    "type": "boolean"
+                },
+                "spec": {
+                    "description": "Additional entries here will be added to the Service [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core). Cannot contain selector or ports entries.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "description": "The service account the pods will use to interact with the Kubernetes API",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "serviceAccountAnnotations": {
+            "description": "Additional serviceAccount annotations (e.g. for oidc authentication)",
+            "type": "object"
+        },
+        "startupProbe": {
+            "description": "Define [Startup Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)",
+            "type": "object"
+        },
+        "tlsOptions": {
+            "description": "TLS Options are created as [TLSOption CRDs](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/crd/tls/tlsoption/) When using `labelSelector`, you'll need to set labels on tlsOption accordingly. See EXAMPLE.md for details.",
+            "type": "object"
+        },
+        "tlsStore": {
+            "description": "TLS Store are created as [TLSStore CRDs](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/crd/tls/tlsstore/). This is useful if you want to set a default certificate. See EXAMPLE.md for details.",
+            "type": "object"
+        },
+        "tolerations": {
+            "description": "Tolerations allow the scheduler to schedule pods with matching taints.",
+            "type": "array"
+        },
+        "topologySpreadConstraints": {
+            "description": "You can use topology spread constraints to control how Pods are spread across your cluster among failure-domains.",
+            "type": "array"
+        },
+        "tracing": {
+            "description": "https://doc.traefik.io/traefik/reference/install-configuration/observability/tracing/",
+            "type": "object",
+            "properties": {
+                "addInternals": {
+                    "description": "Enables tracing for internal resources. Default: false.",
+                    "type": "boolean"
+                },
+                "capturedRequestHeaders": {
+                    "description": "Defines the list of request headers to add as attributes. It applies to client and server kind spans.",
+                    "type": "array"
+                },
+                "capturedResponseHeaders": {
+                    "description": "Defines the list of response headers to add as attributes. It applies to client and server kind spans.",
+                    "type": "array"
+                },
+                "otlp": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "See https://doc.traefik.io/traefik/reference/install-configuration/observability/tracing/#configuration-options",
+                            "type": "boolean"
+                        },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to send metrics to the OpenTelemetry Collector using gRPC",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003chost\u003e:\u003cport\u003e. Default: \"localhost:4317\"",
+                                    "type": "string"
+                                },
+                                "insecure": {
+                                    "description": "Allows reporter to send metrics to the OpenTelemetry Collector without using a secured protocol.",
+                                    "type": "boolean"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                            "type": [
+                                                "boolean",
+                                                "null"
+                                            ]
+                                        },
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "http": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Set to true in order to send metrics to the OpenTelemetry Collector using HTTP.",
+                                    "type": "boolean"
+                                },
+                                "endpoint": {
+                                    "description": "Format: \u003cscheme\u003e://\u003chost\u003e:\u003cport\u003e\u003cpath\u003e. Default: https://localhost:4318/v1/tracing",
+                                    "type": "string"
+                                },
+                                "headers": {
+                                    "description": "Additional headers sent with metrics by the reporter to the OpenTelemetry Collector.",
+                                    "type": "object"
+                                },
+                                "tls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "The path to the certificate authority, it defaults to the system bundle.",
+                                            "type": "string"
+                                        },
+                                        "cert": {
+                                            "description": "The path to the public certificate. When using this option, setting the key option is required.",
+                                            "type": "string"
+                                        },
+                                        "insecureSkipVerify": {
+                                            "description": "When set to true, the TLS connection accepts any certificate presented by the server regardless of the hostnames it covers.",
+                                            "type": [
+                                                "boolean",
+                                                "null"
+                                            ]
+                                        },
+                                        "key": {
+                                            "description": "The path to the private key. When using this option, setting the cert option is required.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "resourceAttributes": {
+                    "description": "Defines additional resource attributes to be sent to the collector.",
+                    "type": "object"
+                },
+                "safeQueryParams": {
+                    "description": "By default, all query parameters are redacted. Defines the list of query parameters to not redact.",
+                    "type": "array"
+                },
+                "sampleRate": {
+                    "description": "The proportion of requests to trace, specified between 0.0 and 1.0. Default: 1.0.",
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "maximum": 1,
+                    "minimum": 0
+                },
+                "serviceName": {
+                    "description": "Service name used in selected backend. Default: traefik.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxSurge": {
+                            "type": [
+                                "integer",
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "maxUnavailable": {
+                            "type": [
+                                "integer",
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "type": {
+                    "description": "Customize updateStrategy of Deployment or DaemonSet",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "versionOverride": {
+            "description": "This field overrides the default version extracted from image.tag. Required when pinning by `image.digest`, since the version cannot be derived from a digest.",
+            "type": "string"
+        },
+        "volumes": {
+            "description": "Add volumes to the traefik pod. The volume name will be passed to tpl. This can be used to mount a cert pair or a configmap that holds a config.toml file. After the volume has been mounted, add the configs into traefik by using the `additionalArguments` list below, eg: `additionalArguments:",
+            "type": "array"
+        }
+    },
+    "additionalProperties": false
+}

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/overlay/templates/migrationClass.yaml
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/overlay/templates/migrationClass.yaml
@@ -1,0 +1,9 @@
+{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+{{- if $kubernetesIngressNGINX.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: rke2-ingress-nginx-migration
+spec:
+  controller: rke2.cattle.io/ingress-nginx-migration
+{{- end -}}

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/Chart.yaml.patch
@@ -1,0 +1,19 @@
+--- charts-original/Chart.yaml
++++ charts/Chart.yaml
+@@ -9,6 +9,7 @@
+   traefik.io/hub-min-version: v3.19.3
+   traefik.io/proxy-max-version: v3.7.1
+   traefik.io/proxy-min-version: v3.6.0
++  fleet.cattle.io/bundle-id: rke2
+ apiVersion: v2
+ appVersion: v3.7.1
+ description: A Traefik based Kubernetes ingress controller
+@@ -25,7 +26,7 @@
+ - email: remi.buisson@traefik.io
+   name: darkweaver87
+ - name: jnoordsij
+-name: traefik
++name: rke2-traefik
+ sources:
+ - https://github.com/traefik/traefik-helm-chart
+ - https://github.com/traefik/traefik

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/EXAMPLES.md.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/EXAMPLES.md.patch
@@ -1,0 +1,11 @@
+--- charts-original/EXAMPLES.md
++++ charts/EXAMPLES.md
+@@ -2,7 +2,7 @@
+ 
+ ## Install as a DaemonSet
+ 
+-Default install is using a `Deployment` but it's possible to use `DaemonSet`
++Upstream default install is using a `Deployment` but in RKE2 we use a `DaemonSet`
+ 
+ ```yaml
+ deployment:

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/VALUES.md.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/VALUES.md.patch
@@ -1,0 +1,47 @@
+--- charts-original/VALUES.md
++++ charts/VALUES.md
+@@ -59,7 +59,7 @@
+ | deployment.hostUsers | string | unset (inherits cluster default) | Whether to use the host user namespace. Setting this to false enables user namespaces, which can improve security by isolating the pod's users from the host. See https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
+ | deployment.imagePullSecrets | list | `[]` | Pull secret for fetching traefik container image |
+ | deployment.initContainers | list | `[]` | Additional initContainers (e.g. for setting file permission as shown below) |
+-| deployment.kind | string | `"Deployment"` | Deployment or DaemonSet |
++| deployment.kind | string | `"Daemonset"` | Deployment or DaemonSet |
+ | deployment.labels | object | `{}` | Additional deployment labels (e.g. for filtering deployment by custom labels) |
+ | deployment.lifecycle | object | `{}` | Pod lifecycle actions |
+ | deployment.livenessPath | string | `""` | Override the liveness path. Default: /ping |
+@@ -217,7 +217,7 @@
+ | image.digest | string | `nil` | Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest). |
+ | image.pullPolicy | string | `"IfNotPresent"` | Traefik image pull policy |
+ | image.registry | string | `"docker.io"` | Traefik image host registry |
+-| image.repository | string | `"traefik"` | Traefik image repository |
++| image.repository | string | `"rancher/hardened-traefik"` | Traefik image repository |
+ | image.tag | string | `nil` | defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-. To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image). |
+ | ingressClass.enabled | bool | `true` | Create a default IngressClass for Traefik |
+ | ingressClass.isDefaultClass | bool | `true` |  |
+@@ -455,7 +455,7 @@
+ | providers.kubernetesCRD.allowEmptyServices | bool | `true` | Allows to return 503 when there are no endpoints available |
+ | providers.kubernetesCRD.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in IngressRoute |
+ | providers.kubernetesCRD.enabled | bool | `true` | Load Kubernetes IngressRoute provider |
+-| providers.kubernetesCRD.ingressClass | string | `""` | When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled. |
++| providers.kubernetesCRD.ingressClass | string | `"traefik"` | When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled. |
+ | providers.kubernetesCRD.labelSelector | string | `""` | See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector) |
+ | providers.kubernetesCRD.namespaces | list | `[]` | Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array. |
+ | providers.kubernetesCRD.nativeLBByDefault | bool | `false` | Defines whether to use Native Kubernetes load-balancing mode by default. |
+@@ -473,7 +473,7 @@
+ | providers.kubernetesIngress.allowExternalNameServices | bool | `false` | Allows to reference ExternalName services in Ingress |
+ | providers.kubernetesIngress.disableIngressClassLookup | bool | `false` | Only for Traefik v3.0, Deprecated since v3.1. See [upstream documentation](https://doc.traefik.io/traefik/v3.0/providers/kubernetes-ingress/#disableingressclasslookup) |
+ | providers.kubernetesIngress.enabled | bool | `true` | Load Kubernetes Ingress provider |
+-| providers.kubernetesIngress.ingressClass | string | `nil` | When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed. |
++| providers.kubernetesIngress.ingressClass | string | `traefik` | When ingressClass is set, only Ingresses containing an annotation with the same value are processed. Otherwise, Ingresses missing the annotation, having an empty value, or the value traefik are processed. |
+ | providers.kubernetesIngress.ingressEndpoint.hostname | string | `""` | Hostname used for Kubernetes Ingress endpoints |
+ | providers.kubernetesIngress.ingressEndpoint.ip | string | `""` | IP used for Kubernetes Ingress endpoints |
+ | providers.kubernetesIngress.labelSelector | string | `nil` |  |
+@@ -545,7 +545,7 @@
+ | service.labels | object | `{}` | Additional service labels (e.g. for filtering Service by custom labels) |
+ | service.nameOverride | string | `""` | Override the default Service name. Useful for adopting an existing Service (e.g., during migration from another ingress controller). |
+ | service.single | bool | `true` |  |
+-| service.spec | object | `{"type":"LoadBalancer"}` | Additional entries here will be added to the Service [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core). Cannot contain selector or ports entries. |
++| service.spec | object | `{"type":"ClusterIP"}` | Additional entries here will be added to the Service [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core). Cannot contain selector or ports entries. |
+ | serviceAccount | object | `{"name":""}` | The service account the pods will use to interact with the Kubernetes API |
+ | serviceAccountAnnotations | object | `{}` | Additional serviceAccount annotations (e.g. for oidc authentication) |
+ | startupProbe | object | `{}` | Define [Startup Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) |

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/crds/gateway-standard-install.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/crds/gateway-standard-install.yaml.patch
@@ -1,0 +1,66 @@
+--- charts-original/crds/gateway-standard-install.yaml
++++ charts/crds/gateway-standard-install.yaml
+@@ -26,6 +26,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   labels:
+     gateway.networking.k8s.io/policy: Direct
+   name: backendtlspolicies.gateway.networking.k8s.io
+@@ -1412,6 +1413,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: gatewayclasses.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -1931,6 +1933,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: gateways.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -5218,6 +5221,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: grpcroutes.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -7292,6 +7296,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: httproutes.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -14225,6 +14230,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: listenersets.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -15009,6 +15015,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: referencegrants.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io
+@@ -15366,6 +15373,7 @@
+     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
+     gateway.networking.k8s.io/bundle-version: v1.5.1
+     gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
+   name: tlsroutes.gateway.networking.k8s.io
+ spec:
+   group: gateway.networking.k8s.io

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/NOTES.txt.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/NOTES.txt.patch
@@ -1,0 +1,19 @@
+--- charts-original/templates/NOTES.txt
++++ charts/templates/NOTES.txt
+@@ -120,6 +120,16 @@
+   {{- end -}}
+ 
+ 
++{{/* Warn about legacy Kubernetes Ingress NGINX provider key */}}
++{{- if and (hasKey .Values.providers "kubernetesIngressNginx") (default false .Values.providers.kubernetesIngressNginx.enabled) }}
++{{- printf "\n" -}}
++⚠️ DEPRECATION WARNING: You are using providers.kubernetesIngressNginx (legacy key).
++Please migrate to providers.kubernetesIngressNGINX.
++The legacy key will be removed in a future version.
++{{- printf "\n" -}}
++{{- end -}}
++
++
+ {{/* Warn about Gateway API CRDs no longer shipped with this chart in future versions */}}
+ {{- if .Values.providers.kubernetesGateway.enabled }}
+ {{- printf "\n" -}}

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,0 +1,60 @@
+--- charts-original/templates/_helpers.tpl
++++ charts/templates/_helpers.tpl
+@@ -33,7 +33,7 @@
+ {{- else if .Values.image.digest -}}
+ {{- printf "%s/%s@%s" .Values.image.registry .Values.image.repository .Values.image.digest }}
+ {{- else -}}
+-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
++{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+ {{- end -}}
+ {{- end -}}
+ 
+@@ -147,9 +147,20 @@
+ {{- print $servicePath | trimSuffix "-" -}}
+ {{- end -}}
+ 
++{{- define "providers.kubernetesIngressNGINX.values" -}}
++{{- $new := default dict .Values.providers.kubernetesIngressNGINX -}}
++{{- $old := default dict .Values.providers.kubernetesIngressNginx -}}
++{{- $provider := $new -}}
++{{- if and $old.enabled (not $new.enabled) -}}
++{{- $provider = mergeOverwrite (dict) $new $old -}}
++{{- end -}}
++{{- toYaml $provider }}
++{{- end -}}
++
+ {{- define "providers.kubernetesIngressNGINX.publishServicePath" -}}
+ {{- $defServiceName := printf "%s/%s" (include "traefik.namespace" .) (include "traefik.fullname" .) -}}
+-{{- $servicePath := default $defServiceName .Values.providers.kubernetesIngressNGINX.publishService.pathOverride }}
++{{- $provider := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
++{{- $servicePath := default $defServiceName (dig "publishService" "pathOverride" "" $provider) }}
+ {{- print $servicePath | trimSuffix "-" -}}
+ {{- end -}}
+ 
+@@ -166,7 +177,13 @@
+ {{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngress.namespaces) }}
+ {{- end -}}
+ {{- define "providers.kubernetesIngressNGINX.namespaces" -}}
+-{{- default (include "traefik.namespace" .) (join "," .Values.providers.kubernetesIngressNGINX.watchNamespace) }}
++{{- $provider := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
++{{- $watchNamespace := dig "watchNamespace" "" $provider -}}
++{{- if kindIs "slice" $watchNamespace -}}
++{{- default (include "traefik.namespace" .) (join "," $watchNamespace) }}
++{{- else -}}
++{{- default (include "traefik.namespace" .) $watchNamespace }}
++{{- end -}}
+ {{- end -}}
+ {{- define "providers.knative.namespaces" -}}
+ {{- default (include "traefik.namespace" .) (join "," .Values.providers.knative.namespaces) }}
+@@ -486,3 +503,11 @@
+ {{- define "traefik.hubTokenFilePath" }}
+ {{- printf "%s/%s" (.Values.hub.tokenMountPath | trimSuffix "/") "token" -}}
+ {{- end -}}
++
++{{- define "system_default_registry" -}}
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/_podtemplate.tpl.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/_podtemplate.tpl.patch
@@ -1,0 +1,21 @@
+--- charts-original/templates/_podtemplate.tpl
++++ charts/templates/_podtemplate.tpl
+@@ -68,7 +68,7 @@
+       runtimeClassName: {{ . }}
+       {{- end }}
+       containers:
+-      - image: {{ template "traefik.image-name" . }}
++      - image: "{{ template "system_default_registry" . }}{{ template "traefik.image-name" . }}"
+         imagePullPolicy: {{ .Values.image.pullPolicy }}
+         name: {{ template "traefik.fullname" . }}
+         resources:
+@@ -596,7 +596,8 @@
+           {{- end }}
+           {{- end }}
+           {{- end }}
+-          {{- with .Values.providers.kubernetesIngressNGINX }}
++          {{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) }}
++          {{- with $kubernetesIngressNGINX }}
+            {{- if .enabled }}
+           - "--providers.kubernetesingressnginx"
+             {{- if or .watchNamespace (and $.Values.rbac.enabled $.Values.rbac.namespaced) }}

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/ingressclass.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/ingressclass.yaml.patch
@@ -1,0 +1,11 @@
+--- charts-original/templates/ingressclass.yaml
++++ charts/templates/ingressclass.yaml
+@@ -3,7 +3,7 @@
+ kind: IngressClass
+ metadata:
+   annotations:
+-    ingressclass.kubernetes.io/is-default-class: {{ .Values.ingressClass.isDefaultClass | quote }}
++    ingressclass.kubernetes.io/is-default-class: {{ or (.Values.ingressClass.isDefaultClass) (eq .Values.global.systemDefaultIngressClass "traefik") | quote }}
+   labels:
+     {{- include "traefik.labels" . | nindent 4 }}
+   name: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/rbac/clusterrole.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/rbac/clusterrole.yaml.patch
@@ -1,0 +1,17 @@
+--- charts-original/templates/rbac/clusterrole.yaml
++++ charts/templates/rbac/clusterrole.yaml
+@@ -1,4 +1,5 @@
+ {{- $version := include "traefik.proxyVersion" $ }}
++{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+ {{- if and .Values.rbac.enabled (not .Values.rbac.namespaced) }}
+ ---
+ kind: ClusterRole
+@@ -48,7 +49,7 @@
+       - delete
+       - deletecollection
+     {{- end }}
+-  {{- if or .Values.providers.kubernetesIngress.enabled .Values.providers.kubernetesIngressNGINX.enabled }}
++  {{- if or .Values.providers.kubernetesIngress.enabled $kubernetesIngressNGINX.enabled }}
+   - apiGroups:
+       - extensions
+       - networking.k8s.io

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/rbac/role.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/rbac/role.yaml.patch
@@ -1,0 +1,17 @@
+--- charts-original/templates/rbac/role.yaml
++++ charts/templates/rbac/role.yaml
+@@ -1,4 +1,5 @@
+ {{- $version := include "traefik.proxyVersion" $ }}
++{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+ {{- $ingressNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesIngress.namespaces -}}
+ {{- $CRDNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.kubernetesCRD.namespaces -}}
+ {{- $knativeNamespaces := concat (include "traefik.namespace" . | list) .Values.providers.knative.namespaces -}}
+@@ -47,7 +48,7 @@
+       - get
+       - list
+       - watch
+-{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) ($.Values.providers.kubernetesIngressNGINX.enabled) }}
++{{- if or (and (has . $ingressNamespaces) $.Values.providers.kubernetesIngress.enabled) ($kubernetesIngressNGINX.enabled) }}
+   - apiGroups:
+       - extensions
+       - networking.k8s.io

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/requirements.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/templates/requirements.yaml.patch
@@ -1,0 +1,54 @@
+--- charts-original/templates/requirements.yaml
++++ charts/templates/requirements.yaml
+@@ -1,4 +1,5 @@
+ {{- $version := include "traefik.proxyVersion" $ }}
++{{- $kubernetesIngressNGINX := (include "providers.kubernetesIngressNGINX.values" . | fromYaml) -}}
+ {{- $proxyMinVersion := index .Chart.Annotations "traefik.io/proxy-min-version" }}
+ {{- $proxyMaxVersion := index .Chart.Annotations "traefik.io/proxy-max-version" }}
+ {{- if (ne $version "experimental-v3.0") }}
+@@ -31,15 +32,15 @@
+   {{- end }}
+ {{- end }}
+ 
+-{{- if and (semverCompare "<v3.6.2-0" $version) (.Values.providers.kubernetesIngressNGINX).enabled}}
++{{- if and (semverCompare "<v3.6.2-0" $version) $kubernetesIngressNGINX.enabled}}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider is only available for traefik >= v3.6.2." }}
+ {{- end }}
+ 
+-{{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (not $.Values.hub.token) }}
++{{- if and ($kubernetesIngressNGINX.modsec).enabled (not $.Values.hub.token) }}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub." }}
+ {{- end }}
+ 
+-{{- with .Values.providers.kubernetesIngressNGINX }}
++{{- with $kubernetesIngressNGINX }}
+   {{- if and (semverCompare "<v3.7.0-0" $version) .enabled (or
+     (ne .proxyRequestBuffering nil)
+     (gt (.clientBodyBufferSize | int) 0)
+@@ -65,7 +66,7 @@
+   {{- end }}
+ {{- end }}
+ 
+-{{- if and (semverCompare "<v3.7.0-ea.2" $version) (ne (.Values.providers.kubernetesIngressNGINX).strictValidatePathType nil) }}
++{{- if and (semverCompare "<v3.7.0-ea.2" $version) (ne ($kubernetesIngressNGINX).strictValidatePathType nil) }}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider strictValidatePathType option requires traefik >= v3.7.0-ea.2." }}
+ {{- end }}
+ 
+@@ -73,7 +74,7 @@
+   {{- fail "ERROR: providers.precedence option requires traefik >= v3.7.0-rc.1." }}
+ {{- end }}
+ 
+-{{- if and (semverCompare "<v3.7.0-rc.1" $version) (not (empty (.Values.providers.kubernetesIngressNGINX).globalAuthUrl)) }}
++{{- if and (semverCompare "<v3.7.0-rc.1" $version) (not (empty ($kubernetesIngressNGINX).globalAuthUrl)) }}
+   {{- fail "ERROR: Kubernetes Ingress NGINX provider globalAuthUrl option requires traefik >= v3.7.0-rc.1." }}
+ {{- end }}
+ 
+@@ -159,7 +160,7 @@
+     {{- end }}
+   {{- end }}
+ 
+-  {{- if and (.Values.providers.kubernetesIngressNGINX.modsec).enabled (semverCompare "<v3.20.0-ea.8" $hubVersion) }}
++  {{- if and ($kubernetesIngressNGINX.modsec).enabled (semverCompare "<v3.20.0-ea.8" $hubVersion) }}
+     {{ fail "ERROR: Kubernetes Ingress NGINX provider modsec option requires Traefik Hub >= v3.20.0-ea.8." }}
+   {{- end }}
+ 

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
    # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
    # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
 -  tag:  # @schema type:[string, null]
-+  tag: v3.7.8-build20260717  # @schema type:[string, null]
++  tag: v3.7.11-build20260819  # @schema type:[string, null]
    # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
    digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
    # -- Traefik image pull policy

--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/values.yaml.patch
@@ -1,0 +1,102 @@
+--- charts-original/values.yaml
++++ charts/values.yaml
+@@ -6,10 +6,10 @@
+   # -- Traefik image host registry
+   registry: docker.io
+   # -- Traefik image repository
+-  repository: traefik
++  repository: rancher/hardened-traefik
+   # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
+   # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
+-  tag:  # @schema type:[string, null]
++  tag: v3.7.8-build20260717  # @schema type:[string, null]
+   # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
+   digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
+   # -- Traefik image pull policy
+@@ -22,7 +22,7 @@
+   # -- Enable deployment
+   enabled: true
+   # -- Deployment or DaemonSet
+-  kind: Deployment
++  kind: DaemonSet
+   # -- Number of pods of the deployment (only applies when kind == Deployment)
+   replicas: 1
+   # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+@@ -123,8 +123,8 @@
+ ingressClass:  # @schema additionalProperties: false
+   # -- Create a default IngressClass for Traefik
+   enabled: true
+-  isDefaultClass: true
+-  name: ""
++  isDefaultClass: false
++  name: "traefik"
+ 
+ core:  # @schema additionalProperties: false
+   # -- Can be used to use globally v2 router syntax. Deprecated since v3.4 /!\.
+@@ -268,8 +268,8 @@
+   # -- Customize updateStrategy of Deployment or DaemonSet
+   type: RollingUpdate
+   rollingUpdate:
+-    maxUnavailable: 0  # @schema type:[integer, string, null]
+-    maxSurge: 1        # @schema type:[integer, string, null]
++    maxUnavailable: 1  # @schema type:[integer, string, null]
++    maxSurge: 0        # @schema type:[integer, string, null]
+ 
+ readinessProbe:  # @schema additionalProperties: false
+   # -- The number of consecutive failures allowed before considering the probe as failed.
+@@ -312,7 +312,7 @@
+     # -- Allows to return 503 when there are no endpoints available
+     allowEmptyServices: true
+     # -- When the parameter is set, only resources containing an annotation with the same value are processed. Otherwise, resources missing the annotation, having an empty value, or the value traefik are processed. It will also set required annotation on Dashboard and Healthcheck IngressRoute when enabled.
+-    ingressClass: ""
++    ingressClass: "traefik"
+     # -- See [upstream documentation](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress/#opt-providers-kubernetesIngress-labelselector)
+     labelSelector: ""
+     # -- Array of namespaces to watch. If left empty, Traefik watches all namespaces. . When using `rbac.namespaced`, it will watch helm release namespace and namespaces listed in this array.
+@@ -854,6 +854,8 @@
+         insecureSkipVerify:  # @schema type:[boolean, null]
+ 
+ global:
++  systemDefaultRegistry: ""
++  systemDefaultIngressClass: ""
+   checkNewVersion: true
+   # -- Please take time to consider whether or not you wish to share anonymous data with us
+   # See https://doc.traefik.io/traefik/contributing/data-collection/
+@@ -926,7 +928,7 @@
+     ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+     asDefault:  # @schema type: [boolean, null]; default: null
+     port: 8000
+-    # hostPort: 8000
++    hostPort: 80
+     # containerPort: 8000
+     expose:
+       default: true
+@@ -984,7 +986,7 @@
+     ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+     # asDefault: true
+     port: 8443
+-    hostPort:  # @schema type:[integer, null]; minimum:0
++    hostPort: 443 # @schema type:[integer, null]; minimum:0
+     containerPort:  # @schema type:[integer, null]; minimum:0
+     expose:
+       default: true
+@@ -1112,7 +1114,8 @@
+   # -- Additional entries here will be added to the Service [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core).
+   # Cannot contain selector or ports entries.
+   spec:
+-    type: LoadBalancer
++    type: ClusterIP
++    ipFamilyPolicy: PreferDualStack
+   # -- Can be used to create multiple Service.
+   # See EXAMPLES.md for more details.
+   additionalServices: {}
+@@ -1201,7 +1204,8 @@
+ #        topologyKey: kubernetes.io/hostname
+ 
+ # -- nodeSelector is the simplest recommended form of node selection constraint.
+-nodeSelector: {}
++nodeSelector:
++  kubernetes.io/os: linux
+ # -- Tolerations allow the scheduler to schedule pods with matching taints.
+ tolerations: []
+ # -- You can use topology spread constraints to control

--- a/packages/rke2-traefik-1.34-1.36/package.yaml
+++ b/packages/rke2-traefik-1.34-1.36/package.yaml
@@ -1,0 +1,11 @@
+url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
+packageVersion: 09
+# This repository does not use releaseCandidateVersions, so you can leave this as 00.
+releaseCandidateVersion: 00
+
+additionalCharts:
+  - workingDir: charts-crd
+    crdOptions:
+      templateDirectory: crd-template
+      crdDirectory: templates
+      addCRDValidationToMainChart: true

--- a/packages/rke2-traefik-1.34-1.36/package.yaml
+++ b/packages/rke2-traefik-1.34-1.36/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
-packageVersion: 09
+packageVersion: 00
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 

--- a/packages/rke2-traefik-1.34-1.36/templates/crd-template/Chart.yaml
+++ b/packages/rke2-traefik-1.34-1.36/templates/crd-template/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+version: 40.1.0
+appVersion: v3.7.1
+description: Installs the CRDs for rke2-traefik
+name: rke2-traefik-crd
+type: application
+annotations:
+  fleet.cattle.io/bundle-id: rke2


### PR DESCRIPTION
Upstream traefik dropped the gateway crd API so we need to stay at version <= 40.1.0 on rke2 versions 1.34 to 1.36

Only 1.37 should move to upstream traefik >=40.2.0.