### PR TITLE
Move GatewayAPI to 1.6.1 in old Traefik chart

### DIFF
--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/crds/gateway-standard-install.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/crds/gateway-standard-install.yaml.patch
@@ -1,66 +1,3739 @@
 --- charts-original/crds/gateway-standard-install.yaml
 +++ charts/crds/gateway-standard-install.yaml
-@@ -26,6 +26,7 @@
+@@ -24,8 +24,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    labels:
      gateway.networking.k8s.io/policy: Direct
    name: backendtlspolicies.gateway.networking.k8s.io
-@@ -1412,6 +1413,7 @@
+@@ -135,12 +136,12 @@
+ 
+                   Support Levels:
+ 
+-                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
++                  * Extended: Kubernetes Service referenced by backendRefs used on a Route.
++                    - HTTPRoute, GRPCRoute, TLSRoute with termination
++                    - Filters that needs a backend of type Service, like Mirror and External Authorization
+ 
+-                  * Implementation-Specific: Services not connected via HTTPRoute, and any
+-                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
++                  * Implementation-Specific: Implementations MAY use BackendTLSPolicy for:
+                     - Services not referenced by any Route (e.g., infrastructure services)
+-                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
+                     - Service mesh workload-to-service communication
+                     - Other resource types beyond Service
+ 
+@@ -811,12 +812,12 @@
+ 
+                   Support Levels:
+ 
+-                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
++                  * Extended: Kubernetes Service referenced by backendRefs used on a Route.
++                    - HTTPRoute, GRPCRoute, TLSRoute with termination
++                    - Filters that needs a backend of type Service, like Mirror and External Authorization
+ 
+-                  * Implementation-Specific: Services not connected via HTTPRoute, and any
+-                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
++                  * Implementation-Specific: Implementations MAY use BackendTLSPolicy for:
+                     - Services not referenced by any Route (e.g., infrastructure services)
+-                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
+                     - Service mesh workload-to-service communication
+                     - Other resource types beyond Service
+ 
+@@ -1395,12 +1396,6 @@
+     storage: false
+     subresources:
+       status: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
+ ---
+ #
+ # config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+@@ -1410,8 +1405,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    name: gatewayclasses.gateway.networking.k8s.io
  spec:
    group: gateway.networking.k8s.io
-@@ -1931,6 +1933,7 @@
+@@ -1461,6 +1457,9 @@
+           Gateway is not deleted while in use.
+ 
+           GatewayClass is a Cluster level resource.
++
++          A GatewayClass name SHOULD be compliant with RFC 1035, consisting of a maximum of 63 lower case alphanumeric
++          characters or hyphens ('-'), and MUST start and end with an alphanumeric character.
+         properties:
+           apiVersion:
+             description: |-
+@@ -1914,12 +1913,6 @@
+     storage: false
+     subresources:
+       status: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
+ ---
+ #
+ # config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+@@ -1929,8 +1922,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    name: gateways.gateway.networking.k8s.io
  spec:
    group: gateway.networking.k8s.io
-@@ -5218,6 +5221,7 @@
+@@ -1964,6 +1958,8 @@
+         description: |-
+           Gateway represents an instance of a service-traffic handling infrastructure
+           by binding Listeners to a set of IP addresses.
++          A Gateway name SHOULD be compliant with RFC 1035, consisting of a maximum of 63 lower case alphanumeric
++          characters or hyphens ('-'), and MUST start and end with an alphanumeric character.
+         properties:
+           apiVersion:
+             description: |-
+@@ -2174,7 +2170,7 @@
+                       An implementation may chose to add additional implementation-specific annotations as they see fit.
+ 
+                       Support: Extended
+-                    maxProperties: 8
++                    maxProperties: 16
+                     type: object
+                     x-kubernetes-validations:
+                     - message: Annotation keys must be in the form of an optional
+@@ -2396,6 +2392,12 @@
+                   request to "foo.example.com" SHOULD only be routed using routes attached
+                   to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+ 
++                  If traffic to a Gateway does not match any Listener's hostname (or if
++                  the Listener does not specify a hostname and the request does not match
++                  any attached Route), the request MUST be rejected. The specific mechanism
++                  for rejection depends on the protocol: HTTP returns a 404 status code,
++                  while gRPC returns an Unimplemented status code.
++
+                   This concept is known as "Listener Isolation", and it is an Extended feature
+                   of Gateway API. Implementations that do not support Listener Isolation MUST
+                   clearly document this, and MUST NOT claim support for the
+@@ -3036,7 +3038,7 @@
+                                   - kind
+                                   - name
+                                   type: object
+-                                maxItems: 8
++                                maxItems: 16
+                                 minItems: 1
+                                 type: array
+                                 x-kubernetes-list-type: atomic
+@@ -3201,7 +3203,7 @@
+                                         - kind
+                                         - name
+                                         type: object
+-                                      maxItems: 8
++                                      maxItems: 16
+                                       minItems: 1
+                                       type: array
+                                       x-kubernetes-list-type: atomic
+@@ -3802,7 +3804,7 @@
+                       An implementation may chose to add additional implementation-specific annotations as they see fit.
+ 
+                       Support: Extended
+-                    maxProperties: 8
++                    maxProperties: 16
+                     type: object
+                     x-kubernetes-validations:
+                     - message: Annotation keys must be in the form of an optional
+@@ -4024,6 +4026,12 @@
+                   request to "foo.example.com" SHOULD only be routed using routes attached
+                   to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+ 
++                  If traffic to a Gateway does not match any Listener's hostname (or if
++                  the Listener does not specify a hostname and the request does not match
++                  any attached Route), the request MUST be rejected. The specific mechanism
++                  for rejection depends on the protocol: HTTP returns a 404 status code,
++                  while gRPC returns an Unimplemented status code.
++
+                   This concept is known as "Listener Isolation", and it is an Extended feature
+                   of Gateway API. Implementations that do not support Listener Isolation MUST
+                   clearly document this, and MUST NOT claim support for the
+@@ -4664,7 +4672,7 @@
+                                   - kind
+                                   - name
+                                   type: object
+-                                maxItems: 8
++                                maxItems: 16
+                                 minItems: 1
+                                 type: array
+                                 x-kubernetes-list-type: atomic
+@@ -4829,7 +4837,7 @@
+                                         - kind
+                                         - name
+                                         type: object
+-                                      maxItems: 8
++                                      maxItems: 16
+                                       minItems: 1
+                                       type: array
+                                       x-kubernetes-list-type: atomic
+@@ -5201,12 +5209,6 @@
+     storage: false
+     subresources:
+       status: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
+ ---
+ #
+ # config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+@@ -5216,8 +5218,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    name: grpcroutes.gateway.networking.k8s.io
  spec:
    group: gateway.networking.k8s.io
-@@ -7292,6 +7296,7 @@
+@@ -5838,6 +5841,10 @@
+                                         Support: Extended for Kubernetes Service
+ 
+                                         Support: Implementation-specific for any other resource
++
++                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
++                                        implementation to supply the TLS details to be used to connect to that
++                                        backend.
+                                       properties:
+                                         group:
+                                           default: ""
+@@ -6489,6 +6496,10 @@
+                                   Support: Extended for Kubernetes Service
+ 
+                                   Support: Implementation-specific for any other resource
++
++                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
++                                  implementation to supply the TLS details to be used to connect to that
++                                  backend.
+                                 properties:
+                                   group:
+                                     default: ""
+@@ -7275,12 +7286,6 @@
+     storage: true
+     subresources:
+       status: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
+ ---
+ #
+ # config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+@@ -7290,8 +7295,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    name: httproutes.gateway.networking.k8s.io
  spec:
    group: gateway.networking.k8s.io
