### PR TITLE
rke2-traefik-1.34-1.36: bump packageVersion to 10

### DIFF
--- a/packages/rke2-traefik-1.34-1.36/package.yaml
+++ b/packages/rke2-traefik-1.34-1.36/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
-packageVersion: 00
+packageVersion: 10
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 


### PR DESCRIPTION
to avoid duplication with older rke2-traefik