### PR TITLE
Add the "keep" annotation to all CRDs to avoid the upgrading race

### DIFF
--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -25,6 +25,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   labels:
     gateway.networking.k8s.io/policy: Direct
   name: backendtlspolicies.gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gateways.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_gateways.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: gateways.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_grpcroutes.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: grpcroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_httproutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_httproutes.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: httproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_listenersets.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_listenersets.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: listenersets.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_referencegrants.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_referencegrants.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: referencegrants.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_tcproutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_tcproutes.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: tcproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_tlsroutes.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: tlsroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_udproutes.yaml
+++ b/packages/rke2-gateway-api-crd/charts/crdfiles/gateway.networking.k8s.io_udproutes.yaml
@@ -8,6 +8,7 @@ metadata:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: udproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/packages/rke2-gateway-api-crd/package.yaml
+++ b/packages/rke2-gateway-api-crd/package.yaml
@@ -1,2 +1,2 @@
 url: local
-packageVersion: 00
+packageVersion: 01


### PR DESCRIPTION
Same as in K3s => https://github.com/k3s-io/k3s-charts/pull/35.

This label avoid the crds being removed by Treafik-crd if both gateway-api-crd installation and traefik-crd upgrade happen at the same time