### PR TITLE
add rke2-multus-1.34-1.36

### DIFF
--- a/packages/rke2-multus-1.34-1.36/charts/.helmignore
+++ b/packages/rke2-multus-1.34-1.36/charts/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/rke2-multus-1.34-1.36/charts/Chart.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+appVersion: 4.3.0
+dependencies:
+- condition: rke2-whereabouts.enabled
+  name: rke2-whereabouts
+  repository: file://./charts/rke2-whereabouts
+description: Multus Helm chart for Kubernetes
+home: https://github.com/k8snetworkplumbingwg/multus-cni
+icon: https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/doc/images/Multus.png
+maintainers:
+- email: charts@rancher.com
+  name: Rancher Labs
+name: rke2-multus
+sources:
+- https://github.com/intel/multus-cni
+type: application
+version: v4.3.0

--- a/packages/rke2-multus-1.34-1.36/charts/templates/NOTES.txt
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/NOTES.txt
@@ -1,0 +1,33 @@
+======
+1. The following components have been deployed as part of this helm chart:
+{{- if .Values.manifests.clusterRole }}
+Cluster Role: {{ .Values.serviceAccount.name }}
+{{- end}}
+{{- if .Values.manifests.clusterRoleBinding }}
+Cluster Role Binding: {{ .Chart.Name }}
+{{- end }}
+{{- if .Values.manifests.configMap }}
+Config Map: {{ .Release.Name }}-{{ .Chart.Version }}-config
+{{- end }}
+{{- if .Values.manifests.customResourceDefinition }}
+Custom Resource Definition: network-attachment-definitions.k8s.cni.cncf.io
+{{- end }}
+{{- if .Values.manifests.daemonSet }}
+Daemon Set: {{ .Release.Name }}
+{{- end }}
+{{- if .Values.manifests.dhcpDaemonSet }}
+Daemon Set: {{ .Release.Name }}-dhcp
+{{- end}}
+{{- if .Values.manifests.serviceAccount }}
+Service Account: {{ .Values.serviceAccount.name }}
+{{- end }}
+
+You can now deploy any other CNI and create its Network Attachment Defintion.
+---------
+
+2. To uninstall helm chart use the command:
+helm delete {{ .Release.Name }}
+
+You may have to manually delete CRD -
+kubectl delete crd network-attachment-definitions.k8s.cni.cncf.io
+---------

