### PR TITLE
rke2-snapshot-controller: bump image to v8.6.0-build20260909

### DIFF
--- a/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-snapshot-controller/generated-changes/patch/values.yaml.patch
@@ -5,7 +5,7 @@
 +installCRDs: false
  
  controller:
-    enabled: true
+   enabled: true
 @@ -16,10 +16,10 @@
      featureGates: CSIVolumeGroupSnapshot=true
  
@@ -15,7 +15,7 @@
      pullPolicy: IfNotPresent
      # Overrides the image tag whose default is the chart appVersion.
 -    tag: ""
-+    tag: "v8.6.0-build20260819"
++    tag: "v8.6.0-build20260909"
  
    imagePullSecrets: []
  

--- a/packages/rke2-snapshot-controller/package.yaml
+++ b/packages/rke2-snapshot-controller/package.yaml
@@ -1,7 +1,7 @@
 url: https://github.com/piraeusdatastore/helm-charts.git
 subdirectory: charts/snapshot-controller
 commit: 5d733d8c44f666d26a7f1dd210fee876eae16c3f  # snapshot-controller-5.2.0
-packageVersion: 03
+packageVersion: 04
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Resolve grpc CVEs in the hardened-snapshot-controller image