### PR TITLE
rke2-multus: install whereabouts CRDs unconditionally in crd chart

### DIFF
--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,4 +1,3 @@
-{{ if (index .Values "rke2-whereabouts" | default dict).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -70,4 +69,3 @@ spec:
         type: object
     served: true
     storage: true
-{{ end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_nodeslicepools.yaml
@@ -1,4 +1,3 @@
-{{ if (index .Values "rke2-whereabouts" | default dict).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -78,4 +77,3 @@ spec:
         type: object
     served: true
     storage: true
-{{ end }}

--- a/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/packages/rke2-multus/charts/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -1,4 +1,3 @@
-{{ if (index .Values "rke2-whereabouts" | default dict).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -56,4 +55,3 @@ spec:
         type: object
     served: true
     storage: true
-{{ end }}

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,6 +1,6 @@
 url: local
 workingDir: charts
-packageVersion: 17
+packageVersion: 18
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
`rke2-whereabouts.enabled` only exists on the `rke2-multus` chart, whereas the `rke2-multus-crd` chart is deployed as its own release.

Fixup: 593a27cbafbd36378ee35366ab3fcee864a88e0a
Fixup: c121de0593a89f282fff3e1402000bf2a2b03819

Issue: https://github.com/rancher/rke2/issues/8628