-@@ -14225,6 +14230,7 @@
+@@ -7728,9 +7734,9 @@
+                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                         response header are separated by a comma (",").
+ 
+-                                        When the `AllowHeaders` field is configured with one or more headers, the
++                                        When the `allowHeaders` field is configured with one or more headers, the
+                                         gateway must return the `Access-Control-Allow-Headers` response header
+-                                        which value is present in the `AllowHeaders` field.
++                                        which value is present in the `allowHeaders` field.
+ 
+                                         If any header name in the `Access-Control-Request-Headers` request header
+                                         is not included in the list of header names specified by the response
+@@ -7742,21 +7748,20 @@
+                                         client side.
+ 
+                                         A wildcard indicates that the requests with all HTTP headers are allowed.
+-                                        If config contains the wildcard "*" in allowHeaders and the request is
+-                                        not credentialed, the `Access-Control-Allow-Headers` response header
+-                                        can either use the `*` wildcard or the value of
+-                                        Access-Control-Request-Headers from the request.
+-
+-                                        When the request is credentialed, the gateway must not specify the `*`
+-                                        wildcard in the `Access-Control-Allow-Headers` response header. When
+-                                        also the `AllowCredentials` field is true and `AllowHeaders` field
+-                                        is specified with the `*` wildcard, the gateway must specify one or more
+-                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
+-                                        header. The value of the header `Access-Control-Allow-Headers` is same as
+-                                        the `Access-Control-Request-Headers` header provided by the client. If
+-                                        the header `Access-Control-Request-Headers` is not included in the
+-                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+-                                        response header, instead of specifying the `*` wildcard.
++
++                                        If the configuration contains the wildcard `*` in `allowHeaders` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
++                                        response header may either contain the wildcard `*` or echo the value
++                                        of the `Access-Control-Request-Headers` request header.
++
++                                        If the configuration contains the wildcard `*` in `allowHeaders` and
++                                        `allowCredentials` is set to `true`, the gateway must not return `*`
++                                        in the `Access-Control-Allow-Headers` response header. Instead, it must
++                                        return one or more header names matching the value of the
++                                        `Access-Control-Request-Headers` request header.
++                                        If the `Access-Control-Request-Headers` header is not present in the
++                                        request, the gateway must omit the `Access-Control-Allow-Headers`
++                                        response header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -7801,32 +7806,29 @@
+                                         A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                         CORS-safelisted methods are always allowed, regardless of whether they
+-                                        are specified in the `AllowMethods` field.
++                                        are specified in the `allowMethods` field.
+ 
+-                                        When the `AllowMethods` field is configured with one or more methods, the
++                                        When the `allowMethods` field is configured with one or more methods, the
+                                         gateway must return the `Access-Control-Allow-Methods` response header
+-                                        which value is present in the `AllowMethods` field.
++                                        which value is present in the `allowMethods` field.
+ 
+                                         If the HTTP method of the `Access-Control-Request-Method` request header
+                                         is not included in the list of methods specified by the response header
+                                         `Access-Control-Allow-Methods`, it will present an error on the client
+                                         side.
+ 
+-                                        If config contains the wildcard "*" in allowMethods and the request is
+-                                        not credentialed, the `Access-Control-Allow-Methods` response header
+-                                        can either use the `*` wildcard or the value of
+-                                        Access-Control-Request-Method from the request.
+-
+-                                        When the request is credentialed, the gateway must not specify the `*`
+-                                        wildcard in the `Access-Control-Allow-Methods` response header. When
+-                                        also the `AllowCredentials` field is true and `AllowMethods` field
+-                                        specified with the `*` wildcard, the gateway must specify one HTTP method
+-                                        in the value of the Access-Control-Allow-Methods response header. The
+-                                        value of the header `Access-Control-Allow-Methods` is same as the
+-                                        `Access-Control-Request-Method` header provided by the client. If the
+-                                        header `Access-Control-Request-Method` is not included in the request,
+-                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
+-                                        instead of specifying the `*` wildcard.
++                                        If the configuration contains the wildcard `*` in `allowMethods` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
++                                        response header may either contain the wildcard `*` or echo the value
++                                        of the `Access-Control-Request-Method` request header.
++
++                                        If the configuration contains the wildcard `*` in `allowMethods` and
++                                        `allowCredentials` is set to `true`, the gateway must not return `*`
++                                        in the `Access-Control-Allow-Methods` response header. Instead, it must
++                                        return a single HTTP method matching the value of the
++                                        `Access-Control-Request-Method` request header.
++                                        If the `Access-Control-Request-Method` header is not present in the request,
++                                        the gateway must omit the `Access-Control-Allow-Methods` response header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -7876,7 +7878,7 @@
+                                         An origin value that includes _only_ the `*` character indicates requests
+                                         from all `Origin`s are allowed.
+ 
+-                                        When the `AllowOrigins` field is configured with multiple origins, it
++                                        When the `allowOrigins` field is configured with multiple origins, it
+                                         means the server supports clients from multiple origins. If the request
+                                         `Origin` matches the configured allowed origins, the gateway must return
+                                         the given `Origin` and sets value of the header
+@@ -7898,19 +7900,15 @@
+                                         `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                         header provided by the client.
+ 
+-                                        When config has the wildcard ("*") in allowOrigins, and the request
+-                                        is not credentialed (e.g., it is a preflight request), the
+-                                        `Access-Control-Allow-Origin` response header either contains the
+-                                        wildcard as well or the Origin from the request.
+-
+-                                        When the request is credentialed, the gateway must not specify the `*`
+-                                        wildcard in the `Access-Control-Allow-Origin` response header. When
+-                                        also the `AllowCredentials` field is true and `AllowOrigins` field
+-                                        specified with the `*` wildcard, the gateway must return a single origin
+-                                        in the value of the `Access-Control-Allow-Origin` response header,
+-                                        instead of specifying the `*` wildcard. The value of the header
+-                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+-                                        the client.
++                                        If the configuration contains the wildcard `*` in `allowOrigins` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
++                                        response header may either contain the wildcard `*` or echo the value
++                                        of the `Origin` request header.
++
++                                        If the configuration contains the wildcard `*` in `allowOrigins` and
++                                        `allowCredentials` is set to `true`, the gateway must not return `*`
++                                        in the `Access-Control-Allow-Origin` response header. Instead, it must
++                                        return a single origin matching the value of the `Origin` request header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -7949,7 +7947,7 @@
+                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                         The CORS-safelisted response headers are exposed to client by default.
+ 
+-                                        When an HTTP header name is specified using the `ExposeHeaders` field,
++                                        When an HTTP header name is specified using the `exposeHeaders` field,
+                                         this additional header will be exposed as part of the response to the
+                                         client.
+ 
+@@ -7959,12 +7957,15 @@
+                                         response header are separated by a comma (",").
+ 
+                                         A wildcard indicates that the responses with all HTTP headers are exposed
+-                                        to clients. The `Access-Control-Expose-Headers` response header can only
+-                                        use `*` wildcard as value when the request is not credentialed.
++                                        to clients.
+ 
+-                                        When the `exposeHeaders` config field contains the "*" wildcard and
+-                                        the request is credentialed, the gateway cannot use the `*` wildcard in
+-                                        the `Access-Control-Expose-Headers` response header.
++                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
++                                        response header can contain the wildcard `*`.
++
++                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                        `allowCredentials` is set to `true`, the gateway cannot use the `*`
++                                        in the `Access-Control-Expose-Headers` response header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -8214,6 +8215,10 @@
+                                         Support: Extended for Kubernetes Service
+ 
+                                         Support: Implementation-specific for any other resource
++
++                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
++                                        implementation to supply the TLS details to be used to connect to that
++                                        backend.
+                                       properties:
+                                         group:
+                                           default: ""
+@@ -8985,9 +8990,9 @@
+                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                   response header are separated by a comma (",").
+ 
+-                                  When the `AllowHeaders` field is configured with one or more headers, the
++                                  When the `allowHeaders` field is configured with one or more headers, the
+                                   gateway must return the `Access-Control-Allow-Headers` response header
+-                                  which value is present in the `AllowHeaders` field.
++                                  which value is present in the `allowHeaders` field.
+ 
+                                   If any header name in the `Access-Control-Request-Headers` request header
+                                   is not included in the list of header names specified by the response
+@@ -8999,21 +9004,20 @@
+                                   client side.
+ 
+                                   A wildcard indicates that the requests with all HTTP headers are allowed.
+-                                  If config contains the wildcard "*" in allowHeaders and the request is
+-                                  not credentialed, the `Access-Control-Allow-Headers` response header
+-                                  can either use the `*` wildcard or the value of
+-                                  Access-Control-Request-Headers from the request.
+-
+-                                  When the request is credentialed, the gateway must not specify the `*`
+-                                  wildcard in the `Access-Control-Allow-Headers` response header. When
+-                                  also the `AllowCredentials` field is true and `AllowHeaders` field
+-                                  is specified with the `*` wildcard, the gateway must specify one or more
+-                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
+-                                  header. The value of the header `Access-Control-Allow-Headers` is same as
+-                                  the `Access-Control-Request-Headers` header provided by the client. If
+-                                  the header `Access-Control-Request-Headers` is not included in the
+-                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+-                                  response header, instead of specifying the `*` wildcard.
++
++                                  If the configuration contains the wildcard `*` in `allowHeaders` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
++                                  response header may either contain the wildcard `*` or echo the value
++                                  of the `Access-Control-Request-Headers` request header.
++
++                                  If the configuration contains the wildcard `*` in `allowHeaders` and
++                                  `allowCredentials` is set to `true`, the gateway must not return `*`
++                                  in the `Access-Control-Allow-Headers` response header. Instead, it must
++                                  return one or more header names matching the value of the
++                                  `Access-Control-Request-Headers` request header.
++                                  If the `Access-Control-Request-Headers` header is not present in the
++                                  request, the gateway must omit the `Access-Control-Allow-Headers`
++                                  response header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -9058,32 +9062,29 @@
+                                   A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                   CORS-safelisted methods are always allowed, regardless of whether they
+-                                  are specified in the `AllowMethods` field.
++                                  are specified in the `allowMethods` field.
+ 
+-                                  When the `AllowMethods` field is configured with one or more methods, the
++                                  When the `allowMethods` field is configured with one or more methods, the
+                                   gateway must return the `Access-Control-Allow-Methods` response header
+-                                  which value is present in the `AllowMethods` field.
++                                  which value is present in the `allowMethods` field.
+ 
+                                   If the HTTP method of the `Access-Control-Request-Method` request header
+                                   is not included in the list of methods specified by the response header
+                                   `Access-Control-Allow-Methods`, it will present an error on the client
+                                   side.
+ 
+-                                  If config contains the wildcard "*" in allowMethods and the request is
+-                                  not credentialed, the `Access-Control-Allow-Methods` response header
+-                                  can either use the `*` wildcard or the value of
+-                                  Access-Control-Request-Method from the request.
+-
+-                                  When the request is credentialed, the gateway must not specify the `*`
+-                                  wildcard in the `Access-Control-Allow-Methods` response header. When
+-                                  also the `AllowCredentials` field is true and `AllowMethods` field
+-                                  specified with the `*` wildcard, the gateway must specify one HTTP method
+-                                  in the value of the Access-Control-Allow-Methods response header. The
+-                                  value of the header `Access-Control-Allow-Methods` is same as the
+-                                  `Access-Control-Request-Method` header provided by the client. If the
+-                                  header `Access-Control-Request-Method` is not included in the request,
+-                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
+-                                  instead of specifying the `*` wildcard.
++                                  If the configuration contains the wildcard `*` in `allowMethods` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
++                                  response header may either contain the wildcard `*` or echo the value
++                                  of the `Access-Control-Request-Method` request header.
++
++                                  If the configuration contains the wildcard `*` in `allowMethods` and
++                                  `allowCredentials` is set to `true`, the gateway must not return `*`
++                                  in the `Access-Control-Allow-Methods` response header. Instead, it must
++                                  return a single HTTP method matching the value of the
++                                  `Access-Control-Request-Method` request header.
++                                  If the `Access-Control-Request-Method` header is not present in the request,
++                                  the gateway must omit the `Access-Control-Allow-Methods` response header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -9133,7 +9134,7 @@
+                                   An origin value that includes _only_ the `*` character indicates requests
+                                   from all `Origin`s are allowed.
+ 
+-                                  When the `AllowOrigins` field is configured with multiple origins, it
++                                  When the `allowOrigins` field is configured with multiple origins, it
+                                   means the server supports clients from multiple origins. If the request
+                                   `Origin` matches the configured allowed origins, the gateway must return
+                                   the given `Origin` and sets value of the header
+@@ -9155,19 +9156,15 @@
+                                   `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                   header provided by the client.
+ 
+-                                  When config has the wildcard ("*") in allowOrigins, and the request
+-                                  is not credentialed (e.g., it is a preflight request), the
+-                                  `Access-Control-Allow-Origin` response header either contains the
+-                                  wildcard as well or the Origin from the request.
+-
+-                                  When the request is credentialed, the gateway must not specify the `*`
+-                                  wildcard in the `Access-Control-Allow-Origin` response header. When
+-                                  also the `AllowCredentials` field is true and `AllowOrigins` field
+-                                  specified with the `*` wildcard, the gateway must return a single origin
+-                                  in the value of the `Access-Control-Allow-Origin` response header,
+-                                  instead of specifying the `*` wildcard. The value of the header
+-                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+-                                  the client.
++                                  If the configuration contains the wildcard `*` in `allowOrigins` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
++                                  response header may either contain the wildcard `*` or echo the value
++                                  of the `Origin` request header.
++
++                                  If the configuration contains the wildcard `*` in `allowOrigins` and
++                                  `allowCredentials` is set to `true`, the gateway must not return `*`
++                                  in the `Access-Control-Allow-Origin` response header. Instead, it must
++                                  return a single origin matching the value of the `Origin` request header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -9206,7 +9203,7 @@
+                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                   The CORS-safelisted response headers are exposed to client by default.
+ 
+-                                  When an HTTP header name is specified using the `ExposeHeaders` field,
++                                  When an HTTP header name is specified using the `exposeHeaders` field,
+                                   this additional header will be exposed as part of the response to the
+                                   client.
+ 
+@@ -9216,12 +9213,15 @@
+                                   response header are separated by a comma (",").
+ 
+                                   A wildcard indicates that the responses with all HTTP headers are exposed
+-                                  to clients. The `Access-Control-Expose-Headers` response header can only
+-                                  use `*` wildcard as value when the request is not credentialed.
++                                  to clients.
+ 
+-                                  When the `exposeHeaders` config field contains the "*" wildcard and
+-                                  the request is credentialed, the gateway cannot use the `*` wildcard in
+-                                  the `Access-Control-Expose-Headers` response header.
++                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
++                                  response header can contain the wildcard `*`.
++
++                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                  `allowCredentials` is set to `true`, the gateway cannot use the `*`
++                                  in the `Access-Control-Expose-Headers` response header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -9469,6 +9469,10 @@
+                                   Support: Extended for Kubernetes Service
+ 
+                                   Support: Implementation-specific for any other resource
++
++                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
++                                  implementation to supply the TLS details to be used to connect to that
++                                  backend.
+                                 properties:
+                                   group:
+                                     default: ""
+@@ -11180,9 +11184,9 @@
+                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                         response header are separated by a comma (",").
+ 
+-                                        When the `AllowHeaders` field is configured with one or more headers, the
++                                        When the `allowHeaders` field is configured with one or more headers, the
+                                         gateway must return the `Access-Control-Allow-Headers` response header
+-                                        which value is present in the `AllowHeaders` field.
++                                        which value is present in the `allowHeaders` field.
+ 
+                                         If any header name in the `Access-Control-Request-Headers` request header
+                                         is not included in the list of header names specified by the response
+@@ -11194,21 +11198,20 @@
+                                         client side.
+ 
+                                         A wildcard indicates that the requests with all HTTP headers are allowed.
+-                                        If config contains the wildcard "*" in allowHeaders and the request is
+-                                        not credentialed, the `Access-Control-Allow-Headers` response header
+-                                        can either use the `*` wildcard or the value of
+-                                        Access-Control-Request-Headers from the request.
+-
+-                                        When the request is credentialed, the gateway must not specify the `*`
+-                                        wildcard in the `Access-Control-Allow-Headers` response header. When
+-                                        also the `AllowCredentials` field is true and `AllowHeaders` field
+-                                        is specified with the `*` wildcard, the gateway must specify one or more
+-                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
+-                                        header. The value of the header `Access-Control-Allow-Headers` is same as
+-                                        the `Access-Control-Request-Headers` header provided by the client. If
+-                                        the header `Access-Control-Request-Headers` is not included in the
+-                                        request, the gateway will omit the `Access-Control-Allow-Headers`
+-                                        response header, instead of specifying the `*` wildcard.
++
++                                        If the configuration contains the wildcard `*` in `allowHeaders` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
++                                        response header may either contain the wildcard `*` or echo the value
++                                        of the `Access-Control-Request-Headers` request header.
++
++                                        If the configuration contains the wildcard `*` in `allowHeaders` and
++                                        `allowCredentials` is set to `true`, the gateway must not return `*`
++                                        in the `Access-Control-Allow-Headers` response header. Instead, it must
++                                        return one or more header names matching the value of the
++                                        `Access-Control-Request-Headers` request header.
++                                        If the `Access-Control-Request-Headers` header is not present in the
++                                        request, the gateway must omit the `Access-Control-Allow-Headers`
++                                        response header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -11253,32 +11256,29 @@
+                                         A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                         CORS-safelisted methods are always allowed, regardless of whether they
+-                                        are specified in the `AllowMethods` field.
++                                        are specified in the `allowMethods` field.
+ 
+-                                        When the `AllowMethods` field is configured with one or more methods, the
++                                        When the `allowMethods` field is configured with one or more methods, the
+                                         gateway must return the `Access-Control-Allow-Methods` response header
+-                                        which value is present in the `AllowMethods` field.
++                                        which value is present in the `allowMethods` field.
+ 
+                                         If the HTTP method of the `Access-Control-Request-Method` request header
+                                         is not included in the list of methods specified by the response header
+                                         `Access-Control-Allow-Methods`, it will present an error on the client
+                                         side.
+ 
+-                                        If config contains the wildcard "*" in allowMethods and the request is
+-                                        not credentialed, the `Access-Control-Allow-Methods` response header
+-                                        can either use the `*` wildcard or the value of
+-                                        Access-Control-Request-Method from the request.
+-
+-                                        When the request is credentialed, the gateway must not specify the `*`
+-                                        wildcard in the `Access-Control-Allow-Methods` response header. When
+-                                        also the `AllowCredentials` field is true and `AllowMethods` field
+-                                        specified with the `*` wildcard, the gateway must specify one HTTP method
+-                                        in the value of the Access-Control-Allow-Methods response header. The
+-                                        value of the header `Access-Control-Allow-Methods` is same as the
+-                                        `Access-Control-Request-Method` header provided by the client. If the
+-                                        header `Access-Control-Request-Method` is not included in the request,
+-                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
+-                                        instead of specifying the `*` wildcard.
++                                        If the configuration contains the wildcard `*` in `allowMethods` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
++                                        response header may either contain the wildcard `*` or echo the value
++                                        of the `Access-Control-Request-Method` request header.
++
++                                        If the configuration contains the wildcard `*` in `allowMethods` and
++                                        `allowCredentials` is set to `true`, the gateway must not return `*`
++                                        in the `Access-Control-Allow-Methods` response header. Instead, it must
++                                        return a single HTTP method matching the value of the
++                                        `Access-Control-Request-Method` request header.
++                                        If the `Access-Control-Request-Method` header is not present in the request,
++                                        the gateway must omit the `Access-Control-Allow-Methods` response header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -11328,7 +11328,7 @@
+                                         An origin value that includes _only_ the `*` character indicates requests
+                                         from all `Origin`s are allowed.
+ 
+-                                        When the `AllowOrigins` field is configured with multiple origins, it
++                                        When the `allowOrigins` field is configured with multiple origins, it
+                                         means the server supports clients from multiple origins. If the request
+                                         `Origin` matches the configured allowed origins, the gateway must return
+                                         the given `Origin` and sets value of the header
+@@ -11350,19 +11350,15 @@
+                                         `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                         header provided by the client.
+ 
+-                                        When config has the wildcard ("*") in allowOrigins, and the request
+-                                        is not credentialed (e.g., it is a preflight request), the
+-                                        `Access-Control-Allow-Origin` response header either contains the
+-                                        wildcard as well or the Origin from the request.
+-
+-                                        When the request is credentialed, the gateway must not specify the `*`
+-                                        wildcard in the `Access-Control-Allow-Origin` response header. When
+-                                        also the `AllowCredentials` field is true and `AllowOrigins` field
+-                                        specified with the `*` wildcard, the gateway must return a single origin
+-                                        in the value of the `Access-Control-Allow-Origin` response header,
+-                                        instead of specifying the `*` wildcard. The value of the header
+-                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+-                                        the client.
++                                        If the configuration contains the wildcard `*` in `allowOrigins` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
++                                        response header may either contain the wildcard `*` or echo the value
++                                        of the `Origin` request header.
++
++                                        If the configuration contains the wildcard `*` in `allowOrigins` and
++                                        `allowCredentials` is set to `true`, the gateway must not return `*`
++                                        in the `Access-Control-Allow-Origin` response header. Instead, it must
++                                        return a single origin matching the value of the `Origin` request header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -11401,7 +11397,7 @@
+                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                         The CORS-safelisted response headers are exposed to client by default.
+ 
+-                                        When an HTTP header name is specified using the `ExposeHeaders` field,
++                                        When an HTTP header name is specified using the `exposeHeaders` field,
+                                         this additional header will be exposed as part of the response to the
+                                         client.
+ 
+@@ -11411,12 +11407,15 @@
+                                         response header are separated by a comma (",").
+ 
+                                         A wildcard indicates that the responses with all HTTP headers are exposed
+-                                        to clients. The `Access-Control-Expose-Headers` response header can only
+-                                        use `*` wildcard as value when the request is not credentialed.
++                                        to clients.
+ 
+-                                        When the `exposeHeaders` config field contains the "*" wildcard and
+-                                        the request is credentialed, the gateway cannot use the `*` wildcard in
+-                                        the `Access-Control-Expose-Headers` response header.
++                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                        `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
++                                        response header can contain the wildcard `*`.
++
++                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                        `allowCredentials` is set to `true`, the gateway cannot use the `*`
++                                        in the `Access-Control-Expose-Headers` response header.
+ 
+                                         Support: Extended
+                                       items:
+@@ -11666,6 +11665,10 @@
+                                         Support: Extended for Kubernetes Service
+ 
+                                         Support: Implementation-specific for any other resource
++
++                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
++                                        implementation to supply the TLS details to be used to connect to that
++                                        backend.
+                                       properties:
+                                         group:
+                                           default: ""
+@@ -12437,9 +12440,9 @@
+                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                   response header are separated by a comma (",").
+ 
+-                                  When the `AllowHeaders` field is configured with one or more headers, the
++                                  When the `allowHeaders` field is configured with one or more headers, the
+                                   gateway must return the `Access-Control-Allow-Headers` response header
+-                                  which value is present in the `AllowHeaders` field.
++                                  which value is present in the `allowHeaders` field.
+ 
+                                   If any header name in the `Access-Control-Request-Headers` request header
+                                   is not included in the list of header names specified by the response
+@@ -12451,21 +12454,20 @@
+                                   client side.
+ 
+                                   A wildcard indicates that the requests with all HTTP headers are allowed.
+-                                  If config contains the wildcard "*" in allowHeaders and the request is
+-                                  not credentialed, the `Access-Control-Allow-Headers` response header
+-                                  can either use the `*` wildcard or the value of
+-                                  Access-Control-Request-Headers from the request.
+-
+-                                  When the request is credentialed, the gateway must not specify the `*`
+-                                  wildcard in the `Access-Control-Allow-Headers` response header. When
+-                                  also the `AllowCredentials` field is true and `AllowHeaders` field
+-                                  is specified with the `*` wildcard, the gateway must specify one or more
+-                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
+-                                  header. The value of the header `Access-Control-Allow-Headers` is same as
+-                                  the `Access-Control-Request-Headers` header provided by the client. If
+-                                  the header `Access-Control-Request-Headers` is not included in the
+-                                  request, the gateway will omit the `Access-Control-Allow-Headers`
+-                                  response header, instead of specifying the `*` wildcard.
++
++                                  If the configuration contains the wildcard `*` in `allowHeaders` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
++                                  response header may either contain the wildcard `*` or echo the value
++                                  of the `Access-Control-Request-Headers` request header.
++
++                                  If the configuration contains the wildcard `*` in `allowHeaders` and
++                                  `allowCredentials` is set to `true`, the gateway must not return `*`
++                                  in the `Access-Control-Allow-Headers` response header. Instead, it must
++                                  return one or more header names matching the value of the
++                                  `Access-Control-Request-Headers` request header.
++                                  If the `Access-Control-Request-Headers` header is not present in the
++                                  request, the gateway must omit the `Access-Control-Allow-Headers`
++                                  response header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -12510,32 +12512,29 @@
+                                   A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                   CORS-safelisted methods are always allowed, regardless of whether they
+-                                  are specified in the `AllowMethods` field.
++                                  are specified in the `allowMethods` field.
+ 
+-                                  When the `AllowMethods` field is configured with one or more methods, the
++                                  When the `allowMethods` field is configured with one or more methods, the
+                                   gateway must return the `Access-Control-Allow-Methods` response header
+-                                  which value is present in the `AllowMethods` field.
++                                  which value is present in the `allowMethods` field.
+ 
+                                   If the HTTP method of the `Access-Control-Request-Method` request header
+                                   is not included in the list of methods specified by the response header
+                                   `Access-Control-Allow-Methods`, it will present an error on the client
+                                   side.
+ 
+-                                  If config contains the wildcard "*" in allowMethods and the request is
+-                                  not credentialed, the `Access-Control-Allow-Methods` response header
+-                                  can either use the `*` wildcard or the value of
+-                                  Access-Control-Request-Method from the request.
+-
+-                                  When the request is credentialed, the gateway must not specify the `*`
+-                                  wildcard in the `Access-Control-Allow-Methods` response header. When
+-                                  also the `AllowCredentials` field is true and `AllowMethods` field
+-                                  specified with the `*` wildcard, the gateway must specify one HTTP method
+-                                  in the value of the Access-Control-Allow-Methods response header. The
+-                                  value of the header `Access-Control-Allow-Methods` is same as the
+-                                  `Access-Control-Request-Method` header provided by the client. If the
+-                                  header `Access-Control-Request-Method` is not included in the request,
+-                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
+-                                  instead of specifying the `*` wildcard.
++                                  If the configuration contains the wildcard `*` in `allowMethods` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
++                                  response header may either contain the wildcard `*` or echo the value
++                                  of the `Access-Control-Request-Method` request header.
++
++                                  If the configuration contains the wildcard `*` in `allowMethods` and
++                                  `allowCredentials` is set to `true`, the gateway must not return `*`
++                                  in the `Access-Control-Allow-Methods` response header. Instead, it must
++                                  return a single HTTP method matching the value of the
++                                  `Access-Control-Request-Method` request header.
++                                  If the `Access-Control-Request-Method` header is not present in the request,
++                                  the gateway must omit the `Access-Control-Allow-Methods` response header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -12585,7 +12584,7 @@
+                                   An origin value that includes _only_ the `*` character indicates requests
+                                   from all `Origin`s are allowed.
+ 
+-                                  When the `AllowOrigins` field is configured with multiple origins, it
++                                  When the `allowOrigins` field is configured with multiple origins, it
+                                   means the server supports clients from multiple origins. If the request
+                                   `Origin` matches the configured allowed origins, the gateway must return
+                                   the given `Origin` and sets value of the header
+@@ -12607,19 +12606,15 @@
+                                   `Access-Control-Allow-Origin` to the same value as the `Origin`
+                                   header provided by the client.
+ 
+-                                  When config has the wildcard ("*") in allowOrigins, and the request
+-                                  is not credentialed (e.g., it is a preflight request), the
+-                                  `Access-Control-Allow-Origin` response header either contains the
+-                                  wildcard as well or the Origin from the request.
+-
+-                                  When the request is credentialed, the gateway must not specify the `*`
+-                                  wildcard in the `Access-Control-Allow-Origin` response header. When
+-                                  also the `AllowCredentials` field is true and `AllowOrigins` field
+-                                  specified with the `*` wildcard, the gateway must return a single origin
+-                                  in the value of the `Access-Control-Allow-Origin` response header,
+-                                  instead of specifying the `*` wildcard. The value of the header
+-                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+-                                  the client.
++                                  If the configuration contains the wildcard `*` in `allowOrigins` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
++                                  response header may either contain the wildcard `*` or echo the value
++                                  of the `Origin` request header.
++
++                                  If the configuration contains the wildcard `*` in `allowOrigins` and
++                                  `allowCredentials` is set to `true`, the gateway must not return `*`
++                                  in the `Access-Control-Allow-Origin` response header. Instead, it must
++                                  return a single origin matching the value of the `Origin` request header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -12658,7 +12653,7 @@
+                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                   The CORS-safelisted response headers are exposed to client by default.
+ 
+-                                  When an HTTP header name is specified using the `ExposeHeaders` field,
++                                  When an HTTP header name is specified using the `exposeHeaders` field,
+                                   this additional header will be exposed as part of the response to the
+                                   client.
+ 
+@@ -12668,12 +12663,15 @@
+                                   response header are separated by a comma (",").
+ 
+                                   A wildcard indicates that the responses with all HTTP headers are exposed
+-                                  to clients. The `Access-Control-Expose-Headers` response header can only
+-                                  use `*` wildcard as value when the request is not credentialed.
++                                  to clients.
+ 
+-                                  When the `exposeHeaders` config field contains the "*" wildcard and
+-                                  the request is credentialed, the gateway cannot use the `*` wildcard in
+-                                  the `Access-Control-Expose-Headers` response header.
++                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                  `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
++                                  response header can contain the wildcard `*`.
++
++                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
++                                  `allowCredentials` is set to `true`, the gateway cannot use the `*`
++                                  in the `Access-Control-Expose-Headers` response header.
+ 
+                                   Support: Extended
+                                 items:
+@@ -12921,6 +12919,10 @@
+                                   Support: Extended for Kubernetes Service
+ 
+                                   Support: Implementation-specific for any other resource
++
++                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
++                                  implementation to supply the TLS details to be used to connect to that
++                                  backend.
+                                 properties:
+                                   group:
+                                     default: ""
+@@ -14208,12 +14210,6 @@
+     storage: false
+     subresources:
+       status: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
+ ---
+ #
+ # config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+@@ -14223,8 +14219,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    name: listenersets.gateway.networking.k8s.io
  spec:
    group: gateway.networking.k8s.io
-@@ -15009,6 +15015,7 @@
+@@ -14992,12 +14989,6 @@
+     storage: true
+     subresources:
+       status: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
+ ---
+ #
+ # config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+@@ -15007,8 +14998,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    name: referencegrants.gateway.networking.k8s.io
  spec:
    group: gateway.networking.k8s.io
-@@ -15366,6 +15373,7 @@
+@@ -15182,6 +15174,8 @@
+             - from
+             - to
+             type: object
++        required:
++        - spec
+         type: object
+     served: true
+     storage: false
+@@ -15345,16 +15339,1309 @@
+             - from
+             - to
+             type: object
++        required:
++        - spec
+         type: object
+     served: true
+     storage: true
+     subresources: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
++---
++#
++# config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
++#
++apiVersion: apiextensions.k8s.io/v1
++kind: CustomResourceDefinition
++metadata:
++  annotations:
++    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
++    gateway.networking.k8s.io/bundle-version: v1.6.1
++    gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
++  name: tcproutes.gateway.networking.k8s.io
++spec:
++  group: gateway.networking.k8s.io
++  names:
++    categories:
++    - gateway-api
++    kind: TCPRoute
++    listKind: TCPRouteList
++    plural: tcproutes
++    singular: tcproute
++  scope: Namespaced
++  versions:
++  - additionalPrinterColumns:
++    - jsonPath: .metadata.creationTimestamp
++      name: Age
++      type: date
++    name: v1
++    schema:
++      openAPIV3Schema:
++        description: |-
++          TCPRoute provides a way to route TCP requests. When combined with a Gateway
++          listener, it can be used to forward connections on the port specified by the
++          listener to a set of backends specified by the TCPRoute.
++        properties:
++          apiVersion:
++            description: |-
++              APIVersion defines the versioned schema of this representation of an object.
++              Servers should convert recognized schemas to the latest internal value, and
++              may reject unrecognized values.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
++            type: string
++          kind:
++            description: |-
++              Kind is a string value representing the REST resource this object represents.
++              Servers may infer this from the endpoint the client submits requests to.
++              Cannot be updated.
++              In CamelCase.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
++            type: string
++          metadata:
++            type: object
++          spec:
++            description: Spec defines the desired state of TCPRoute.
++            properties:
++              parentRefs:
++                description: |-
++                  ParentRefs references the resources (usually Gateways) that a Route wants
++                  to be attached to. Note that the referenced parent resource needs to
++                  allow this for the attachment to be complete. For Gateways, that means
++                  the Gateway needs to allow attachment from Routes of this kind and
++                  namespace. For Services, that means the Service must either be in the same
++                  namespace for a "producer" route, or the mesh implementation must support
++                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
++                  not applicable for governing ParentRefs to Services - it is not possible to
++                  create a "producer" route for a Service in a different namespace from the
++                  Route.
++
++                  There are two kinds of parent resources with "Core" support:
++
++                  * Gateway (Gateway conformance profile)
++                  * Service (Mesh conformance profile, ClusterIP Services only)
++
++                  This API may be extended in the future to support additional kinds of parent
++                  resources.
++
++                  ParentRefs must be _distinct_. This means either that:
++
++                  * They select different objects.  If this is the case, then parentRef
++                    entries are distinct. In terms of fields, this means that the
++                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
++                    be unique across all parentRef entries in the Route.
++                  * They do not select different objects, but for each optional field used,
++                    each ParentRef that selects the same object must set the same set of
++                    optional fields to different values. If one ParentRef sets a
++                    combination of optional fields, all must set the same combination.
++
++                  Some examples:
++
++                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
++                    same object must also set `sectionName`.
++                  * If one ParentRef sets `port`, all ParentRefs referencing the same
++                    object must also set `port`.
++                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
++                    referencing the same object must also set `sectionName` and `port`.
++
++                  It is possible to separately reference multiple distinct objects that may
++                  be collapsed by an implementation. For example, some implementations may
++                  choose to merge compatible Gateway Listeners together. If that is the
++                  case, the list of routes attached to those resources should also be
++                  merged.
++
++                  Note that for ParentRefs that cross namespace boundaries, there are specific
++                  rules. Cross-namespace references are only valid if they are explicitly
++                  allowed by something in the namespace they are referring to. For example,
++                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                  generic way to enable other kinds of cross-namespace reference.
++                items:
++                  description: |-
++                    ParentReference identifies an API object (usually a Gateway) that can be considered
++                    a parent of this resource (usually a route). There are two kinds of parent resources
++                    with "Core" support:
++
++                    * Gateway (Gateway conformance profile)
++                    * Service (Mesh conformance profile, ClusterIP Services only)
++
++                    This API may be extended in the future to support additional kinds of parent
++                    resources.
++
++                    The API object must be valid in the cluster; the Group and Kind must
++                    be registered in the cluster for this reference to be valid.
++                  properties:
++                    group:
++                      default: gateway.networking.k8s.io
++                      description: |-
++                        Group is the group of the referent.
++                        When unspecified, "gateway.networking.k8s.io" is inferred.
++                        To set the core API group (such as for a "Service" kind referent),
++                        Group must be explicitly set to "" (empty string).
++
++                        Support: Core
++                      maxLength: 253
++                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                    kind:
++                      default: Gateway
++                      description: |-
++                        Kind is kind of the referent.
++
++                        There are two kinds of parent resources with "Core" support:
++
++                        * Gateway (Gateway conformance profile)
++                        * Service (Mesh conformance profile, ClusterIP Services only)
++
++                        Support for other resources is Implementation-Specific.
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                      type: string
++                    name:
++                      description: |-
++                        Name is the name of the referent.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      type: string
++                    namespace:
++                      description: |-
++                        Namespace is the namespace of the referent. When unspecified, this refers
++                        to the local namespace of the Route.
++
++                        Note that there are specific rules for ParentRefs which cross namespace
++                        boundaries. Cross-namespace references are only valid if they are explicitly
++                        allowed by something in the namespace they are referring to. For example:
++                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                        generic way to enable any other kind of cross-namespace reference.
++
++                        Support: Core
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                      type: string
++                    port:
++                      description: |-
++                        Port is the network port this Route targets. It can be interpreted
++                        differently based on the type of parent resource.
++
++                        When the parent resource is a Gateway, this targets all listeners
++                        listening on the specified port that also support this kind of Route(and
++                        select this Route). It's not recommended to set `Port` unless the
++                        networking behaviors specified in a Route must apply to a specific port
++                        as opposed to a listener(s) whose port(s) may be changed. When both Port
++                        and SectionName are specified, the name and port of the selected listener
++                        must match both specified values.
++
++                        Implementations MAY choose to support other parent resources.
++                        Implementations supporting other types of parent resources MUST clearly
++                        document how/if Port is interpreted.
++
++                        For the purpose of status, an attachment is considered successful as
++                        long as the parent resource accepts it partially. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                        from the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route,
++                        the Route MUST be considered detached from the Gateway.
++
++                        Support: Extended
++                      format: int32
++                      maximum: 65535
++                      minimum: 1
++                      type: integer
++                    sectionName:
++                      description: |-
++                        SectionName is the name of a section within the target resource. In the
++                        following resources, SectionName is interpreted as the following:
++
++                        * Gateway: Listener name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++                        * Service: Port name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++
++                        Implementations MAY choose to support attaching Routes to other resources.
++                        If that is the case, they MUST clearly document how SectionName is
++                        interpreted.
++
++                        When unspecified (empty string), this will reference the entire resource.
++                        For the purpose of status, an attachment is considered successful if at
++                        least one section in the parent resource accepts it. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                        the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route, the
++                        Route MUST be considered detached from the Gateway.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - name
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++                x-kubernetes-validations:
++                - message: sectionName must be specified when parentRefs includes
++                    2 or more references to the same parent
++                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
++                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
++                    == '''')) : true))'
++                - message: sectionName must be unique when parentRefs includes 2 or
++                    more references to the same parent
++                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
++                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
++                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
++                    == p2.sectionName))))
++              rules:
++                description: Rules are a list of TCP matchers and actions.
++                items:
++                  description: TCPRouteRule is the configuration for a given rule.
++                  properties:
++                    backendRefs:
++                      description: |-
++                        BackendRefs defines the backend(s) where matching requests should be
++                        sent. If unspecified or invalid (refers to a nonexistent resource or a
++                        Service with no endpoints), the underlying implementation MUST actively
++                        reject connection attempts to this backend. Connection rejections must
++                        respect weight; if an invalid backend is requested to have 80% of
++                        connections, then 80% of connections must be rejected instead.
++
++                        Support: Core for Kubernetes Service
++                      items:
++                        description: |-
++                          BackendRef defines how a Route should forward a request to a Kubernetes
++                          resource.
++
++                          Note that when a namespace different than the local namespace is specified, a
++                          ReferenceGrant object is required in the referent namespace to allow that
++                          namespace's owner to accept the reference. See the ReferenceGrant
++                          documentation for details.
++
++                          Note that when the BackendTLSPolicy object is enabled by the implementation,
++                          there are some extra rules about validity to consider here. See the fields
++                          where this struct is used for more information about the exact behavior.
++                        properties:
++                          group:
++                            default: ""
++                            description: |-
++                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
++                              When unspecified or empty string, core API group is inferred.
++                            maxLength: 253
++                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                            type: string
++                          kind:
++                            default: Service
++                            description: |-
++                              Kind is the Kubernetes resource kind of the referent. For example
++                              "Service".
++
++                              Defaults to "Service" when not specified.
++
++                              ExternalName services can refer to CNAME DNS records that may live
++                              outside of the cluster and as such are difficult to reason about in
++                              terms of conformance. They also may not be safe to forward to (see
++                              CVE-2021-25740 for more information). Implementations SHOULD NOT
++                              support ExternalName Services.
++
++                              Support: Core (Services with a type other than ExternalName)
++
++                              Support: Implementation-specific (Services with type ExternalName)
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                            type: string
++                          name:
++                            description: Name is the name of the referent.
++                            maxLength: 253
++                            minLength: 1
++                            type: string
++                          namespace:
++                            description: |-
++                              Namespace is the namespace of the backend. When unspecified, the local
++                              namespace is inferred.
++
++                              Note that when a namespace different than the local namespace is specified,
++                              a ReferenceGrant object is required in the referent namespace to allow that
++                              namespace's owner to accept the reference. See the ReferenceGrant
++                              documentation for details.
++
++                              Support: Core
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                            type: string
++                          port:
++                            description: |-
++                              Port specifies the destination port number to use for this resource.
++                              Port is required when the referent is a Kubernetes Service. In this
++                              case, the port number is the service port number, not the target port.
++                              For other resources, destination port might be derived from the referent
++                              resource or this field.
++                            format: int32
++                            maximum: 65535
++                            minimum: 1
++                            type: integer
++                          weight:
++                            default: 1
++                            description: |-
++                              Weight specifies the proportion of requests forwarded to the referenced
++                              backend. This is computed as weight/(sum of all weights in this
++                              BackendRefs list). For non-zero values, there may be some epsilon from
++                              the exact proportion defined here depending on the precision an
++                              implementation supports. Weight is not a percentage and the sum of
++                              weights does not need to equal 100.
++
++                              If only one backend is specified and it has a weight greater than 0, 100%
++                              of the traffic is forwarded to that backend. If weight is set to 0, no
++                              traffic should be forwarded for this entry. If unspecified, weight
++                              defaults to 1.
++
++                              Support for this field varies based on the context where used.
++                            format: int32
++                            maximum: 1000000
++                            minimum: 0
++                            type: integer
++                        required:
++                        - name
++                        type: object
++                        x-kubernetes-validations:
++                        - message: Must have port for Service reference
++                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
++                            ? has(self.port) : true'
++                      maxItems: 16
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-type: atomic
++                    name:
++                      description: Name is the name of the route rule. This name MUST
++                        be unique within a Route if it is set.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - backendRefs
++                  type: object
++                maxItems: 1
++                minItems: 1
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - rules
++            type: object
++          status:
++            description: Status defines the current state of TCPRoute.
++            properties:
++              parents:
++                description: |-
++                  Parents is a list of parent resources (usually Gateways) that are
++                  associated with the route, and the status of the route with respect to
++                  each parent. When this route attaches to a parent, the controller that
++                  manages the parent must add an entry to this list when the controller
++                  first sees the route and should update the entry as appropriate when the
++                  route or gateway is modified.
++
++                  Note that parent references that cannot be resolved by an implementation
++                  of this API will not be added to this list. Implementations of this API
++                  can only populate Route status for the Gateways/parent resources they are
++                  responsible for.
++
++                  A maximum of 32 Gateways will be represented in this list. An empty list
++                  means the route has not been attached to any Gateway.
++                items:
++                  description: |-
++                    RouteParentStatus describes the status of a route with respect to an
++                    associated Parent.
++                  properties:
++                    conditions:
++                      description: |-
++                        Conditions describes the status of the route with respect to the Gateway.
++                        Note that the route's availability is also subject to the Gateway's own
++                        status conditions and listener status.
++
++                        If the Route's ParentRef specifies an existing Gateway that supports
++                        Routes of this kind AND that Gateway's controller has sufficient access,
++                        then that Gateway's controller MUST set the "Accepted" condition on the
++                        Route, to indicate whether the route has been accepted or rejected by the
++                        Gateway, and why.
++
++                        A Route MUST be considered "Accepted" if at least one of the Route's
++                        rules is implemented by the Gateway.
++
++                        There are a number of cases where the "Accepted" condition may not be set
++                        due to lack of controller visibility, that includes when:
++
++                        * The Route refers to a nonexistent parent.
++                        * The Route is of a type that the controller does not support.
++                        * The Route is in a namespace to which the controller does not have access.
++                      items:
++                        description: Condition contains details for one aspect of
++                          the current state of this API Resource.
++                        properties:
++                          lastTransitionTime:
++                            description: |-
++                              lastTransitionTime is the last time the condition transitioned from one status to another.
++                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
++                            format: date-time
++                            type: string
++                          message:
++                            description: |-
++                              message is a human readable message indicating details about the transition.
++                              This may be an empty string.
++                            maxLength: 32768
++                            type: string
++                          observedGeneration:
++                            description: |-
++                              observedGeneration represents the .metadata.generation that the condition was set based upon.
++                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
++                              with respect to the current state of the instance.
++                            format: int64
++                            minimum: 0
++                            type: integer
++                          reason:
++                            description: |-
++                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
++                              Producers of specific condition types may define expected values and meanings for this field,
++                              and whether the values are considered a guaranteed API.
++                              The value should be a CamelCase string.
++                              This field may not be empty.
++                            maxLength: 1024
++                            minLength: 1
++                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
++                            type: string
++                          status:
++                            description: status of the condition, one of True, False,
++                              Unknown.
++                            enum:
++                            - "True"
++                            - "False"
++                            - Unknown
++                            type: string
++                          type:
++                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
++                            maxLength: 316
++                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
++                            type: string
++                        required:
++                        - lastTransitionTime
++                        - message
++                        - reason
++                        - status
++                        - type
++                        type: object
++                      maxItems: 8
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-map-keys:
++                      - type
++                      x-kubernetes-list-type: map
++                    controllerName:
++                      description: |-
++                        ControllerName is a domain/path string that indicates the name of the
++                        controller that wrote this status. This corresponds with the
++                        controllerName field on GatewayClass.
++
++                        Example: "example.net/gateway-controller".
++
++                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
++                        valid Kubernetes names
++                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
++
++                        Controllers MUST populate this field when writing status. Controllers should ensure that
++                        entries to status populated with their ControllerName are cleaned up when they are no
++                        longer necessary.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
++                      type: string
++                    parentRef:
++                      description: |-
++                        ParentRef corresponds with a ParentRef in the spec that this
++                        RouteParentStatus struct describes the status of.
++                      properties:
++                        group:
++                          default: gateway.networking.k8s.io
++                          description: |-
++                            Group is the group of the referent.
++                            When unspecified, "gateway.networking.k8s.io" is inferred.
++                            To set the core API group (such as for a "Service" kind referent),
++                            Group must be explicitly set to "" (empty string).
++
++                            Support: Core
++                          maxLength: 253
++                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                        kind:
++                          default: Gateway
++                          description: |-
++                            Kind is kind of the referent.
++
++                            There are two kinds of parent resources with "Core" support:
++
++                            * Gateway (Gateway conformance profile)
++                            * Service (Mesh conformance profile, ClusterIP Services only)
++
++                            Support for other resources is Implementation-Specific.
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                          type: string
++                        name:
++                          description: |-
++                            Name is the name of the referent.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          type: string
++                        namespace:
++                          description: |-
++                            Namespace is the namespace of the referent. When unspecified, this refers
++                            to the local namespace of the Route.
++
++                            Note that there are specific rules for ParentRefs which cross namespace
++                            boundaries. Cross-namespace references are only valid if they are explicitly
++                            allowed by something in the namespace they are referring to. For example:
++                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                            generic way to enable any other kind of cross-namespace reference.
++
++                            Support: Core
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                          type: string
++                        port:
++                          description: |-
++                            Port is the network port this Route targets. It can be interpreted
++                            differently based on the type of parent resource.
++
++                            When the parent resource is a Gateway, this targets all listeners
++                            listening on the specified port that also support this kind of Route(and
++                            select this Route). It's not recommended to set `Port` unless the
++                            networking behaviors specified in a Route must apply to a specific port
++                            as opposed to a listener(s) whose port(s) may be changed. When both Port
++                            and SectionName are specified, the name and port of the selected listener
++                            must match both specified values.
++
++                            Implementations MAY choose to support other parent resources.
++                            Implementations supporting other types of parent resources MUST clearly
++                            document how/if Port is interpreted.
++
++                            For the purpose of status, an attachment is considered successful as
++                            long as the parent resource accepts it partially. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                            from the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route,
++                            the Route MUST be considered detached from the Gateway.
++
++                            Support: Extended
++                          format: int32
++                          maximum: 65535
++                          minimum: 1
++                          type: integer
++                        sectionName:
++                          description: |-
++                            SectionName is the name of a section within the target resource. In the
++                            following resources, SectionName is interpreted as the following:
++
++                            * Gateway: Listener name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++                            * Service: Port name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++
++                            Implementations MAY choose to support attaching Routes to other resources.
++                            If that is the case, they MUST clearly document how SectionName is
++                            interpreted.
++
++                            When unspecified (empty string), this will reference the entire resource.
++                            For the purpose of status, an attachment is considered successful if at
++                            least one section in the parent resource accepts it. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                            the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route, the
++                            Route MUST be considered detached from the Gateway.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                      required:
++                      - name
++                      type: object
++                  required:
++                  - conditions
++                  - controllerName
++                  - parentRef
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - parents
++            type: object
++        required:
++        - spec
++        type: object
++    served: true
++    storage: true
++    subresources:
++      status: {}
++  - additionalPrinterColumns:
++    - jsonPath: .metadata.creationTimestamp
++      name: Age
++      type: date
++    deprecated: true
++    deprecationWarning: The v1alpha2 version of TCPRoute has been deprecated and will
++      be removed in a future release of the API. Please upgrade to v1.
++    name: v1alpha2
++    schema:
++      openAPIV3Schema:
++        description: |-
++          TCPRoute provides a way to route TCP requests. When combined with a Gateway
++          listener, it can be used to forward connections on the port specified by the
++          listener to a set of backends specified by the TCPRoute.
++        properties:
++          apiVersion:
++            description: |-
++              APIVersion defines the versioned schema of this representation of an object.
++              Servers should convert recognized schemas to the latest internal value, and
++              may reject unrecognized values.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
++            type: string
++          kind:
++            description: |-
++              Kind is a string value representing the REST resource this object represents.
++              Servers may infer this from the endpoint the client submits requests to.
++              Cannot be updated.
++              In CamelCase.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
++            type: string
++          metadata:
++            type: object
++          spec:
++            description: Spec defines the desired state of TCPRoute.
++            properties:
++              parentRefs:
++                description: |-
++                  ParentRefs references the resources (usually Gateways) that a Route wants
++                  to be attached to. Note that the referenced parent resource needs to
++                  allow this for the attachment to be complete. For Gateways, that means
++                  the Gateway needs to allow attachment from Routes of this kind and
++                  namespace. For Services, that means the Service must either be in the same
++                  namespace for a "producer" route, or the mesh implementation must support
++                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
++                  not applicable for governing ParentRefs to Services - it is not possible to
++                  create a "producer" route for a Service in a different namespace from the
++                  Route.
++
++                  There are two kinds of parent resources with "Core" support:
++
++                  * Gateway (Gateway conformance profile)
++                  * Service (Mesh conformance profile, ClusterIP Services only)
++
++                  This API may be extended in the future to support additional kinds of parent
++                  resources.
++
++                  ParentRefs must be _distinct_. This means either that:
++
++                  * They select different objects.  If this is the case, then parentRef
++                    entries are distinct. In terms of fields, this means that the
++                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
++                    be unique across all parentRef entries in the Route.
++                  * They do not select different objects, but for each optional field used,
++                    each ParentRef that selects the same object must set the same set of
++                    optional fields to different values. If one ParentRef sets a
++                    combination of optional fields, all must set the same combination.
++
++                  Some examples:
++
++                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
++                    same object must also set `sectionName`.
++                  * If one ParentRef sets `port`, all ParentRefs referencing the same
++                    object must also set `port`.
++                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
++                    referencing the same object must also set `sectionName` and `port`.
++
++                  It is possible to separately reference multiple distinct objects that may
++                  be collapsed by an implementation. For example, some implementations may
++                  choose to merge compatible Gateway Listeners together. If that is the
++                  case, the list of routes attached to those resources should also be
++                  merged.
++
++                  Note that for ParentRefs that cross namespace boundaries, there are specific
++                  rules. Cross-namespace references are only valid if they are explicitly
++                  allowed by something in the namespace they are referring to. For example,
++                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                  generic way to enable other kinds of cross-namespace reference.
++                items:
++                  description: |-
++                    ParentReference identifies an API object (usually a Gateway) that can be considered
++                    a parent of this resource (usually a route). There are two kinds of parent resources
++                    with "Core" support:
++
++                    * Gateway (Gateway conformance profile)
++                    * Service (Mesh conformance profile, ClusterIP Services only)
++
++                    This API may be extended in the future to support additional kinds of parent
++                    resources.
++
++                    The API object must be valid in the cluster; the Group and Kind must
++                    be registered in the cluster for this reference to be valid.
++                  properties:
++                    group:
++                      default: gateway.networking.k8s.io
++                      description: |-
++                        Group is the group of the referent.
++                        When unspecified, "gateway.networking.k8s.io" is inferred.
++                        To set the core API group (such as for a "Service" kind referent),
++                        Group must be explicitly set to "" (empty string).
++
++                        Support: Core
++                      maxLength: 253
++                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                    kind:
++                      default: Gateway
++                      description: |-
++                        Kind is kind of the referent.
++
++                        There are two kinds of parent resources with "Core" support:
++
++                        * Gateway (Gateway conformance profile)
++                        * Service (Mesh conformance profile, ClusterIP Services only)
++
++                        Support for other resources is Implementation-Specific.
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                      type: string
++                    name:
++                      description: |-
++                        Name is the name of the referent.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      type: string
++                    namespace:
++                      description: |-
++                        Namespace is the namespace of the referent. When unspecified, this refers
++                        to the local namespace of the Route.
++
++                        Note that there are specific rules for ParentRefs which cross namespace
++                        boundaries. Cross-namespace references are only valid if they are explicitly
++                        allowed by something in the namespace they are referring to. For example:
++                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                        generic way to enable any other kind of cross-namespace reference.
++
++                        Support: Core
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                      type: string
++                    port:
++                      description: |-
++                        Port is the network port this Route targets. It can be interpreted
++                        differently based on the type of parent resource.
++
++                        When the parent resource is a Gateway, this targets all listeners
++                        listening on the specified port that also support this kind of Route(and
++                        select this Route). It's not recommended to set `Port` unless the
++                        networking behaviors specified in a Route must apply to a specific port
++                        as opposed to a listener(s) whose port(s) may be changed. When both Port
++                        and SectionName are specified, the name and port of the selected listener
++                        must match both specified values.
++
++                        Implementations MAY choose to support other parent resources.
++                        Implementations supporting other types of parent resources MUST clearly
++                        document how/if Port is interpreted.
++
++                        For the purpose of status, an attachment is considered successful as
++                        long as the parent resource accepts it partially. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                        from the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route,
++                        the Route MUST be considered detached from the Gateway.
++
++                        Support: Extended
++                      format: int32
++                      maximum: 65535
++                      minimum: 1
++                      type: integer
++                    sectionName:
++                      description: |-
++                        SectionName is the name of a section within the target resource. In the
++                        following resources, SectionName is interpreted as the following:
++
++                        * Gateway: Listener name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++                        * Service: Port name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++
++                        Implementations MAY choose to support attaching Routes to other resources.
++                        If that is the case, they MUST clearly document how SectionName is
++                        interpreted.
++
++                        When unspecified (empty string), this will reference the entire resource.
++                        For the purpose of status, an attachment is considered successful if at
++                        least one section in the parent resource accepts it. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                        the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route, the
++                        Route MUST be considered detached from the Gateway.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - name
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++                x-kubernetes-validations:
++                - message: sectionName must be specified when parentRefs includes
++                    2 or more references to the same parent
++                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
++                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
++                    == '''')) : true))'
++                - message: sectionName must be unique when parentRefs includes 2 or
++                    more references to the same parent
++                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
++                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
++                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
++                    == p2.sectionName))))
++              rules:
++                description: Rules are a list of TCP matchers and actions.
++                items:
++                  description: TCPRouteRule is the configuration for a given rule.
++                  properties:
++                    backendRefs:
++                      description: |-
++                        BackendRefs defines the backend(s) where matching requests should be
++                        sent. If unspecified or invalid (refers to a nonexistent resource or a
++                        Service with no endpoints), the underlying implementation MUST actively
++                        reject connection attempts to this backend. Connection rejections must
++                        respect weight; if an invalid backend is requested to have 80% of
++                        connections, then 80% of connections must be rejected instead.
++
++                        Support: Core for Kubernetes Service
++                      items:
++                        description: |-
++                          BackendRef defines how a Route should forward a request to a Kubernetes
++                          resource.
++
++                          Note that when a namespace different than the local namespace is specified, a
++                          ReferenceGrant object is required in the referent namespace to allow that
++                          namespace's owner to accept the reference. See the ReferenceGrant
++                          documentation for details.
++
++                          Note that when the BackendTLSPolicy object is enabled by the implementation,
++                          there are some extra rules about validity to consider here. See the fields
++                          where this struct is used for more information about the exact behavior.
++                        properties:
++                          group:
++                            default: ""
++                            description: |-
++                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
++                              When unspecified or empty string, core API group is inferred.
++                            maxLength: 253
++                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                            type: string
++                          kind:
++                            default: Service
++                            description: |-
++                              Kind is the Kubernetes resource kind of the referent. For example
++                              "Service".
++
++                              Defaults to "Service" when not specified.
++
++                              ExternalName services can refer to CNAME DNS records that may live
++                              outside of the cluster and as such are difficult to reason about in
++                              terms of conformance. They also may not be safe to forward to (see
++                              CVE-2021-25740 for more information). Implementations SHOULD NOT
++                              support ExternalName Services.
++
++                              Support: Core (Services with a type other than ExternalName)
++
++                              Support: Implementation-specific (Services with type ExternalName)
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                            type: string
++                          name:
++                            description: Name is the name of the referent.
++                            maxLength: 253
++                            minLength: 1
++                            type: string
++                          namespace:
++                            description: |-
++                              Namespace is the namespace of the backend. When unspecified, the local
++                              namespace is inferred.
++
++                              Note that when a namespace different than the local namespace is specified,
++                              a ReferenceGrant object is required in the referent namespace to allow that
++                              namespace's owner to accept the reference. See the ReferenceGrant
++                              documentation for details.
++
++                              Support: Core
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                            type: string
++                          port:
++                            description: |-
++                              Port specifies the destination port number to use for this resource.
++                              Port is required when the referent is a Kubernetes Service. In this
++                              case, the port number is the service port number, not the target port.
++                              For other resources, destination port might be derived from the referent
++                              resource or this field.
++                            format: int32
++                            maximum: 65535
++                            minimum: 1
++                            type: integer
++                          weight:
++                            default: 1
++                            description: |-
++                              Weight specifies the proportion of requests forwarded to the referenced
++                              backend. This is computed as weight/(sum of all weights in this
++                              BackendRefs list). For non-zero values, there may be some epsilon from
++                              the exact proportion defined here depending on the precision an
++                              implementation supports. Weight is not a percentage and the sum of
++                              weights does not need to equal 100.
++
++                              If only one backend is specified and it has a weight greater than 0, 100%
++                              of the traffic is forwarded to that backend. If weight is set to 0, no
++                              traffic should be forwarded for this entry. If unspecified, weight
++                              defaults to 1.
++
++                              Support for this field varies based on the context where used.
++                            format: int32
++                            maximum: 1000000
++                            minimum: 0
++                            type: integer
++                        required:
++                        - name
++                        type: object
++                        x-kubernetes-validations:
++                        - message: Must have port for Service reference
++                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
++                            ? has(self.port) : true'
++                      maxItems: 16
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-type: atomic
++                    name:
++                      description: Name is the name of the route rule. This name MUST
++                        be unique within a Route if it is set.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - backendRefs
++                  type: object
++                maxItems: 16
++                minItems: 1
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - rules
++            type: object
++          status:
++            description: Status defines the current state of TCPRoute.
++            properties:
++              parents:
++                description: |-
++                  Parents is a list of parent resources (usually Gateways) that are
++                  associated with the route, and the status of the route with respect to
++                  each parent. When this route attaches to a parent, the controller that
++                  manages the parent must add an entry to this list when the controller
++                  first sees the route and should update the entry as appropriate when the
++                  route or gateway is modified.
++
++                  Note that parent references that cannot be resolved by an implementation
++                  of this API will not be added to this list. Implementations of this API
++                  can only populate Route status for the Gateways/parent resources they are
++                  responsible for.
++
++                  A maximum of 32 Gateways will be represented in this list. An empty list
++                  means the route has not been attached to any Gateway.
++                items:
++                  description: |-
++                    RouteParentStatus describes the status of a route with respect to an
++                    associated Parent.
++                  properties:
++                    conditions:
++                      description: |-
++                        Conditions describes the status of the route with respect to the Gateway.
++                        Note that the route's availability is also subject to the Gateway's own
++                        status conditions and listener status.
++
++                        If the Route's ParentRef specifies an existing Gateway that supports
++                        Routes of this kind AND that Gateway's controller has sufficient access,
++                        then that Gateway's controller MUST set the "Accepted" condition on the
++                        Route, to indicate whether the route has been accepted or rejected by the
++                        Gateway, and why.
++
++                        A Route MUST be considered "Accepted" if at least one of the Route's
++                        rules is implemented by the Gateway.
++
++                        There are a number of cases where the "Accepted" condition may not be set
++                        due to lack of controller visibility, that includes when:
++
++                        * The Route refers to a nonexistent parent.
++                        * The Route is of a type that the controller does not support.
++                        * The Route is in a namespace to which the controller does not have access.
++                      items:
++                        description: Condition contains details for one aspect of
++                          the current state of this API Resource.
++                        properties:
++                          lastTransitionTime:
++                            description: |-
++                              lastTransitionTime is the last time the condition transitioned from one status to another.
++                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
++                            format: date-time
++                            type: string
++                          message:
++                            description: |-
++                              message is a human readable message indicating details about the transition.
++                              This may be an empty string.
++                            maxLength: 32768
++                            type: string
++                          observedGeneration:
++                            description: |-
++                              observedGeneration represents the .metadata.generation that the condition was set based upon.
++                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
++                              with respect to the current state of the instance.
++                            format: int64
++                            minimum: 0
++                            type: integer
++                          reason:
++                            description: |-
++                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
++                              Producers of specific condition types may define expected values and meanings for this field,
++                              and whether the values are considered a guaranteed API.
++                              The value should be a CamelCase string.
++                              This field may not be empty.
++                            maxLength: 1024
++                            minLength: 1
++                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
++                            type: string
++                          status:
++                            description: status of the condition, one of True, False,
++                              Unknown.
++                            enum:
++                            - "True"
++                            - "False"
++                            - Unknown
++                            type: string
++                          type:
++                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
++                            maxLength: 316
++                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
++                            type: string
++                        required:
++                        - lastTransitionTime
++                        - message
++                        - reason
++                        - status
++                        - type
++                        type: object
++                      maxItems: 8
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-map-keys:
++                      - type
++                      x-kubernetes-list-type: map
++                    controllerName:
++                      description: |-
++                        ControllerName is a domain/path string that indicates the name of the
++                        controller that wrote this status. This corresponds with the
++                        controllerName field on GatewayClass.
++
++                        Example: "example.net/gateway-controller".
++
++                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
++                        valid Kubernetes names
++                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
++
++                        Controllers MUST populate this field when writing status. Controllers should ensure that
++                        entries to status populated with their ControllerName are cleaned up when they are no
++                        longer necessary.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
++                      type: string
++                    parentRef:
++                      description: |-
++                        ParentRef corresponds with a ParentRef in the spec that this
++                        RouteParentStatus struct describes the status of.
++                      properties:
++                        group:
++                          default: gateway.networking.k8s.io
++                          description: |-
++                            Group is the group of the referent.
++                            When unspecified, "gateway.networking.k8s.io" is inferred.
++                            To set the core API group (such as for a "Service" kind referent),
++                            Group must be explicitly set to "" (empty string).
++
++                            Support: Core
++                          maxLength: 253
++                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                        kind:
++                          default: Gateway
++                          description: |-
++                            Kind is kind of the referent.
++
++                            There are two kinds of parent resources with "Core" support:
++
++                            * Gateway (Gateway conformance profile)
++                            * Service (Mesh conformance profile, ClusterIP Services only)
++
++                            Support for other resources is Implementation-Specific.
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                          type: string
++                        name:
++                          description: |-
++                            Name is the name of the referent.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          type: string
++                        namespace:
++                          description: |-
++                            Namespace is the namespace of the referent. When unspecified, this refers
++                            to the local namespace of the Route.
++
++                            Note that there are specific rules for ParentRefs which cross namespace
++                            boundaries. Cross-namespace references are only valid if they are explicitly
++                            allowed by something in the namespace they are referring to. For example:
++                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                            generic way to enable any other kind of cross-namespace reference.
++
++                            Support: Core
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                          type: string
++                        port:
++                          description: |-
++                            Port is the network port this Route targets. It can be interpreted
++                            differently based on the type of parent resource.
++
++                            When the parent resource is a Gateway, this targets all listeners
++                            listening on the specified port that also support this kind of Route(and
++                            select this Route). It's not recommended to set `Port` unless the
++                            networking behaviors specified in a Route must apply to a specific port
++                            as opposed to a listener(s) whose port(s) may be changed. When both Port
++                            and SectionName are specified, the name and port of the selected listener
++                            must match both specified values.
++
++                            Implementations MAY choose to support other parent resources.
++                            Implementations supporting other types of parent resources MUST clearly
++                            document how/if Port is interpreted.
++
++                            For the purpose of status, an attachment is considered successful as
++                            long as the parent resource accepts it partially. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                            from the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route,
++                            the Route MUST be considered detached from the Gateway.
++
++                            Support: Extended
++                          format: int32
++                          maximum: 65535
++                          minimum: 1
++                          type: integer
++                        sectionName:
++                          description: |-
++                            SectionName is the name of a section within the target resource. In the
++                            following resources, SectionName is interpreted as the following:
++
++                            * Gateway: Listener name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++                            * Service: Port name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++
++                            Implementations MAY choose to support attaching Routes to other resources.
++                            If that is the case, they MUST clearly document how SectionName is
++                            interpreted.
++
++                            When unspecified (empty string), this will reference the entire resource.
++                            For the purpose of status, an attachment is considered successful if at
++                            least one section in the parent resource accepts it. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                            the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route, the
++                            Route MUST be considered detached from the Gateway.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                      required:
++                      - name
++                      type: object
++                  required:
++                  - conditions
++                  - controllerName
++                  - parentRef
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - parents
++            type: object
++        required:
++        - spec
++        type: object
++    served: false
++    storage: false
++    subresources:
++      status: {}
+ ---
+ #
+ # config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+@@ -15364,8 +16651,9 @@
+ metadata:
+   annotations:
      api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-     gateway.networking.k8s.io/bundle-version: v1.5.1
+-    gateway.networking.k8s.io/bundle-version: v1.5.1
++    gateway.networking.k8s.io/bundle-version: v1.6.1
      gateway.networking.k8s.io/channel: standard
 +    helm.sh/resource-policy: keep
    name: tlsroutes.gateway.networking.k8s.io
  spec:
    group: gateway.networking.k8s.io
+@@ -15442,7 +16730,7 @@
+                   minLength: 1
+                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                   type: string
+-                maxItems: 16
++                maxItems: 1024
+                 minItems: 1
+                 type: array
+                 x-kubernetes-list-type: atomic
+@@ -15677,6 +16965,9 @@
+                         weight; if an invalid backend is requested to have 80% of requests, then
+                         80% of requests must be rejected instead.
+ 
++                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
++                        can be used to enable re-encryption of the traffic to the backends.
++
+                         Support: Core for Kubernetes Service
+ 
+                         Support: Extended for Kubernetes ServiceImport
+@@ -15684,6 +16975,8 @@
+                         Support: Implementation-specific for any other resource
+ 
+                         Support for weight: Extended
++
++                        Support for BackendTLSPolicy: Extended
+                       items:
+                         description: |-
+                           BackendRef defines how a Route should forward a request to a Kubernetes
+@@ -16159,7 +17452,7 @@
+                   minLength: 1
+                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                   type: string
+-                maxItems: 16
++                maxItems: 1024
+                 type: array
+                 x-kubernetes-list-type: atomic
+               parentRefs:
+@@ -16382,6 +17675,9 @@
+                         weight; if an invalid backend is requested to have 80% of requests, then
+                         80% of requests must be rejected instead.
+ 
++                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
++                        can be used to enable re-encryption of the traffic to the backends.
++
+                         Support: Core for Kubernetes Service
+ 
+                         Support: Extended for Kubernetes ServiceImport
+@@ -16389,6 +17685,8 @@
+                         Support: Implementation-specific for any other resource
+ 
+                         Support for weight: Extended
++
++                        Support for BackendTLSPolicy: Extended
+                       items:
+                         description: |-
+                           BackendRef defines how a Route should forward a request to a Kubernetes
+@@ -16840,7 +18138,7 @@
+                   minLength: 1
+                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                   type: string
+-                maxItems: 16
++                maxItems: 1024
+                 minItems: 1
+                 type: array
+                 x-kubernetes-list-type: atomic
+@@ -17075,6 +18373,9 @@
+                         weight; if an invalid backend is requested to have 80% of requests, then
+                         80% of requests must be rejected instead.
+ 
++                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
++                        can be used to enable re-encryption of the traffic to the backends.
++
+                         Support: Core for Kubernetes Service
+ 
+                         Support: Extended for Kubernetes ServiceImport
+@@ -17082,6 +18383,8 @@
+                         Support: Implementation-specific for any other resource
+ 
+                         Support for weight: Extended
++
++                        Support for BackendTLSPolicy: Extended
+                       items:
+                         description: |-
+                           BackendRef defines how a Route should forward a request to a Kubernetes
+@@ -17467,9 +18770,1300 @@
+     storage: false
+     subresources:
+       status: {}
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: null
+-  storedVersions: null
++---
++#
++# config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
++#
++apiVersion: apiextensions.k8s.io/v1
++kind: CustomResourceDefinition
++metadata:
++  annotations:
++    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
++    gateway.networking.k8s.io/bundle-version: v1.6.1
++    gateway.networking.k8s.io/channel: standard
++    helm.sh/resource-policy: keep
++  name: udproutes.gateway.networking.k8s.io
++spec:
++  group: gateway.networking.k8s.io
++  names:
++    categories:
++    - gateway-api
++    kind: UDPRoute
++    listKind: UDPRouteList
++    plural: udproutes
++    singular: udproute
++  scope: Namespaced
++  versions:
++  - additionalPrinterColumns:
++    - jsonPath: .metadata.creationTimestamp
++      name: Age
++      type: date
++    name: v1
++    schema:
++      openAPIV3Schema:
++        description: |-
++          UDPRoute provides a way to route UDP traffic. When combined with a Gateway
++          listener, it can be used to forward traffic on the port specified by the
++          listener to a set of backends specified by the UDPRoute.
++        properties:
++          apiVersion:
++            description: |-
++              APIVersion defines the versioned schema of this representation of an object.
++              Servers should convert recognized schemas to the latest internal value, and
++              may reject unrecognized values.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
++            type: string
++          kind:
++            description: |-
++              Kind is a string value representing the REST resource this object represents.
++              Servers may infer this from the endpoint the client submits requests to.
++              Cannot be updated.
++              In CamelCase.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
++            type: string
++          metadata:
++            type: object
++          spec:
++            description: Spec defines the desired state of UDPRoute.
++            properties:
++              parentRefs:
++                description: |-
++                  ParentRefs references the resources (usually Gateways) that a Route wants
++                  to be attached to. Note that the referenced parent resource needs to
++                  allow this for the attachment to be complete. For Gateways, that means
++                  the Gateway needs to allow attachment from Routes of this kind and
++                  namespace. For Services, that means the Service must either be in the same
++                  namespace for a "producer" route, or the mesh implementation must support
++                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
++                  not applicable for governing ParentRefs to Services - it is not possible to
++                  create a "producer" route for a Service in a different namespace from the
++                  Route.
++
++                  There are two kinds of parent resources with "Core" support:
++
++                  * Gateway (Gateway conformance profile)
++                  * Service (Mesh conformance profile, ClusterIP Services only)
++
++                  This API may be extended in the future to support additional kinds of parent
++                  resources.
++
++                  ParentRefs must be _distinct_. This means either that:
++
++                  * They select different objects.  If this is the case, then parentRef
++                    entries are distinct. In terms of fields, this means that the
++                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
++                    be unique across all parentRef entries in the Route.
++                  * They do not select different objects, but for each optional field used,
++                    each ParentRef that selects the same object must set the same set of
++                    optional fields to different values. If one ParentRef sets a
++                    combination of optional fields, all must set the same combination.
++
++                  Some examples:
++
++                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
++                    same object must also set `sectionName`.
++                  * If one ParentRef sets `port`, all ParentRefs referencing the same
++                    object must also set `port`.
++                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
++                    referencing the same object must also set `sectionName` and `port`.
++
++                  It is possible to separately reference multiple distinct objects that may
++                  be collapsed by an implementation. For example, some implementations may
++                  choose to merge compatible Gateway Listeners together. If that is the
++                  case, the list of routes attached to those resources should also be
++                  merged.
++
++                  Note that for ParentRefs that cross namespace boundaries, there are specific
++                  rules. Cross-namespace references are only valid if they are explicitly
++                  allowed by something in the namespace they are referring to. For example,
++                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                  generic way to enable other kinds of cross-namespace reference.
++                items:
++                  description: |-
++                    ParentReference identifies an API object (usually a Gateway) that can be considered
++                    a parent of this resource (usually a route). There are two kinds of parent resources
++                    with "Core" support:
++
++                    * Gateway (Gateway conformance profile)
++                    * Service (Mesh conformance profile, ClusterIP Services only)
++
++                    This API may be extended in the future to support additional kinds of parent
++                    resources.
++
++                    The API object must be valid in the cluster; the Group and Kind must
++                    be registered in the cluster for this reference to be valid.
++                  properties:
++                    group:
++                      default: gateway.networking.k8s.io
++                      description: |-
++                        Group is the group of the referent.
++                        When unspecified, "gateway.networking.k8s.io" is inferred.
++                        To set the core API group (such as for a "Service" kind referent),
++                        Group must be explicitly set to "" (empty string).
++
++                        Support: Core
++                      maxLength: 253
++                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                    kind:
++                      default: Gateway
++                      description: |-
++                        Kind is kind of the referent.
++
++                        There are two kinds of parent resources with "Core" support:
++
++                        * Gateway (Gateway conformance profile)
++                        * Service (Mesh conformance profile, ClusterIP Services only)
++
++                        Support for other resources is Implementation-Specific.
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                      type: string
++                    name:
++                      description: |-
++                        Name is the name of the referent.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      type: string
++                    namespace:
++                      description: |-
++                        Namespace is the namespace of the referent. When unspecified, this refers
++                        to the local namespace of the Route.
++
++                        Note that there are specific rules for ParentRefs which cross namespace
++                        boundaries. Cross-namespace references are only valid if they are explicitly
++                        allowed by something in the namespace they are referring to. For example:
++                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                        generic way to enable any other kind of cross-namespace reference.
++
++                        Support: Core
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                      type: string
++                    port:
++                      description: |-
++                        Port is the network port this Route targets. It can be interpreted
++                        differently based on the type of parent resource.
++
++                        When the parent resource is a Gateway, this targets all listeners
++                        listening on the specified port that also support this kind of Route(and
++                        select this Route). It's not recommended to set `Port` unless the
++                        networking behaviors specified in a Route must apply to a specific port
++                        as opposed to a listener(s) whose port(s) may be changed. When both Port
++                        and SectionName are specified, the name and port of the selected listener
++                        must match both specified values.
++
++                        Implementations MAY choose to support other parent resources.
++                        Implementations supporting other types of parent resources MUST clearly
++                        document how/if Port is interpreted.
++
++                        For the purpose of status, an attachment is considered successful as
++                        long as the parent resource accepts it partially. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                        from the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route,
++                        the Route MUST be considered detached from the Gateway.
++
++                        Support: Extended
++                      format: int32
++                      maximum: 65535
++                      minimum: 1
++                      type: integer
++                    sectionName:
++                      description: |-
++                        SectionName is the name of a section within the target resource. In the
++                        following resources, SectionName is interpreted as the following:
++
++                        * Gateway: Listener name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++                        * Service: Port name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++
++                        Implementations MAY choose to support attaching Routes to other resources.
++                        If that is the case, they MUST clearly document how SectionName is
++                        interpreted.
++
++                        When unspecified (empty string), this will reference the entire resource.
++                        For the purpose of status, an attachment is considered successful if at
++                        least one section in the parent resource accepts it. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                        the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route, the
++                        Route MUST be considered detached from the Gateway.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - name
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++                x-kubernetes-validations:
++                - message: sectionName must be specified when parentRefs includes
++                    2 or more references to the same parent
++                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
++                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
++                    == '''')) : true))'
++                - message: sectionName must be unique when parentRefs includes 2 or
++                    more references to the same parent
++                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
++                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
++                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
++                    == p2.sectionName))))
++              rules:
++                description: Rules are a list of UDP matchers and actions.
++                items:
++                  description: UDPRouteRule is the configuration for a given rule.
++                  properties:
++                    backendRefs:
++                      description: |-
++                        BackendRefs defines the backend(s) where matching requests should be
++                        sent. If unspecified or invalid (refers to a nonexistent resource or a
++                        Service with no endpoints), the underlying implementation MUST actively
++                        reject connection attempts to this backend. Packet drops must
++                        respect weight; if an invalid backend is requested to have 80% of
++                        the packets, then 80% of packets must be dropped instead.
++
++                        Support: Extended for Kubernetes Service
++                      items:
++                        description: |-
++                          BackendRef defines how a Route should forward a request to a Kubernetes
++                          resource.
++
++                          Note that when a namespace different than the local namespace is specified, a
++                          ReferenceGrant object is required in the referent namespace to allow that
++                          namespace's owner to accept the reference. See the ReferenceGrant
++                          documentation for details.
++
++                          Note that when the BackendTLSPolicy object is enabled by the implementation,
++                          there are some extra rules about validity to consider here. See the fields
++                          where this struct is used for more information about the exact behavior.
++                        properties:
++                          group:
++                            default: ""
++                            description: |-
++                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
++                              When unspecified or empty string, core API group is inferred.
++                            maxLength: 253
++                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                            type: string
++                          kind:
++                            default: Service
++                            description: |-
++                              Kind is the Kubernetes resource kind of the referent. For example
++                              "Service".
++
++                              Defaults to "Service" when not specified.
++
++                              ExternalName services can refer to CNAME DNS records that may live
++                              outside of the cluster and as such are difficult to reason about in
++                              terms of conformance. They also may not be safe to forward to (see
++                              CVE-2021-25740 for more information). Implementations SHOULD NOT
++                              support ExternalName Services.
++
++                              Support: Core (Services with a type other than ExternalName)
++
++                              Support: Implementation-specific (Services with type ExternalName)
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                            type: string
++                          name:
++                            description: Name is the name of the referent.
++                            maxLength: 253
++                            minLength: 1
++                            type: string
++                          namespace:
++                            description: |-
++                              Namespace is the namespace of the backend. When unspecified, the local
++                              namespace is inferred.
++
++                              Note that when a namespace different than the local namespace is specified,
++                              a ReferenceGrant object is required in the referent namespace to allow that
++                              namespace's owner to accept the reference. See the ReferenceGrant
++                              documentation for details.
++
++                              Support: Core
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                            type: string
++                          port:
++                            description: |-
++                              Port specifies the destination port number to use for this resource.
++                              Port is required when the referent is a Kubernetes Service. In this
++                              case, the port number is the service port number, not the target port.
++                              For other resources, destination port might be derived from the referent
++                              resource or this field.
++                            format: int32
++                            maximum: 65535
++                            minimum: 1
++                            type: integer
++                          weight:
++                            default: 1
++                            description: |-
++                              Weight specifies the proportion of requests forwarded to the referenced
++                              backend. This is computed as weight/(sum of all weights in this
++                              BackendRefs list). For non-zero values, there may be some epsilon from
++                              the exact proportion defined here depending on the precision an
++                              implementation supports. Weight is not a percentage and the sum of
++                              weights does not need to equal 100.
++
++                              If only one backend is specified and it has a weight greater than 0, 100%
++                              of the traffic is forwarded to that backend. If weight is set to 0, no
++                              traffic should be forwarded for this entry. If unspecified, weight
++                              defaults to 1.
++
++                              Support for this field varies based on the context where used.
++                            format: int32
++                            maximum: 1000000
++                            minimum: 0
++                            type: integer
++                        required:
++                        - name
++                        type: object
++                        x-kubernetes-validations:
++                        - message: Must have port for Service reference
++                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
++                            ? has(self.port) : true'
++                      maxItems: 16
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-type: atomic
++                    name:
++                      description: Name is the name of the route rule. This name MUST
++                        be unique within a Route if it is set.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - backendRefs
++                  type: object
++                maxItems: 1
++                minItems: 1
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - rules
++            type: object
++          status:
++            description: Status defines the current state of UDPRoute.
++            properties:
++              parents:
++                description: |-
++                  Parents is a list of parent resources (usually Gateways) that are
++                  associated with the route, and the status of the route with respect to
++                  each parent. When this route attaches to a parent, the controller that
++                  manages the parent must add an entry to this list when the controller
++                  first sees the route and should update the entry as appropriate when the
++                  route or gateway is modified.
++
++                  Note that parent references that cannot be resolved by an implementation
++                  of this API will not be added to this list. Implementations of this API
++                  can only populate Route status for the Gateways/parent resources they are
++                  responsible for.
++
++                  A maximum of 32 Gateways will be represented in this list. An empty list
++                  means the route has not been attached to any Gateway.
++                items:
++                  description: |-
++                    RouteParentStatus describes the status of a route with respect to an
++                    associated Parent.
++                  properties:
++                    conditions:
++                      description: |-
++                        Conditions describes the status of the route with respect to the Gateway.
++                        Note that the route's availability is also subject to the Gateway's own
++                        status conditions and listener status.
++
++                        If the Route's ParentRef specifies an existing Gateway that supports
++                        Routes of this kind AND that Gateway's controller has sufficient access,
++                        then that Gateway's controller MUST set the "Accepted" condition on the
++                        Route, to indicate whether the route has been accepted or rejected by the
++                        Gateway, and why.
++
++                        A Route MUST be considered "Accepted" if at least one of the Route's
++                        rules is implemented by the Gateway.
++
++                        There are a number of cases where the "Accepted" condition may not be set
++                        due to lack of controller visibility, that includes when:
++
++                        * The Route refers to a nonexistent parent.
++                        * The Route is of a type that the controller does not support.
++                        * The Route is in a namespace to which the controller does not have access.
++                      items:
++                        description: Condition contains details for one aspect of
++                          the current state of this API Resource.
++                        properties:
++                          lastTransitionTime:
++                            description: |-
++                              lastTransitionTime is the last time the condition transitioned from one status to another.
++                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
++                            format: date-time
++                            type: string
++                          message:
++                            description: |-
++                              message is a human readable message indicating details about the transition.
++                              This may be an empty string.
++                            maxLength: 32768
++                            type: string
++                          observedGeneration:
++                            description: |-
++                              observedGeneration represents the .metadata.generation that the condition was set based upon.
++                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
++                              with respect to the current state of the instance.
++                            format: int64
++                            minimum: 0
++                            type: integer
++                          reason:
++                            description: |-
++                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
++                              Producers of specific condition types may define expected values and meanings for this field,
++                              and whether the values are considered a guaranteed API.
++                              The value should be a CamelCase string.
++                              This field may not be empty.
++                            maxLength: 1024
++                            minLength: 1
++                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
++                            type: string
++                          status:
++                            description: status of the condition, one of True, False,
++                              Unknown.
++                            enum:
++                            - "True"
++                            - "False"
++                            - Unknown
++                            type: string
++                          type:
++                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
++                            maxLength: 316
++                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
++                            type: string
++                        required:
++                        - lastTransitionTime
++                        - message
++                        - reason
++                        - status
++                        - type
++                        type: object
++                      maxItems: 8
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-map-keys:
++                      - type
++                      x-kubernetes-list-type: map
++                    controllerName:
++                      description: |-
++                        ControllerName is a domain/path string that indicates the name of the
++                        controller that wrote this status. This corresponds with the
++                        controllerName field on GatewayClass.
++
++                        Example: "example.net/gateway-controller".
++
++                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
++                        valid Kubernetes names
++                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
++
++                        Controllers MUST populate this field when writing status. Controllers should ensure that
++                        entries to status populated with their ControllerName are cleaned up when they are no
++                        longer necessary.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
++                      type: string
++                    parentRef:
++                      description: |-
++                        ParentRef corresponds with a ParentRef in the spec that this
++                        RouteParentStatus struct describes the status of.
++                      properties:
++                        group:
++                          default: gateway.networking.k8s.io
++                          description: |-
++                            Group is the group of the referent.
++                            When unspecified, "gateway.networking.k8s.io" is inferred.
++                            To set the core API group (such as for a "Service" kind referent),
++                            Group must be explicitly set to "" (empty string).
++
++                            Support: Core
++                          maxLength: 253
++                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                        kind:
++                          default: Gateway
++                          description: |-
++                            Kind is kind of the referent.
++
++                            There are two kinds of parent resources with "Core" support:
++
++                            * Gateway (Gateway conformance profile)
++                            * Service (Mesh conformance profile, ClusterIP Services only)
++
++                            Support for other resources is Implementation-Specific.
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                          type: string
++                        name:
++                          description: |-
++                            Name is the name of the referent.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          type: string
++                        namespace:
++                          description: |-
++                            Namespace is the namespace of the referent. When unspecified, this refers
++                            to the local namespace of the Route.
++
++                            Note that there are specific rules for ParentRefs which cross namespace
++                            boundaries. Cross-namespace references are only valid if they are explicitly
++                            allowed by something in the namespace they are referring to. For example:
++                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                            generic way to enable any other kind of cross-namespace reference.
++
++                            Support: Core
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                          type: string
++                        port:
++                          description: |-
++                            Port is the network port this Route targets. It can be interpreted
++                            differently based on the type of parent resource.
++
++                            When the parent resource is a Gateway, this targets all listeners
++                            listening on the specified port that also support this kind of Route(and
++                            select this Route). It's not recommended to set `Port` unless the
++                            networking behaviors specified in a Route must apply to a specific port
++                            as opposed to a listener(s) whose port(s) may be changed. When both Port
++                            and SectionName are specified, the name and port of the selected listener
++                            must match both specified values.
++
++                            Implementations MAY choose to support other parent resources.
++                            Implementations supporting other types of parent resources MUST clearly
++                            document how/if Port is interpreted.
++
++                            For the purpose of status, an attachment is considered successful as
++                            long as the parent resource accepts it partially. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                            from the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route,
++                            the Route MUST be considered detached from the Gateway.
++
++                            Support: Extended
++                          format: int32
++                          maximum: 65535
++                          minimum: 1
++                          type: integer
++                        sectionName:
++                          description: |-
++                            SectionName is the name of a section within the target resource. In the
++                            following resources, SectionName is interpreted as the following:
++
++                            * Gateway: Listener name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++                            * Service: Port name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++
++                            Implementations MAY choose to support attaching Routes to other resources.
++                            If that is the case, they MUST clearly document how SectionName is
++                            interpreted.
++
++                            When unspecified (empty string), this will reference the entire resource.
++                            For the purpose of status, an attachment is considered successful if at
++                            least one section in the parent resource accepts it. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                            the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route, the
++                            Route MUST be considered detached from the Gateway.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                      required:
++                      - name
++                      type: object
++                  required:
++                  - conditions
++                  - controllerName
++                  - parentRef
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - parents
++            type: object
++        required:
++        - spec
++        type: object
++    served: true
++    storage: true
++    subresources:
++      status: {}
++  - additionalPrinterColumns:
++    - jsonPath: .metadata.creationTimestamp
++      name: Age
++      type: date
++    deprecated: true
++    deprecationWarning: The v1alpha2 version of UDPRoute has been deprecated and will
++      be removed in a future release of the API. Please upgrade to v1.
++    name: v1alpha2
++    schema:
++      openAPIV3Schema:
++        description: |-
++          UDPRoute provides a way to route UDP traffic. When combined with a Gateway
++          listener, it can be used to forward traffic on the port specified by the
++          listener to a set of backends specified by the UDPRoute.
++        properties:
++          apiVersion:
++            description: |-
++              APIVersion defines the versioned schema of this representation of an object.
++              Servers should convert recognized schemas to the latest internal value, and
++              may reject unrecognized values.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
++            type: string
++          kind:
++            description: |-
++              Kind is a string value representing the REST resource this object represents.
++              Servers may infer this from the endpoint the client submits requests to.
++              Cannot be updated.
++              In CamelCase.
++              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
++            type: string
++          metadata:
++            type: object
++          spec:
++            description: Spec defines the desired state of UDPRoute.
++            properties:
++              parentRefs:
++                description: |-
++                  ParentRefs references the resources (usually Gateways) that a Route wants
++                  to be attached to. Note that the referenced parent resource needs to
++                  allow this for the attachment to be complete. For Gateways, that means
++                  the Gateway needs to allow attachment from Routes of this kind and
++                  namespace. For Services, that means the Service must either be in the same
++                  namespace for a "producer" route, or the mesh implementation must support
++                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
++                  not applicable for governing ParentRefs to Services - it is not possible to
++                  create a "producer" route for a Service in a different namespace from the
++                  Route.
++
++                  There are two kinds of parent resources with "Core" support:
++
++                  * Gateway (Gateway conformance profile)
++                  * Service (Mesh conformance profile, ClusterIP Services only)
++
++                  This API may be extended in the future to support additional kinds of parent
++                  resources.
++
++                  ParentRefs must be _distinct_. This means either that:
++
++                  * They select different objects.  If this is the case, then parentRef
++                    entries are distinct. In terms of fields, this means that the
++                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
++                    be unique across all parentRef entries in the Route.
++                  * They do not select different objects, but for each optional field used,
++                    each ParentRef that selects the same object must set the same set of
++                    optional fields to different values. If one ParentRef sets a
++                    combination of optional fields, all must set the same combination.
++
++                  Some examples:
++
++                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
++                    same object must also set `sectionName`.
++                  * If one ParentRef sets `port`, all ParentRefs referencing the same
++                    object must also set `port`.
++                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
++                    referencing the same object must also set `sectionName` and `port`.
++
++                  It is possible to separately reference multiple distinct objects that may
++                  be collapsed by an implementation. For example, some implementations may
++                  choose to merge compatible Gateway Listeners together. If that is the
++                  case, the list of routes attached to those resources should also be
++                  merged.
++
++                  Note that for ParentRefs that cross namespace boundaries, there are specific
++                  rules. Cross-namespace references are only valid if they are explicitly
++                  allowed by something in the namespace they are referring to. For example,
++                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                  generic way to enable other kinds of cross-namespace reference.
++                items:
++                  description: |-
++                    ParentReference identifies an API object (usually a Gateway) that can be considered
++                    a parent of this resource (usually a route). There are two kinds of parent resources
++                    with "Core" support:
++
++                    * Gateway (Gateway conformance profile)
++                    * Service (Mesh conformance profile, ClusterIP Services only)
++
++                    This API may be extended in the future to support additional kinds of parent
++                    resources.
++
++                    The API object must be valid in the cluster; the Group and Kind must
++                    be registered in the cluster for this reference to be valid.
++                  properties:
++                    group:
++                      default: gateway.networking.k8s.io
++                      description: |-
++                        Group is the group of the referent.
++                        When unspecified, "gateway.networking.k8s.io" is inferred.
++                        To set the core API group (such as for a "Service" kind referent),
++                        Group must be explicitly set to "" (empty string).
++
++                        Support: Core
++                      maxLength: 253
++                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                    kind:
++                      default: Gateway
++                      description: |-
++                        Kind is kind of the referent.
++
++                        There are two kinds of parent resources with "Core" support:
++
++                        * Gateway (Gateway conformance profile)
++                        * Service (Mesh conformance profile, ClusterIP Services only)
++
++                        Support for other resources is Implementation-Specific.
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                      type: string
++                    name:
++                      description: |-
++                        Name is the name of the referent.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      type: string
++                    namespace:
++                      description: |-
++                        Namespace is the namespace of the referent. When unspecified, this refers
++                        to the local namespace of the Route.
++
++                        Note that there are specific rules for ParentRefs which cross namespace
++                        boundaries. Cross-namespace references are only valid if they are explicitly
++                        allowed by something in the namespace they are referring to. For example:
++                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                        generic way to enable any other kind of cross-namespace reference.
++
++                        Support: Core
++                      maxLength: 63
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                      type: string
++                    port:
++                      description: |-
++                        Port is the network port this Route targets. It can be interpreted
++                        differently based on the type of parent resource.
++
++                        When the parent resource is a Gateway, this targets all listeners
++                        listening on the specified port that also support this kind of Route(and
++                        select this Route). It's not recommended to set `Port` unless the
++                        networking behaviors specified in a Route must apply to a specific port
++                        as opposed to a listener(s) whose port(s) may be changed. When both Port
++                        and SectionName are specified, the name and port of the selected listener
++                        must match both specified values.
++
++                        Implementations MAY choose to support other parent resources.
++                        Implementations supporting other types of parent resources MUST clearly
++                        document how/if Port is interpreted.
++
++                        For the purpose of status, an attachment is considered successful as
++                        long as the parent resource accepts it partially. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                        from the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route,
++                        the Route MUST be considered detached from the Gateway.
++
++                        Support: Extended
++                      format: int32
++                      maximum: 65535
++                      minimum: 1
++                      type: integer
++                    sectionName:
++                      description: |-
++                        SectionName is the name of a section within the target resource. In the
++                        following resources, SectionName is interpreted as the following:
++
++                        * Gateway: Listener name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++                        * Service: Port name. When both Port (experimental) and SectionName
++                        are specified, the name and port of the selected listener must match
++                        both specified values.
++
++                        Implementations MAY choose to support attaching Routes to other resources.
++                        If that is the case, they MUST clearly document how SectionName is
++                        interpreted.
++
++                        When unspecified (empty string), this will reference the entire resource.
++                        For the purpose of status, an attachment is considered successful if at
++                        least one section in the parent resource accepts it. For example, Gateway
++                        listeners can restrict which Routes can attach to them by Route kind,
++                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                        the referencing Route, the Route MUST be considered successfully
++                        attached. If no Gateway listeners accept attachment from this Route, the
++                        Route MUST be considered detached from the Gateway.
++
++                        Support: Core
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - name
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++                x-kubernetes-validations:
++                - message: sectionName must be specified when parentRefs includes
++                    2 or more references to the same parent
++                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
++                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
++                    == '''')) : true))'
++                - message: sectionName must be unique when parentRefs includes 2 or
++                    more references to the same parent
++                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
++                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
++                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
++                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
++                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
++                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
++                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
++                    == p2.sectionName))))
++              rules:
++                description: Rules are a list of UDP matchers and actions.
++                items:
++                  description: UDPRouteRule is the configuration for a given rule.
++                  properties:
++                    backendRefs:
++                      description: |-
++                        BackendRefs defines the backend(s) where matching requests should be
++                        sent. If unspecified or invalid (refers to a nonexistent resource or a
++                        Service with no endpoints), the underlying implementation MUST actively
++                        reject connection attempts to this backend. Packet drops must
++                        respect weight; if an invalid backend is requested to have 80% of
++                        the packets, then 80% of packets must be dropped instead.
++
++                        Support: Extended for Kubernetes Service
++                      items:
++                        description: |-
++                          BackendRef defines how a Route should forward a request to a Kubernetes
++                          resource.
++
++                          Note that when a namespace different than the local namespace is specified, a
++                          ReferenceGrant object is required in the referent namespace to allow that
++                          namespace's owner to accept the reference. See the ReferenceGrant
++                          documentation for details.
++
++                          Note that when the BackendTLSPolicy object is enabled by the implementation,
++                          there are some extra rules about validity to consider here. See the fields
++                          where this struct is used for more information about the exact behavior.
++                        properties:
++                          group:
++                            default: ""
++                            description: |-
++                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
++                              When unspecified or empty string, core API group is inferred.
++                            maxLength: 253
++                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                            type: string
++                          kind:
++                            default: Service
++                            description: |-
++                              Kind is the Kubernetes resource kind of the referent. For example
++                              "Service".
++
++                              Defaults to "Service" when not specified.
++
++                              ExternalName services can refer to CNAME DNS records that may live
++                              outside of the cluster and as such are difficult to reason about in
++                              terms of conformance. They also may not be safe to forward to (see
++                              CVE-2021-25740 for more information). Implementations SHOULD NOT
++                              support ExternalName Services.
++
++                              Support: Core (Services with a type other than ExternalName)
++
++                              Support: Implementation-specific (Services with type ExternalName)
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                            type: string
++                          name:
++                            description: Name is the name of the referent.
++                            maxLength: 253
++                            minLength: 1
++                            type: string
++                          namespace:
++                            description: |-
++                              Namespace is the namespace of the backend. When unspecified, the local
++                              namespace is inferred.
++
++                              Note that when a namespace different than the local namespace is specified,
++                              a ReferenceGrant object is required in the referent namespace to allow that
++                              namespace's owner to accept the reference. See the ReferenceGrant
++                              documentation for details.
++
++                              Support: Core
++                            maxLength: 63
++                            minLength: 1
++                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                            type: string
++                          port:
++                            description: |-
++                              Port specifies the destination port number to use for this resource.
++                              Port is required when the referent is a Kubernetes Service. In this
++                              case, the port number is the service port number, not the target port.
++                              For other resources, destination port might be derived from the referent
++                              resource or this field.
++                            format: int32
++                            maximum: 65535
++                            minimum: 1
++                            type: integer
++                          weight:
++                            default: 1
++                            description: |-
++                              Weight specifies the proportion of requests forwarded to the referenced
++                              backend. This is computed as weight/(sum of all weights in this
++                              BackendRefs list). For non-zero values, there may be some epsilon from
++                              the exact proportion defined here depending on the precision an
++                              implementation supports. Weight is not a percentage and the sum of
++                              weights does not need to equal 100.
++
++                              If only one backend is specified and it has a weight greater than 0, 100%
++                              of the traffic is forwarded to that backend. If weight is set to 0, no
++                              traffic should be forwarded for this entry. If unspecified, weight
++                              defaults to 1.
++
++                              Support for this field varies based on the context where used.
++                            format: int32
++                            maximum: 1000000
++                            minimum: 0
++                            type: integer
++                        required:
++                        - name
++                        type: object
++                        x-kubernetes-validations:
++                        - message: Must have port for Service reference
++                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
++                            ? has(self.port) : true'
++                      maxItems: 16
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-type: atomic
++                    name:
++                      description: Name is the name of the route rule. This name MUST
++                        be unique within a Route if it is set.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                      type: string
++                  required:
++                  - backendRefs
++                  type: object
++                maxItems: 16
++                minItems: 1
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - rules
++            type: object
++          status:
++            description: Status defines the current state of UDPRoute.
++            properties:
++              parents:
++                description: |-
++                  Parents is a list of parent resources (usually Gateways) that are
++                  associated with the route, and the status of the route with respect to
++                  each parent. When this route attaches to a parent, the controller that
++                  manages the parent must add an entry to this list when the controller
++                  first sees the route and should update the entry as appropriate when the
++                  route or gateway is modified.
++
++                  Note that parent references that cannot be resolved by an implementation
++                  of this API will not be added to this list. Implementations of this API
++                  can only populate Route status for the Gateways/parent resources they are
++                  responsible for.
++
++                  A maximum of 32 Gateways will be represented in this list. An empty list
++                  means the route has not been attached to any Gateway.
++                items:
++                  description: |-
++                    RouteParentStatus describes the status of a route with respect to an
++                    associated Parent.
++                  properties:
++                    conditions:
++                      description: |-
++                        Conditions describes the status of the route with respect to the Gateway.
++                        Note that the route's availability is also subject to the Gateway's own
++                        status conditions and listener status.
++
++                        If the Route's ParentRef specifies an existing Gateway that supports
++                        Routes of this kind AND that Gateway's controller has sufficient access,
++                        then that Gateway's controller MUST set the "Accepted" condition on the
++                        Route, to indicate whether the route has been accepted or rejected by the
++                        Gateway, and why.
++
++                        A Route MUST be considered "Accepted" if at least one of the Route's
++                        rules is implemented by the Gateway.
++
++                        There are a number of cases where the "Accepted" condition may not be set
++                        due to lack of controller visibility, that includes when:
++
++                        * The Route refers to a nonexistent parent.
++                        * The Route is of a type that the controller does not support.
++                        * The Route is in a namespace to which the controller does not have access.
++                      items:
++                        description: Condition contains details for one aspect of
++                          the current state of this API Resource.
++                        properties:
++                          lastTransitionTime:
++                            description: |-
++                              lastTransitionTime is the last time the condition transitioned from one status to another.
++                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
++                            format: date-time
++                            type: string
++                          message:
++                            description: |-
++                              message is a human readable message indicating details about the transition.
++                              This may be an empty string.
++                            maxLength: 32768
++                            type: string
++                          observedGeneration:
++                            description: |-
++                              observedGeneration represents the .metadata.generation that the condition was set based upon.
++                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
++                              with respect to the current state of the instance.
++                            format: int64
++                            minimum: 0
++                            type: integer
++                          reason:
++                            description: |-
++                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
++                              Producers of specific condition types may define expected values and meanings for this field,
++                              and whether the values are considered a guaranteed API.
++                              The value should be a CamelCase string.
++                              This field may not be empty.
++                            maxLength: 1024
++                            minLength: 1
++                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
++                            type: string
++                          status:
++                            description: status of the condition, one of True, False,
++                              Unknown.
++                            enum:
++                            - "True"
++                            - "False"
++                            - Unknown
++                            type: string
++                          type:
++                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
++                            maxLength: 316
++                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
++                            type: string
++                        required:
++                        - lastTransitionTime
++                        - message
++                        - reason
++                        - status
++                        - type
++                        type: object
++                      maxItems: 8
++                      minItems: 1
++                      type: array
++                      x-kubernetes-list-map-keys:
++                      - type
++                      x-kubernetes-list-type: map
++                    controllerName:
++                      description: |-
++                        ControllerName is a domain/path string that indicates the name of the
++                        controller that wrote this status. This corresponds with the
++                        controllerName field on GatewayClass.
++
++                        Example: "example.net/gateway-controller".
++
++                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
++                        valid Kubernetes names
++                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
++
++                        Controllers MUST populate this field when writing status. Controllers should ensure that
++                        entries to status populated with their ControllerName are cleaned up when they are no
++                        longer necessary.
++                      maxLength: 253
++                      minLength: 1
++                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
++                      type: string
++                    parentRef:
++                      description: |-
++                        ParentRef corresponds with a ParentRef in the spec that this
++                        RouteParentStatus struct describes the status of.
++                      properties:
++                        group:
++                          default: gateway.networking.k8s.io
++                          description: |-
++                            Group is the group of the referent.
++                            When unspecified, "gateway.networking.k8s.io" is inferred.
++                            To set the core API group (such as for a "Service" kind referent),
++                            Group must be explicitly set to "" (empty string).
++
++                            Support: Core
++                          maxLength: 253
++                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                        kind:
++                          default: Gateway
++                          description: |-
++                            Kind is kind of the referent.
++
++                            There are two kinds of parent resources with "Core" support:
++
++                            * Gateway (Gateway conformance profile)
++                            * Service (Mesh conformance profile, ClusterIP Services only)
++
++                            Support for other resources is Implementation-Specific.
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
++                          type: string
++                        name:
++                          description: |-
++                            Name is the name of the referent.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          type: string
++                        namespace:
++                          description: |-
++                            Namespace is the namespace of the referent. When unspecified, this refers
++                            to the local namespace of the Route.
++
++                            Note that there are specific rules for ParentRefs which cross namespace
++                            boundaries. Cross-namespace references are only valid if they are explicitly
++                            allowed by something in the namespace they are referring to. For example:
++                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
++                            generic way to enable any other kind of cross-namespace reference.
++
++                            Support: Core
++                          maxLength: 63
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
++                          type: string
++                        port:
++                          description: |-
++                            Port is the network port this Route targets. It can be interpreted
++                            differently based on the type of parent resource.
++
++                            When the parent resource is a Gateway, this targets all listeners
++                            listening on the specified port that also support this kind of Route(and
++                            select this Route). It's not recommended to set `Port` unless the
++                            networking behaviors specified in a Route must apply to a specific port
++                            as opposed to a listener(s) whose port(s) may be changed. When both Port
++                            and SectionName are specified, the name and port of the selected listener
++                            must match both specified values.
++
++                            Implementations MAY choose to support other parent resources.
++                            Implementations supporting other types of parent resources MUST clearly
++                            document how/if Port is interpreted.
++
++                            For the purpose of status, an attachment is considered successful as
++                            long as the parent resource accepts it partially. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
++                            from the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route,
++                            the Route MUST be considered detached from the Gateway.
++
++                            Support: Extended
++                          format: int32
++                          maximum: 65535
++                          minimum: 1
++                          type: integer
++                        sectionName:
++                          description: |-
++                            SectionName is the name of a section within the target resource. In the
++                            following resources, SectionName is interpreted as the following:
++
++                            * Gateway: Listener name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++                            * Service: Port name. When both Port (experimental) and SectionName
++                            are specified, the name and port of the selected listener must match
++                            both specified values.
++
++                            Implementations MAY choose to support attaching Routes to other resources.
++                            If that is the case, they MUST clearly document how SectionName is
++                            interpreted.
++
++                            When unspecified (empty string), this will reference the entire resource.
++                            For the purpose of status, an attachment is considered successful if at
++                            least one section in the parent resource accepts it. For example, Gateway
++                            listeners can restrict which Routes can attach to them by Route kind,
++                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
++                            the referencing Route, the Route MUST be considered successfully
++                            attached. If no Gateway listeners accept attachment from this Route, the
++                            Route MUST be considered detached from the Gateway.
++
++                            Support: Core
++                          maxLength: 253
++                          minLength: 1
++                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
++                          type: string
++                      required:
++                      - name
++                      type: object
++                  required:
++                  - conditions
++                  - controllerName
++                  - parentRef
++                  type: object
++                maxItems: 32
++                type: array
++                x-kubernetes-list-type: atomic
++            required:
++            - parents
++            type: object
++        required:
++        - spec
++        type: object
++    served: false
++    storage: false
++    subresources:
++      status: {}

--- a/packages/rke2-traefik-1.34-1.36/package.yaml
+++ b/packages/rke2-traefik-1.34-1.36/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
-packageVersion: 10
+packageVersion: 11
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 


### PR DESCRIPTION
There is a new gateway API release: 1.6.1.

In RKE2 1.34, 1.35 and 1.36 we are installing GatewayAPI using the Traefik chart. We must update the rke2-traefik-1.34-1.36 when new gateway api versions are released