### PR TITLE
Bump Traefik to v3.7.13-build20260910

### DIFF
--- a/packages/rke2-traefik-1.34-1.36/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik-1.34-1.36/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
    # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
    # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
 -  tag:  # @schema type:[string, null]
-+  tag: v3.7.13-build20260909  # @schema type:[string, null]
++  tag: v3.7.13-build20260910  # @schema type:[string, null]
    # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
    digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
    # -- Traefik image pull policy

--- a/packages/rke2-traefik-1.34-1.36/package.yaml
+++ b/packages/rke2-traefik-1.34-1.36/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-40.1.0.tgz
-packageVersion: 12
+packageVersion: 13
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 

--- a/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-traefik/generated-changes/patch/values.yaml.patch
@@ -9,7 +9,7 @@
    # -- defaults to appVersion. It's used for version checking, even prefixed with experimental- or latest-.
    # To pin by digest, prefer `image.digest`. A `<version>@<digest>` combo is also accepted here; in that case the digest is what Kubernetes verifies and the version is informational (and can drift from the underlying image).
 -  tag:  # @schema type:[string, null]
-+  tag: v3.7.13-build20260909  # @schema type:[string, null]
++  tag: v3.7.13-build20260910  # @schema type:[string, null]
    # -- Traefik image digest (e.g. `sha256:abc...`). When set, takes precedence over `tag`. Set `versionOverride` alongside it so the chart's version-checking logic knows the version (it cannot be derived from the digest).
    digest:  # @schema type:[string, null]; pattern:^sha256:[a-f0-9]{64}$
    # -- Traefik image pull policy

--- a/packages/rke2-traefik/package.yaml
+++ b/packages/rke2-traefik/package.yaml
@@ -1,5 +1,5 @@
 url: https://traefik.github.io/charts/traefik/traefik-41.2.0.tgz
-packageVersion: 02
+packageVersion: 03
 # This repository does not use releaseCandidateVersions, so you can leave this as 00.
 releaseCandidateVersion: 00
 


### PR DESCRIPTION
Bump Traefik image tag to v3.7.13-build20260910 in rke2-traefik and rke2-traefik-1.34-1.36 packages.