--- a/packages/rke2-multus-1.34-1.36/charts/templates/_helpers.tpl
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{/* Generate basic labels */}}
+{{- define "multus.labels" }}
+tier: node
+app: {{ .Chart.Name }}
+{{- end }}
+
+{{- define "dynamicNetworksController.labels" }}
+tier: node
+app: {{ .Chart.Name }}-dnc
+{{- end }}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/clusterRole.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/clusterRole.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.clusterRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}
+rules:
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/status
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/clusterRoleBinding.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/clusterRoleBinding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.clusterRoleBinding }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/configMap.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/configMap.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.configMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Version }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "multus.labels" . | indent 4 }}
+data:
+{{- if .Values.thickPlugin.enabled }}
+  daemon-config.json: |-
+{{ toJson .Values.config.daemon_conf | indent 4 }}
+{{- else }}
+  cni-conf.json: |-
+{{ toJson .Values.config.cni_conf | indent 4 }}
+{{- end }}
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/customResourceDefinition.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/customResourceDefinition.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.customResourceDefinition }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+      helm.sh/resource-policy: keep
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+    - net-attach-def
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                config:
+                  type: string
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/daemonSet-thick.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/daemonSet-thick.yaml
@@ -1,0 +1,160 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.daemonSet }}
+{{- if .Values.thickPlugin.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "multus.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+{{- include "multus.labels" . | indent 8 }}
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      initContainers:
+      - name: cni-plugins
+        image: {{ template "system_default_registry" . }}{{ .Values.cniplugins.image.repository }}:{{ .Values.cniplugins.image.tag }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: {{ .Values.cniplugins.skipcnis }}
+      - name: install-multus-binary
+        image: {{ template "system_default_registry" . }}{{ .Values.thickPlugin.image.repository }}:{{ .Values.thickPlugin.image.tag }}
+        command:
+          - "/install_multus"
+          - "-d"
+          - "/host/opt/cni/bin"
+          - "-t"
+          - "thick"
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "15Mi"
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cnibin
+            mountPath: /host/opt/cni/bin
+            mountPropagation: Bidirectional
+      containers:
+      - name: kube-multus
+        image: {{ template "system_default_registry" . }}{{ .Values.thickPlugin.image.repository }}:{{ .Values.thickPlugin.image.tag }}
+        imagePullPolicy: {{ .Values.thickPlugin.image.pullPolicy }}
+        command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
+        {{- if .Values.pod.resources.enabled }}
+        resources: {{- toYaml .Values.pod.resources.multus | nindent 10 }}
+        {{- end }}
+        securityContext:
+          privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cni
+            mountPath: /host/etc/cni/net.d
+          # multus-daemon expects that cnibin path must be identical between pod and container host.
+          # e.g. if the cni bin is in '/opt/cni/bin' on the container host side, then it should be mount to '/opt/cni/bin' in multus-daemon,
+          # not to any other directory, like '/opt/bin' or '/usr/bin'.
+          - name: cnibin
+            mountPath: /opt/cni/bin
+          - name: host-run
+            mountPath: /host/run
+          - name: host-var-lib-cni-multus
+            mountPath: /var/lib/cni/multus
+          - name: host-var-lib-kubelet
+            mountPath: /var/lib/kubelet
+            mountPropagation: HostToContainer
+          - name: host-run-k8s-cni-cncf-io
+            mountPath: /run/k8s.cni.cncf.io
+          - name: host-run-netns
+            mountPath: /run/netns
+            mountPropagation: HostToContainer
+          - name: multus-daemon-config
+            mountPath: /etc/cni/net.d/multus.d
+            readOnly: true
+          - name: hostroot
+            mountPath: /hostroot
+            mountPropagation: HostToContainer
+          - mountPath: /etc/cni/multus/net.d
+            name: multus-conf-dir
+          # TODO CNI specific mo
+        env:
+          - name: MULTUS_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin
+        - name: hostroot
+          hostPath:
+            path: /
+        - name: multus-daemon-config
+          configMap:
+            name: {{ .Release.Name }}-{{ .Chart.Version }}-config
+            items:
+            - key: daemon-config.json
+              path: daemon-config.json
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib-cni-multus
+          hostPath:
+            path: /var/lib/cni/multus
+        - name: host-var-lib-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: host-run-k8s-cni-cncf-io
+          hostPath:
+            path: /run/k8s.cni.cncf.io
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns/
+        - name: multus-conf-dir
+          hostPath:
+            path: /etc/cni/multus/net.d
+{{- end }}
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/daemonSet.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/daemonSet.yaml
@@ -1,0 +1,171 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.daemonSet }}
+{{- if not (.Values.thickPlugin.enabled) }}
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "multus.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+{{- include "multus.labels" . | indent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      initContainers:
+      - name: cni-plugins
+        image: {{ template "system_default_registry" . }}{{ .Values.cniplugins.image.repository }}:{{ .Values.cniplugins.image.tag }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: {{ .Values.cniplugins.skipcnis }}
+      containers:
+      - name: kube-{{ .Chart.Name }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command: ["/thin_entrypoint"]
+        args:
+        - "--multus-conf-file={{ .Values.config.cni_conf.multusConfFile }}"
+        {{- if .Values.config.cni_conf.cniVersion }}
+        - "--cni-version={{ .Values.config.cni_conf.cniVersion }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.confDir }}
+        - "--cni-conf-dir=/host{{ .Values.config.cni_conf.confDir }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.binDir }}
+        - "--cni-bin-dir=/host{{ .Values.config.cni_conf.binDir }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.multusAutoconfigDir }}
+        - "--multus-autoconfig-dir=/host{{ .Values.config.cni_conf.multusAutoconfigDir }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.multusCniConfDir }}
+        - "--multus-cni-conf-dir={{ .Values.config.cni_conf.multusCniConfDir }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.multusBinFile }}
+        - "--multus-bin-file={{ .Values.config.cni_conf.multusBinFile }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.kubeconfig }}
+        - "--multus-kubeconfig-file-host={{ .Values.config.cni_conf.kubeconfig }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.masterCniFilename }}
+        - "--multus-master-cni-file-name={{ .Values.config.cni_conf.masterCniFilename }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.additionalBinDir }}
+        - "--additional-bin-dir={{ .Values.config.cni_conf.additionalBinDir }}"
+        {{- end }}
+        {{- if eq .Values.config.cni_conf.skipConfigWatch true }}
+        - "--skip-config-watch"
+        {{- end }}
+        {{- if eq .Values.config.cni_conf.skipMultusBinaryCopy true }}
+        - "--skip-multus-binary-copy"
+        {{- end }}
+        {{- if .Values.config.cni_conf.readinessIndicatorFile }}
+        - "--readiness-indicator-file={{ .Values.config.cni_conf.readinessIndicatorFile }}"
+        {{- end }}
+        {{- if eq .Values.config.cni_conf.renameConfFile true }}
+        - "--rename-conf-file"
+        {{- end }}
+        {{- if eq .Values.config.cni_conf.namespaceIsolation true }}
+        - "--namespace-isolation"
+        {{- end }}
+        {{- if .Values.config.cni_conf.globalNamespaces }}
+        - "--global-namespaces={{ .Values.config.cni_conf.globalNamespaces }}"
+        {{- end }}
+        {{- if eq .Values.config.cni_conf.overrideNetworkName true }}
+        - "--override-network-name"
+        {{- end }}
+        {{- if .Values.config.cni_conf.logLevel }}
+        - "--multus-log-level={{ .Values.config.cni_conf.logLevel }}"
+        {{- end }}
+        {{- if .Values.config.cni_conf.logFile }}
+        - "--multus-log-file={{ .Values.config.cni_conf.logFile }}"
+        {{- end }}
+        {{- if eq .Values.config.cni_conf.logToStderr true }}
+        - "-multus-log-to-stderr"
+        {{- end }}
+        {{- if .Values.config.cni_conf.cleanupConfigOnExit }}
+        - "--cleanup-config-on-exit={{ .Values.config.cni_conf.cleanupConfigOnExit }}"
+        {{- end }}
+        {{- if .Values.pod.resources.enabled }}
+        resources: {{- toYaml .Values.pod.resources.multus.enabled | nindent 10 }}
+        {{- end }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cni
+          mountPath: /host{{ .Values.config.cni_conf.confDir }}
+        - name: cnibin
+          mountPath: /host{{ .Values.config.cni_conf.binDir }}
+        {{- if and .Values.config.cni_conf.multusAutoconfigDir (ne .Values.config.cni_conf.confDir .Values.config.cni_conf.multusAutoconfigDir) }}
+        - name: multusautoconfig
+          mountPath: /host{{ .Values.config.cni_conf.multusAutoconfigDir }}
+        {{- end }}
+        {{- if .Values.manifests.configMap }}
+        - name: multus-cfg
+          mountPath: /tmp/multus-conf/00-multus.conf
+          subPath: "cni-conf.json"
+        {{- end }}
+      volumes:
+        - name: cni
+          hostPath:
+            path: {{ .Values.config.cni_conf.confDir }}
+        - name: cnibin
+          hostPath:
+            path: {{ .Values.config.cni_conf.binDir }}
+        {{- if and .Values.config.cni_conf.multusAutoconfigDir (ne .Values.config.cni_conf.confDir .Values.config.cni_conf.multusAutoconfigDir) }}
+        - name: multusautoconfig
+          hostPath:
+            path: {{ .Values.config.cni_conf.multusAutoconfigDir }}
+        {{- end }}
+        {{- if .Values.manifests.configMap }}
+        - name: multus-cfg
+          configMap:
+            name: {{ .Release.Name }}-{{ .Chart.Version }}-config
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/dhcp-daemonSet.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/dhcp-daemonSet.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.manifests.dhcpDaemonSet }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}-dhcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "multus.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+{{- include "multus.labels" . | indent 8 }}
+    spec:
+      hostNetwork: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
+      initContainers:
+      - name: kube-{{ .Chart.Name }}-dhcp-cleanup
+        image: {{ template "system_default_registry" . }}{{ .Values.dhcpDaemonSet.image.repository }}:{{ .Values.dhcpDaemonSet.image.tag }}
+        command: ["rm", "-f", "/host/run/cni/dhcp.sock"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: socketpath
+          mountPath: /host/run/cni
+      containers:
+      - name: kube-{{ .Chart.Name }}-dhcp
+        image: {{ template "system_default_registry" . }}{{ .Values.dhcpDaemonSet.image.repository }}:{{ .Values.dhcpDaemonSet.image.tag }}
+        command: ["/opt/cni/bin/dhcp", "daemon"]
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: binpath
+          mountPath: /opt/cni/bin
+        - name: socketpath
+          mountPath: /run/cni
+        - name: netnspath
+          mountPath: /var/run/netns
+          mountPropagation: HostToContainer
+      volumes:
+        - name: binpath
+          hostPath:
+            path: {{ .Values.config.cni_conf.binDir }}
+        - name: socketpath
+          hostPath:
+            path: /run/cni
+        - name: netnspath
+          hostPath:
+            path: /run/netns
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/dynamicNetworksController.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/dynamicNetworksController.yaml
@@ -1,0 +1,146 @@
+{{- if .Values.dynamicNetworksController.enabled }}
+{{- if .Values.manifests.clusterRole }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-dnc
+rules:
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources:
+      - network-attachment-definitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/status
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+{{- end }}
+{{- if .Values.manifests.clusterRoleBinding }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-dnc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}-dnc
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Chart.Name }}-dnc
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+{{- if .Values.manifests.serviceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}-dnc
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+{{- if .Values.manifests.configMap }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: dynamic-networks-controller-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "dynamicNetworksController.labels" . | indent 8 }}
+data:
+  dynamic-networks-config.json: |
+    {
+        "criSocketPath": "/host{{ .Values.dynamicNetworksController.sockets.containerd }}",
+        "multusSocketPath": "/host{{ .Values.dynamicNetworksController.sockets.multus }}"
+    }
+{{- end }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}-dnc
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{- include "dynamicNetworksController.labels" . | indent 8 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}-dnc
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+{{- include "dynamicNetworksController.labels" . | indent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      nodeSelector: {{- toYaml .Values.labels.nodeSelector | nindent 8 }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Chart.Name }}-dnc
+      containers:
+        - name: dynamic-networks-controller
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                    fieldPath: spec.nodeName
+          image: {{ template "system_default_registry" . }}{{ .Values.dynamicNetworksController.image.repository }}:{{ .Values.dynamicNetworksController.image.tag }}
+          command: [ "/dynamic-networks-controller" ]
+          args:
+            - "-config=/etc/dynamic-networks-controller/dynamic-networks-config.json"
+            - "-v=5"
+          {{- if .Values.pod.resources.enabled }}
+          resources: {{- toYaml .Values.pod.resources.dynamicNetworksController | nindent 10 }}
+          {{- end }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: dynamic-networks-controller-config-dir
+              mountPath: /etc/dynamic-networks-controller/
+              readOnly: true
+            - name: multus-server-socket
+              mountPath: /host{{ .Values.dynamicNetworksController.sockets.multus }}
+            - name: cri-socket
+              mountPath: /host{{ .Values.dynamicNetworksController.sockets.containerd }}
+          terminationMessagePolicy: FallbackToLogsOnError
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: dynamic-networks-controller-config-dir
+          configMap:
+            name: dynamic-networks-controller-config
+            items:
+              - key: dynamic-networks-config.json
+                path: dynamic-networks-config.json
+        -  name: multus-server-socket
+           hostPath:
+             path: {{ .Values.dynamicNetworksController.sockets.multus }}
+             type: Socket
+        -  name: cri-socket
+           hostPath:
+             path: {{ .Values.dynamicNetworksController.sockets.containerd }}
+             type: Socket
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/templates/serviceAccount.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/templates/serviceAccount.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if .Values.manifests.serviceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/packages/rke2-multus-1.34-1.36/charts/values.yaml
+++ b/packages/rke2-multus-1.34-1.36/charts/values.yaml
@@ -1,0 +1,181 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for multus.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+#replicaCount: 1
+
+image:
+  repository: rancher/hardened-multus-cni
+  tag: v4.3.0-build20260819
+  pullPolicy: IfNotPresent
+
+#imagePullSecrets: []
+#nameOverride: ""
+#fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  #create: true
+  # Annotations to add to the service account
+  #annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: multus
+
+pod:
+  resources:
+    enabled: false
+    multus:
+      requests:
+        memory: "128Mi"
+        cpu: "250m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    dynamicNetworksController:
+      requests:
+        cpu: "100m"
+        memory: "50Mi"
+
+#podSecurityContext: {}
+  # fsGroup: 2000
+
+#securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+#service:
+  #type: ClusterIP
+  #port: 80
+
+#ingress:
+  #enabled: false
+  #annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  #hosts:
+    #- host: chart-example.local
+    #  paths: []
+  #tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+labels:
+  nodeSelector:
+    kubernetes.io/os: linux
+
+# Multus configuration
+# For more details, see https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#entrypoint-script-parameters
+config:
+  cni_conf:
+    confDir: /etc/cni/net.d #path on the host, not inside the container
+    binDir: /opt/cni/bin # path on the host, not inside the container
+    #namespaceIsolation: false
+    #globalNamespaces: default,foo,bar
+    #skipConfigWatch: false
+    #skipMultusBinaryCopy: false
+    #readinessIndicatorFile: ""
+    multusConfFile: auto #or specify a file to be copied on each node
+    #multusBinFile: /usr/src/multus-cni/bin/multus
+    #multusCniConfDir: /host/etc/cni/multus/net.d
+    # The following options can be used only when multusConfFile=auto
+    # multusAutoconfigDir is mandatory when multusConfFile=auto 
+    multusAutoconfigDir: /etc/cni/net.d #path on the host, not inside the container
+    kubeconfig: /etc/cni/net.d/multus.d/multus.kubeconfig
+    #masterCniFilename:
+    #overrideNetworkName: 
+    #renameConfFile: 
+    #logFile: /var/log/multus.log
+    #logLevel: panic
+    #logToStderr: true
+    #cniVersion: 1.0.0
+    cleanupConfigOnExit: true
+    #additionalBinDir: /opt/multus/bin
+  daemon_conf:
+    "chrootDir": "/hostroot"
+    "cniVersion": "0.3.1"
+    "logLevel": "verbose"
+    "logToStderr": true
+    "cniConfigDir": "/host/etc/cni/net.d"
+    "multusAutoconfigDir": "/host/etc/cni/net.d"
+    "multusConfigFile": "auto"
+    "socketDir": "/host/run/multus/"
+
+manifests:
+  serviceAccount: true
+  clusterRole: true
+  clusterRoleBinding: true
+  configMap: true
+  daemonSet: true
+  customResourceDefinition: true
+  dhcpDaemonSet: false
+
+tolerations:
+- operator: Exists 
+  effect: NoSchedule 
+- operator: Exists 
+  effect: NoExecute 
+
+#affinity: {}
+
+
+## RANCHER ADDDED INFO ##
+cniplugins:
+  image:
+    repository: rancher/hardened-cni-plugins
+    tag: v1.9.1-build20260819
+
+  # skipcnis is a comma separated list of cni binaries to skip from
+  # installing.
+  skipcnis: flannel
+
+dhcpDaemonSet:
+  image:
+    repository: rancher/mirrored-library-busybox
+    tag: "1.36.1"
+
+global:
+  systemDefaultRegistry: ""
+
+rke2-whereabouts:
+  enabled: false
+  
+# When using the thick plugin, manifests.configMap MUST be set to true
+thickPlugin:
+  enabled: false
+  image:
+    repository: rancher/hardened-multus-thick
+    tag: v4.3.0-build20260819
+    pullPolicy: IfNotPresent
+
+# This deploys the dynamic networks controller add-on.
+# It can only be used with thickPlugin.enabled=true.
+# See https://github.com/k8snetworkplumbingwg/multus-dynamic-networks-controller/ for more details
+dynamicNetworksController:
+  enabled: false
+  image:
+    repository: rancher/hardened-multus-dynamic-networks-controller
+    tag: v0.3.8-build20260818
+    pullPolicy: IfNotPresent
+  sockets:
+    containerd: /run/k3s/containerd/containerd.sock
+    multus: /run/multus/multus.sock

--- a/packages/rke2-multus-1.34-1.36/generated-changes/dependencies/rke2-whereabouts/dependency.yaml
+++ b/packages/rke2-multus-1.34-1.36/generated-changes/dependencies/rke2-whereabouts/dependency.yaml
@@ -1,0 +1,1 @@
+url: packages/rke2-whereabouts-1.34-1.36

--- a/packages/rke2-multus-1.34-1.36/package.yaml
+++ b/packages/rke2-multus-1.34-1.36/package.yaml
@@ -1,0 +1,3 @@
+url: local
+workingDir: charts
+packageVersion: 10

--- a/packages/rke2-whereabouts-1.34-1.36/charts/Chart.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: whereabouts
+description: A Helm chart to deploy the whereabouts CNI
+home: https://github.com/k8snetworkplumbingwg/whereabouts
+maintainers:
+  - name: Rancher Labs
+    email: charts@rancher.com
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.9.4
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.9.4

--- a/packages/rke2-whereabouts-1.34-1.36/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
+  name: ippools.whereabouts.cni.cncf.io
+spec:
+  group: whereabouts.cni.cncf.io
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPPool is the Schema for the ippools API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPoolSpec defines the desired state of IPPool
+            properties:
+              allocations:
+                additionalProperties:
+                  description: IPAllocation represents metadata about the pod/container
+                    owner of a specific IP
+                  properties:
+                    id:
+                      type: string
+                    ifname:
+                      type: string
+                    podref:
+                      type: string
+                  required:
+                  - id
+                  - podref
+                  type: object
+                description: |-
+                  Allocations is the set of allocated IPs for the given range. Its` indices are a direct mapping to the
+                  IP with the same index/offset for the pool's range.
+                type: object
+              range:
+                description: Range is a RFC 4632/4291-style string that represents
+                  an IP address and prefix length in CIDR notation
+                type: string
+            required:
+            - allocations
+            - range
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/packages/rke2-whereabouts-1.34-1.36/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
+  name: nodeslicepools.whereabouts.cni.cncf.io
+spec:
+  group: whereabouts.cni.cncf.io
+  names:
+    kind: NodeSlicePool
+    listKind: NodeSlicePoolList
+    plural: nodeslicepools
+    singular: nodeslicepool
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeSlicePool is the Schema for the nodesliceippools API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeSlicePoolSpec defines the desired state of NodeSlicePool
+            properties:
+              range:
+                description: |-
+                  Range is a RFC 4632/4291-style string that represents an IP address and prefix length in CIDR notation
+                  this refers to the entire range where the node is allocated a subset
+                type: string
+              sliceSize:
+                description: SliceSize is the size of subnets or slices of the range
+                  that each node will be assigned
+                type: string
+            required:
+            - range
+            - sliceSize
+            type: object
+          status:
+            description: NodeSlicePoolStatus defines the desired state of NodeSlicePool
+            properties:
+              allocations:
+                description: Allocations holds the allocations of nodes to slices
+                items:
+                  properties:
+                    nodeName:
+                      description: NodeName is the name of the node assigned to this
+                        slice, empty node name is an available slice for assignment
+                      type: string
+                    sliceRange:
+                      description: SliceRange is the subnet of this slice
+                      type: string
+                  required:
+                  - nodeName
+                  - sliceRange
+                  type: object
+                type: array
+            required:
+            - allocations
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/packages/rke2-whereabouts-1.34-1.36/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    helm.sh/resource-policy: keep
+  name: overlappingrangeipreservations.whereabouts.cni.cncf.io
+spec:
+  group: whereabouts.cni.cncf.io
+  names:
+    kind: OverlappingRangeIPReservation
+    listKind: OverlappingRangeIPReservationList
+    plural: overlappingrangeipreservations
+    singular: overlappingrangeipreservation
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OverlappingRangeIPReservation is the Schema for the OverlappingRangeIPReservations
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OverlappingRangeIPReservationSpec defines the desired state
+              of OverlappingRangeIPReservation
+            properties:
+              containerid:
+                type: string
+              ifname:
+                type: string
+              podref:
+                type: string
+            required:
+            - podref
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/NOTES.txt
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Whereabouts is installed!!
+
+You can view the pods with the following command:
+
+kubectl get pods -n {{ .Release.Namespace }} -l app=whereabouts

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/_helpers.tpl
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "whereabouts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "whereabouts.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Provide a method to override namespace so parent charts can set it
+*/}}
+{{- define "whereabouts.namespace" -}}
+{{- if hasKey .Values "namespaceOverride" -}}
+namespace: {{ .Values.namespaceOverride }}
+{{- else }}
+namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "whereabouts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "whereabouts.labels" -}}
+helm.sh/chart: {{ include "whereabouts.chart" . }}
+{{ include "whereabouts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "controller.labels" -}}
+helm.sh/chart: {{ include "whereabouts.chart" . }}
+{{ include "controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "whereabouts.selectorLabels" -}}
+app: {{ include "whereabouts.name" . }}
+app.kubernetes.io/name: {{ include "whereabouts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "controller.selectorLabels" -}}
+app: {{ include "whereabouts.name" . }}-controller
+app.kubernetes.io/name: {{ include "whereabouts.name" . }}-controller
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "whereabouts.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "whereabouts.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/cluster_role.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/cluster_role.yaml
@@ -1,0 +1,56 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "whereabouts.serviceAccountName" . }}
+rules:
+- apiGroups:
+  - whereabouts.cni.cncf.io
+  resources:
+  - ippools
+  - overlappingrangeipreservations
+  - nodeslicepools
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+    - events
+  verbs:
+  - create
+  - patch
+  - update
+  - get

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/cluster_role_binding.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/cluster_role_binding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "whereabouts.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "whereabouts.serviceAccountName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "whereabouts.serviceAccountName" . }}
+  {{- include "whereabouts.namespace" . | nindent 2 }}
+{{- end }}

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/configmap.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "whereabouts.fullname" . }}-config
+  {{- include "whereabouts.namespace" . | nindent 2 }}
+  annotations:
+    kubernetes.io/description: |
+      Configmap containing user customizable cronjob schedule
+data:
+  cron-expression: "30 4 * * *" # Default schedule is once per day at 4:30am. Users may configure this value to their liking.

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/daemonset.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/daemonset.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "whereabouts.fullname" . }}
+  {{- include "whereabouts.namespace" . | nindent 2 }}
+  labels:
+    {{- include "whereabouts.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      name: whereabouts
+      {{- include "whereabouts.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        name: whereabouts
+        {{- include "whereabouts.selectorLabels" . | nindent 8 }}
+    spec:
+      hostNetwork: true
+      serviceAccountName: {{ include "whereabouts.serviceAccountName" . }}  
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext: #TODO still needed?
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command: [ "/bin/sh" ]
+          args:
+            - -c
+            - |
+              SLEEP=false source /install-cni.sh 
+              /token-watcher.sh &
+              /ip-control-loop -log-level debug
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: NODENAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: WHEREABOUTS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CNI_CONF_DIR
+            value: /host{{ .Values.cniConf.confDir }}
+          - name: CNI_BIN_DIR
+            value: /host{{ .Values.cniConf.binDir }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: cnibin
+            mountPath: /host{{ .Values.cniConf.binDir }}
+          - name: cni-net-dir
+            mountPath: /host{{ .Values.cniConf.confDir }}
+          - name: cron-scheduler-configmap
+            mountPath: /cron-schedule
+      volumes:
+        - name: cnibin
+          hostPath:
+            path: {{ .Values.cniConf.binDir }}
+        - name: cni-net-dir
+          hostPath:
+            path: {{ .Values.cniConf.confDir }}
+        - name: cron-scheduler-configmap
+          configMap:
+            name: {{ include "whereabouts.fullname" . }}-config
+            defaultMode: 0744
+            items:
+            - key: "cron-expression"
+              path: "config"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/node_slice_controller.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/node_slice_controller.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.nodeSliceController.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "whereabouts.fullname" . }}-controller
+  {{- include "whereabouts.namespace" . | nindent 2 }}
+  labels:
+    {{- include "whereabouts.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "controller.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+  template:
+    metadata:
+    {{- with .Values.nodeSliceController.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "controller.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.nodeSliceController.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - command:
+            - /node-slice-controller
+          env:
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: WHEREABOUTS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          image: "{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: whereabouts
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cnibin
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /cron-schedule
+              name: cron-scheduler-configmap
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access-6kd6k
+              readOnly: true
+      preemptionPolicy: PreemptLowerPriority
+      priority: 0
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: {{ include "whereabouts.serviceAccountName" . }}
+      serviceAccountName: {{ include "whereabouts.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - hostPath:
+            path: /opt/cni/bin
+            type: ""
+          name: cnibin
+        - hostPath:
+            path: /etc/cni/net.d
+            type: ""
+          name: cni-net-dir
+        - configMap:
+            defaultMode: 484
+            items:
+              - key: cron-expression
+                path: config
+            name: {{ include "whereabouts.fullname" . }}-config
+          name: cron-scheduler-configmap
+        - name: kube-api-access-6kd6k
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+{{- end}}

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/reconciler.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/reconciler.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "whereabouts.fullname" . }}-reconciler
+  {{- include "whereabouts.namespace" . | nindent 2 }}
+  labels:
+    {{- include "whereabouts.labels" . | nindent 4 }}
+spec:
+  # replicas must not be set to more than 1; there is no leader election, so running multiple replicas would cause duplicate reconciliation.
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ include "whereabouts.fullname" . }}-reconciler
+      {{- include "whereabouts.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        name: {{ include "whereabouts.fullname" . }}-reconciler
+        {{- include "whereabouts.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "whereabouts.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: reconciler
+          image: "{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/ip-reconciler" ]
+          args:
+            - -log-level
+            - {{ .Values.reconciler.logLevel }}
+          env:
+          - name: WHEREABOUTS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          resources:
+            {{- toYaml .Values.reconciler.resources | nindent 12 }}
+          volumeMounts:
+          - name: cron-scheduler-configmap
+            mountPath: /cron-schedule
+      volumes:
+        - name: cron-scheduler-configmap
+          configMap:
+            name: {{ include "whereabouts.fullname" . }}-config
+            defaultMode: 0744
+            items:
+            - key: "cron-expression"
+              path: "config"

--- a/packages/rke2-whereabouts-1.34-1.36/charts/templates/serviceaccount.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "whereabouts.serviceAccountName" . }}
+  {{- include "whereabouts.namespace" . | nindent 2 }}
+  labels:
+    {{- include "whereabouts.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/packages/rke2-whereabouts-1.34-1.36/charts/values.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/charts/values.yaml
@@ -1,0 +1,71 @@
+# Default values for whereabouts.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: rancher/hardened-whereabouts
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: v0.9.4-build20260819
+
+updateStrategy: RollingUpdate
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: "kube-system"
+successfulJobsHistoryLimit: 0
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  #name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  privileged: true
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "100Mi"
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations:
+  - operator: Exists
+    effect: NoSchedule
+
+affinity: {}
+
+priorityClassName: ""
+
+cniConf:
+  confDir: /etc/cni/net.d
+  binDir: /opt/cni/bin
+
+nodeSliceController:
+  enabled: false
+  podAnnotations: {}
+
+reconciler:
+  logLevel: info
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "50Mi"
+    limits:
+      cpu: "100m"
+      memory: "50Mi"
+
+global:
+  systemDefaultRegistry: ""
+  priorityClassName: ""

--- a/packages/rke2-whereabouts-1.34-1.36/package.yaml
+++ b/packages/rke2-whereabouts-1.34-1.36/package.yaml
@@ -1,0 +1,5 @@
+url: local
+workingDir: charts
+packageVersion: 06
+# whereabouts is only used as a dependency of multus
+doNotRelease: true


### PR DESCRIPTION
as well as rke2-whereabouts-1.34-1.36.

In 1.37, the crds for both charts are moved to a dedicated chart. This is not backward-comptatible so we need separate charts for the backport branches.